### PR TITLE
Tighten doc linting in CI

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,3 +89,9 @@ missing_docs                        = "deny"
 
 [workspace.lints.rustdoc]
 missing_crate_level_docs            = "deny"
+broken_intra_doc_links              = "deny"
+private_intra_doc_links             = "deny"
+bare_urls                           = "deny"
+invalid_html_tags                   = "deny"
+invalid_codeblock_attributes        = "deny"
+unescaped_backticks                 = "deny"

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ APP ?= tei-rapporteur
 CARGO ?= cargo
 BUILD_JOBS ?=
 CLIPPY_FLAGS ?= --all-targets --all-features -- -D warnings
+RUSTDOC_FLAGS ?= --cfg docsrs -D warnings
 MDLINT ?= markdownlint-cli2
 NIXIE ?= nixie
 
@@ -22,6 +23,7 @@ test: ## Run tests with warnings treated as errors
 	RUSTFLAGS="-D warnings" $(CARGO) test --workspace --all-targets --all-features $(BUILD_JOBS)
 
 lint: ## Run Clippy with warnings denied
+	RUSTDOCFLAGS="$(RUSTDOC_FLAGS)" $(CARGO) doc --workspace --no-deps
 	$(CARGO) clippy $(CLIPPY_FLAGS)
 
 fmt: ## Format Rust and Markdown sources


### PR DESCRIPTION
## Summary
- enable stricter rustdoc workspace lints to catch intra-doc regressions
- extend the lint make target to run cargo doc with docs.rs configuration

## Testing
- make check-fmt
- make lint
- make test

------
https://chatgpt.com/codex/tasks/task_e_68fd4b396d988322a6ed359dd3b20884

## Summary by Sourcery

Tighten documentation linting by enabling additional rustdoc lints and integrating a docs.rs-configured documentation check into the CI lint target.

Enhancements:
- Add new rustdoc workspace lints to deny broken intra-doc links, private links, bare URLs, invalid HTML tags, invalid codeblock attributes, and unescaped backticks
- Introduce RUSTDOC_FLAGS for docs.rs configuration and update the lint target to run cargo doc with warnings denied