### PR TITLE
Add TeiText convenience delegations

### DIFF
--- a/tei-core/src/text/mod.rs
+++ b/tei-core/src/text/mod.rs
@@ -137,6 +137,17 @@ impl TeiText {
 #[cfg(test)]
 mod tests {
     use super::{BodyBlock, P, TeiBody, TeiText, Utterance};
+    use rstest::{fixture, rstest};
+
+    #[fixture]
+    fn sample_paragraph() -> P {
+        P::new(["Intro paragraph"]).expect("valid paragraph")
+    }
+
+    #[fixture]
+    fn sample_utterance() -> Utterance {
+        Utterance::new(Some("host"), ["Greetings"]).expect("valid utterance")
+    }
 
     #[test]
     fn text_reports_emptiness() {
@@ -166,38 +177,32 @@ mod tests {
         );
     }
 
-    #[test]
-    fn convenience_helpers_delegate_to_body() {
-        let paragraph = P::new(["Intro paragraph"]).expect("valid paragraph");
-        let utterance = Utterance::new(Some("host"), ["Greetings"]).expect("valid utterance");
-
+    #[rstest]
+    fn convenience_helpers_delegate_to_body(sample_paragraph: P, sample_utterance: Utterance) {
         let mut text = TeiText::empty();
-        text.push_paragraph(paragraph.clone())
-            .push_utterance(utterance.clone());
+        text.push_paragraph(sample_paragraph.clone())
+            .push_utterance(sample_utterance.clone());
 
         assert_eq!(
             text.body().blocks(),
             [
-                BodyBlock::Paragraph(paragraph),
-                BodyBlock::Utterance(utterance)
+                BodyBlock::Paragraph(sample_paragraph),
+                BodyBlock::Utterance(sample_utterance)
             ]
         );
     }
 
-    #[test]
-    fn extend_forwards_to_body() {
-        let paragraph = P::new(["Intro paragraph"]).expect("valid paragraph");
-        let utterance = Utterance::new(Some("host"), ["Greetings"]).expect("valid utterance");
-
+    #[rstest]
+    fn extend_forwards_to_body(sample_paragraph: P, sample_utterance: Utterance) {
         let mut text = TeiText::empty();
-        text.extend([BodyBlock::Paragraph(paragraph.clone())])
-            .push_utterance(utterance.clone());
+        text.extend([BodyBlock::Paragraph(sample_paragraph.clone())])
+            .push_utterance(sample_utterance.clone());
 
         assert_eq!(
             text.body().blocks(),
             [
-                BodyBlock::Paragraph(paragraph),
-                BodyBlock::Utterance(utterance)
+                BodyBlock::Paragraph(sample_paragraph),
+                BodyBlock::Utterance(sample_utterance)
             ]
         );
     }


### PR DESCRIPTION
## Summary
- expose `push_paragraph` and `push_utterance` helpers on `TeiText`
- cover the new helpers with a forwarding unit test

## Testing
- make check-fmt
- make lint
- make test

------
https://chatgpt.com/codex/tasks/task_e_68fd4b46cc8c8322b818c9da11e9c0d9

## Summary by Sourcery

Add convenience delegation methods to TeiText for appending paragraphs and utterances, including documentation examples and a forwarding unit test.

New Features:
- Add TeiText::push_paragraph and TeiText::push_utterance convenience methods

Documentation:
- Document the new helper methods with examples in their doc comments

Tests:
- Add a unit test verifying that the new convenience helpers delegate correctly to the underlying TeiBody