### PR TITLE
Update clippy configuration thresholds

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,5 +1,5 @@
-# Align with CodeScene’s ceiling
-cognitive-complexity-threshold = 9     # default is 25 
+# Align with CodeScene's ceiling
+cognitive-complexity-threshold = 9     # default is 25
 too-many-arguments-threshold = 4       # default is 7
 too-many-lines-threshold = 70          # default is 100
 excessive-nesting-threshold = 4        # default is off


### PR DESCRIPTION
## Summary
- normalise the CodeScene alignment comment in clippy.toml while preserving the requested thresholds

## Testing
- make check-fmt
- make lint
- make test

------
https://chatgpt.com/codex/tasks/task_e_68ff3a377b248322ab98f34d8864d293

## Summary by Sourcery

Normalize the CodeScene alignment comment in clippy.toml by replacing the curly apostrophe with a straight one while preserving the existing thresholds

Documentation:
- Standardize punctuation in the clippy.toml comment

Chores:
- Retain all original threshold values for clippy lints