### PR TITLE
Implement TEI XML serialization with tests

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -57,10 +57,12 @@ in-memory Rust structs and TEI XML strings.
       function using `quick_xml::de::from_str`.
 - [ ] Implement the `emit_xml(doc: &TeiDocument) -> Result<String, TeiError>`
       function using `quick_xml::se::to_string`.
-- [ ] Write integration tests to verify semantic round-trip fidelity:
+- [x] Implement the `emit_xml(doc: &TeiDocument) -> Result<String, TeiError>`
+      function using `quick_xml::se::to_string`.
+- [x] Write integration tests to verify semantic round-trip fidelity:
       `emit_xml(parse_xml(input))` should produce a canonically equivalent XML
       output.
-- [ ] Ensure tests cover namespace handling and normalization of insignificant
+- [x] Ensure tests cover namespace handling and normalization of insignificant
       whitespace.
 
 ## Phase 2: Python Integration

--- a/docs/tei-rapporteur-design-document.md
+++ b/docs/tei-rapporteur-design-document.md
@@ -579,6 +579,21 @@ Some specifics of the parse/emit implementation:
   order of a few thousand words), this approach should be very fast and use
   only a few MBs of memory.
 
+The concrete `tei_xml::emit_xml` helper now wraps `quick_xml::se::to_string`
+and surfaces any writer failures as `TeiError::Xml`. Serialisation therefore
+shares the same ergonomic error channel as parsing while still keeping
+`quick-xml` scoped to the XML crate. Behaviour-driven tests (powered by
+`rstest-bdd` v0.1.0-alpha4) cover the round-trip contract explicitly:
+`emit_xml(parse_xml(pretty_input))` collapses pretty-printed whitespace into
+the canonical single-line representation, so diffing emitted XML is
+deterministic. Those scenarios also assert that namespace-qualified attributes
+such as `xml:id` survive emission unchanged, satisfying the namespace-handling
+requirement called out in the roadmap. Finally, the emission tests feed a
+`TeiDocument` that contains control characters into `emit_xml` to guarantee the
+function refuses to produce malformed XML. The helper now reports the
+underlying serializer message ("character" errors in practice), making it easy
+for callers to diagnose invalid content before retrying.
+
 ### JSON/MessagePack Serialization
 
 In addition to XML, the Rust data model can be serialized to and from JSON or

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -16,9 +16,12 @@ available today and how to exercise it.
   as deprecated shims for existing callers.
 - `tei-xml` depends on the core crate and now covers both directions of XML
   flow. `serialize_document_title(raw_title)` still emits a `<title>` snippet,
-  while the new `parse_xml(xml)` helper wraps `quick-xml` to materialize full
-  `TeiDocument` values. Both functions surface parser/validator issues via the
-  shared `TeiError` enum.
+  `parse_xml(xml)` wraps `quick-xml` to materialize full `TeiDocument` values,
+  and the new `emit_xml(document)` helper canonically serializes any in-memory
+  document. Emission reuses `quick-xml::se::to_string`, so the formatter
+  normalizes insignificant whitespace, preserves namespace-qualified attributes
+  such as `xml:id`, and surfaces serializer failures via the shared `TeiError`
+  enum.
 - `tei-py` depends on both crates and re-exports the serialization helper as
   `emit_title_markup`, propagating the same `TeiError` enum. This crate is the
   future home of the PyO3 bindings.
@@ -43,7 +46,9 @@ that blank revision notes are rejected, and that the body model preserves
 paragraph/utterance order while rejecting empty utterances. Additional cases
 demonstrate inline emphasis, rend-aware mixed content, pause cues with duration
 metadata, and ensure empty `<hi>` segments are rejected. The XML crate now
-tests both title serialization and the new parser: feature files cover
-successful parsing, missing header errors, and syntax failures triggered by
-truncated documents. These tests run alongside the unit suite, so developers
-receive fast feedback when modifying the scaffolding.
+tests title serialization, the parser, and emission: feature files cover
+successful parsing, missing header errors, syntax failures triggered by
+truncated documents, canonical emission of pretty-printed input, preservation
+of `xml:id` attributes, and rejection of invalid control characters while
+serializing. These tests run alongside the unit suite, so developers receive
+fast feedback when modifying the scaffolding.

--- a/tei-core/src/header/encoding.rs
+++ b/tei-core/src/header/encoding.rs
@@ -63,7 +63,7 @@ impl EncodingDesc {
 /// Annotation toolkit metadata.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct AnnotationSystem {
-    #[serde(rename = "xml:id")]
+    #[serde(rename = "@xml:id")]
     identifier: AnnotationSystemId,
     #[serde(skip_serializing_if = "Option::is_none", rename = "desc", default)]
     description: Option<String>,

--- a/tei-core/src/text/body/paragraph.rs
+++ b/tei-core/src/text/body/paragraph.rs
@@ -15,7 +15,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename = "p")]
 pub struct P {
-    #[serde(rename = "xml:id", skip_serializing_if = "Option::is_none", default)]
+    #[serde(rename = "@xml:id", skip_serializing_if = "Option::is_none", default)]
     id: Option<XmlId>,
     #[serde(rename = "$value", default)]
     content: Vec<Inline>,

--- a/tei-core/src/text/body/utterance.rs
+++ b/tei-core/src/text/body/utterance.rs
@@ -18,9 +18,9 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename = "u")]
 pub struct Utterance {
-    #[serde(rename = "xml:id", skip_serializing_if = "Option::is_none", default)]
+    #[serde(rename = "@xml:id", skip_serializing_if = "Option::is_none", default)]
     id: Option<XmlId>,
-    #[serde(rename = "who", skip_serializing_if = "Option::is_none", default)]
+    #[serde(rename = "@who", skip_serializing_if = "Option::is_none", default)]
     speaker: Option<Speaker>,
     #[serde(rename = "$value", default)]
     content: Vec<Inline>,

--- a/tei-xml/tests/emit_xml.rs
+++ b/tei-xml/tests/emit_xml.rs
@@ -1,0 +1,273 @@
+//! Behaviour-driven scenarios covering document emission.
+
+use anyhow::{Context, Result, bail, ensure};
+use rstest::fixture;
+use rstest_bdd_macros::{given, scenario, then, when};
+use std::cell::RefCell;
+use tei_core::{FileDesc, P, TeiDocument, TeiError, TeiHeader, TeiText};
+use tei_xml::{emit_xml, parse_xml};
+
+const _: &str = include_str!("features/emit_xml.feature");
+
+const PRETTY_FIXTURE: &str = r#"<TEI>
+  <teiHeader>
+    <fileDesc>
+      <title>Sample Episode</title>
+      <series>Broadcasts</series>
+    </fileDesc>
+  </teiHeader>
+  <text>
+    <body>
+      <p xml:id="intro">Hello <hi rend="stress">world</hi></p>
+      <u xml:id="u1" who="host">Mind the gap</u>
+    </body>
+  </text>
+</TEI>
+"#;
+
+const CANONICAL_FIXTURE: &str = concat!(
+    "<TEI>",
+    "<teiHeader>",
+    "<fileDesc>",
+    "<title>Sample Episode</title>",
+    "<series>Broadcasts</series>",
+    "</fileDesc>",
+    "</teiHeader>",
+    "<text>",
+    "<body>",
+    "<p xml:id=\"intro\">Hello <hi rend=\"stress\">world</hi></p>",
+    "<u xml:id=\"u1\" who=\"host\">Mind the gap</u>",
+    "</body>",
+    "</text>",
+    "</TEI>",
+);
+
+#[derive(Default)]
+struct EmitState {
+    xml: RefCell<Option<String>>,
+    document: RefCell<Option<Result<TeiDocument, TeiError>>>,
+    emission: RefCell<Option<Result<String, TeiError>>>,
+}
+
+impl EmitState {
+    fn set_xml(&self, value: &str) {
+        *self.xml.borrow_mut() = Some(value.to_owned());
+    }
+
+    fn xml(&self) -> Result<String> {
+        self.xml
+            .borrow()
+            .as_ref()
+            .cloned()
+            .context("scenario must define XML input")
+    }
+
+    fn set_document(&self, result: Result<TeiDocument, TeiError>) {
+        *self.document.borrow_mut() = Some(result);
+    }
+
+    fn document(&self) -> Result<Result<TeiDocument, TeiError>> {
+        self.document
+            .borrow()
+            .as_ref()
+            .cloned()
+            .context("document must exist before emission")
+    }
+
+    fn set_emission(&self, result: Result<String, TeiError>) {
+        *self.emission.borrow_mut() = Some(result);
+    }
+
+    fn emission(&self) -> Result<Result<String, TeiError>> {
+        self.emission
+            .borrow()
+            .as_ref()
+            .cloned()
+            .context("emission must run before assertions")
+    }
+}
+
+fn tei_fixture(name: &str) -> Result<&'static str> {
+    match name {
+        "pretty-with-ids" => Ok(PRETTY_FIXTURE),
+        "canonical-with-ids" => Ok(CANONICAL_FIXTURE),
+        other => bail!("unknown TEI fixture: {other}"),
+    }
+}
+
+fn canonical_fixture(name: &str) -> Result<&'static str> {
+    match name {
+        "canonical-with-ids" => Ok(CANONICAL_FIXTURE),
+        other => bail!("unknown canonical fixture: {other}"),
+    }
+}
+
+fn document_with_control_characters() -> TeiDocument {
+    let paragraph = P::from_text_segments(["\u{1}"]).unwrap_or_else(|error| {
+        panic!("paragraph should accept control text for testing: {error}")
+    });
+
+    let mut text = TeiText::empty();
+    text.push_paragraph(paragraph);
+
+    let file_desc = FileDesc::from_title_str("Invalid Control Characters")
+        .unwrap_or_else(|error| panic!("title should validate: {error}"));
+    let header = TeiHeader::new(file_desc);
+
+    TeiDocument::new(header, text)
+}
+
+#[fixture]
+fn validated_state_result() -> Result<EmitState> {
+    let state = EmitState::default();
+    ensure!(state.xml.borrow().is_none(), "xml slot must start empty");
+    ensure!(
+        state.document.borrow().is_none(),
+        "document slot must start empty"
+    );
+    ensure!(
+        state.emission.borrow().is_none(),
+        "emission slot must start empty"
+    );
+    Ok(state)
+}
+
+#[fixture]
+fn validated_state() -> EmitState {
+    match validated_state_result() {
+        Ok(state) => state,
+        Err(error) => panic!("failed to initialise emission state: {error}"),
+    }
+}
+
+#[expect(
+    clippy::needless_pass_by_value,
+    reason = "rstest-bdd placeholders must own their `String` values"
+)]
+#[given("the TEI fixture \"{fixture}\"")]
+fn the_tei_fixture(#[from(validated_state)] state: &EmitState, fixture: String) -> Result<()> {
+    let xml = tei_fixture(&fixture)?;
+    state.set_xml(xml);
+    let _ = state.xml()?;
+    Ok(())
+}
+
+#[given("a parsed document containing invalid control characters")]
+fn a_document_with_invalid_control_characters(
+    #[from(validated_state)] state: &EmitState,
+) -> Result<()> {
+    state.set_document(Ok(document_with_control_characters()));
+    state
+        .document()?
+        .context("expected document to be initialised")?;
+    Ok(())
+}
+
+#[when("I parse the TEI input")]
+fn i_parse_the_input(#[from(validated_state)] state: &EmitState) -> Result<()> {
+    let xml = state.xml()?;
+    let result = parse_xml(&xml);
+    state.set_document(result);
+    Ok(())
+}
+
+#[when("I emit the parsed document")]
+fn i_emit_the_parsed_document(#[from(validated_state)] state: &EmitState) -> Result<()> {
+    let document = state
+        .document()?
+        .context("expected parsed document before emission")?;
+    let result = emit_xml(&document);
+    state.set_emission(result);
+    Ok(())
+}
+
+#[then("emission succeeds")]
+fn emission_succeeds(#[from(validated_state)] state: &EmitState) -> Result<()> {
+    let result = state.emission()?;
+    result.context("expected emission to succeed")?;
+    Ok(())
+}
+
+#[expect(
+    clippy::needless_pass_by_value,
+    reason = "rstest-bdd placeholders must own their `String` values"
+)]
+#[then("the XML matches the canonical fixture \"{fixture}\"")]
+fn xml_matches_canonical_fixture(
+    #[from(validated_state)] state: &EmitState,
+    fixture: String,
+) -> Result<()> {
+    let expected = canonical_fixture(&fixture)?;
+    let emitted = state
+        .emission()?
+        .context("expected successful emission before comparison")?;
+    ensure!(
+        emitted == expected,
+        "canonical XML mismatch: expected {expected:?}, found {emitted:?}"
+    );
+    Ok(())
+}
+
+#[expect(
+    clippy::needless_pass_by_value,
+    reason = "rstest-bdd placeholders must own their `String` values"
+)]
+#[then("the emitted XML contains \"{snippet}\"")]
+fn emitted_xml_contains(#[from(validated_state)] state: &EmitState, snippet: String) -> Result<()> {
+    let emission = state
+        .emission()?
+        .context("expected emission before substring assertion")?;
+    ensure!(
+        emission.contains(&snippet),
+        "emitted XML should contain {snippet:?}, found {emission:?}"
+    );
+    Ok(())
+}
+
+#[expect(
+    clippy::needless_pass_by_value,
+    reason = "rstest-bdd placeholders must own their `String` values"
+)]
+#[then("emission fails mentioning \"{snippet}\"")]
+fn emission_fails_mentioning(
+    #[from(validated_state)] state: &EmitState,
+    snippet: String,
+) -> Result<()> {
+    let outcome = state.emission()?;
+    let Err(error) = outcome else {
+        bail!("expected emission to fail");
+    };
+    let message = error.to_string();
+    ensure!(
+        message.contains(&snippet),
+        "error should mention {snippet:?}, found {message:?}"
+    );
+    Ok(())
+}
+
+#[scenario(path = "tests/features/emit_xml.feature", index = 0)]
+fn canonicalises_pretty_printed_input(
+    #[from(validated_state)] _: EmitState,
+    #[from(validated_state_result)] result: Result<EmitState>,
+) -> Result<()> {
+    let _ = result?;
+    Ok(())
+}
+
+#[scenario(path = "tests/features/emit_xml.feature", index = 1)]
+fn preserves_xml_id_attributes(
+    #[from(validated_state)] _: EmitState,
+    #[from(validated_state_result)] result: Result<EmitState>,
+) -> Result<()> {
+    let _ = result?;
+    Ok(())
+}
+
+#[scenario(path = "tests/features/emit_xml.feature", index = 2)]
+fn rejects_control_characters(
+    #[from(validated_state)] _: EmitState,
+    #[from(validated_state_result)] result: Result<EmitState>,
+) -> Result<()> {
+    let _ = result?;
+    Ok(())
+}

--- a/tei-xml/tests/features/emit_xml.feature
+++ b/tei-xml/tests/features/emit_xml.feature
@@ -1,0 +1,21 @@
+Feature: Emit TEI XML
+
+  Scenario: Canonicalise pretty-printed TEI
+    Given the TEI fixture "pretty-with-ids"
+    When I parse the TEI input
+    And I emit the parsed document
+    Then emission succeeds
+    And the XML matches the canonical fixture "canonical-with-ids"
+
+  Scenario: Preserve xml:id attributes
+    Given the TEI fixture "canonical-with-ids"
+    When I parse the TEI input
+    And I emit the parsed document
+    Then emission succeeds
+    And the emitted XML contains "xml:id=\"intro\""
+    And the emitted XML contains "xml:id=\"u1\""
+
+  Scenario: Reject invalid control characters
+    Given a parsed document containing invalid control characters
+    When I emit the parsed document
+    Then emission fails mentioning "character"


### PR DESCRIPTION
## Summary
- Adds TEI XML emission capabilities and tests, including a canonical emission path and behavior-driven checks.
- Introduces a new emit_xml(document) API and wires it to TeiError for consistent error handling with parsing.
- Updates core data model serialization to TEI-XML style attributes (e.g., xml:id) and supports deterministic, canonical XML emission.

## Changes

### TEI XML serialization API
- Add emit_xml(document) -> Result<String, TeiError> in tei-xml crate, wrapping quick_xml::se::to_string.
- Parse helper parse_xml(xml) continues to wrap quick_xml::de::from_str. Both share the same TeiError::Xml pathway for serialization issues.
- Documentation and examples added for usage and error semantics.

### Core data model serialization updates
- Rename serialization targets to TEI attribute style:
  - P.id -> @xml:id
  - Utterance.id -> @xml:id
  - Utterance.speaker -> @who
  - AnnotationSystem.identifier -> @xml:id
- TEI-specific inline serialization updated:
  - Implement Serialize for Inline with explicit variants (Text, Hi, Pause) to produce canonical TEI-like structure (e.g., "$text", "@rend", "$value", "@dur", "@type").
  - Hi now serializes rend as @rend; Pause serializes as @dur and @type accordingly.
- Hi and Pause structures updated to align with TEI attribute naming during serialization.
- Updated tests to reflect these changes and ensure round-tripping remains stable.

### Tests
- Added tei-xml/tests/emit_xml.rs containing behavior-driven tests scaffolded with rstest-bdd for emission flows.
- Added tests for:
  - Canonical emission of a pretty-printed input to a canonical single-line representation.
  - Preservation of xml:id attributes in emitted XML.
  - Rejection of invalid control characters during emission with a Xml error.
- Added tei-xml/tests/features/emit_xml.feature with scenarios:
  - Canonicalise pretty-printed TEI
  - Preserve xml:id attributes
  - Reject invalid control characters

### Documentation
- Updated docs (roadmap, design document, and user guide) to reflect TEI XML emission capability, namespace handling, and the new emission workflow.
- Included notes on whitespace normalization, attribute preservation, and error reporting when emitting invalid XML.

## Test plan
- [x] Canonical emission test compares emitted XML against a canonical fixture for a representative document.
- [x] XML attribute preservation test asserts emitted content contains xml:id attributes (intro, u1).
- [x] Control character test ensures emission fails with a clear Xml error mentioning invalid characters.
- [x] Behavior-driven tests run alongside unit tests and exercise parsing + emission end-to-end.
- [x] Namespace handling and whitespace normalization are covered by the canonicalization tests.

## Notes
- The new emission path aligns with the existing parse path under a shared TeiError handling model, enabling straightforward integration for downstream consumers (e.g., Python bindings).
- The tests provide deterministic expectations for emitted markup, which guards against non-deterministic whitespace or attribute order changes.



🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/d7dcd77f-e62b-4c0e-b9f5-8e9f990aa46a

## Summary by Sourcery

Implement canonical TEI XML serialization in the tei-xml crate, unify error handling with parsing, update serialization targets to TEI attribute style, and add comprehensive unit and behavior-driven tests plus documentation updates.

New Features:
- Add emit_xml(document) API for canonical TEI XML serialization
- Introduce BDD-style emission tests covering canonicalization, xml:id preservation, and control character rejection

Enhancements:
- Update data model serialization to TEI attribute naming (e.g., @xml:id, @who) and custom Inline serialization for deterministic structure
- Normalize whitespace and attribute order for stable XML emission

Documentation:
- Update user guide, design document, and roadmap to document emit_xml API and emission behavior

Tests:
- Add unit tests for canonical XML emission and control character rejection