### PR TITLE
TEI P5 structural body: DivBlock, ListBlock, Item, Label, DivEvent, DivContent

### DIFF
--- a/docs/execplans/tei-p5-body-block-structural-elements.md
+++ b/docs/execplans/tei-p5-body-block-structural-elements.md
@@ -5,7 +5,7 @@ This ExecPlan (execution plan) is a living document. The sections
 `Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
 proceeds.
 
-Status: DRAFT
+Status: COMPLETE
 
 ## Purpose / big picture
 
@@ -119,15 +119,15 @@ These are hard invariants. Violation requires escalation, not workarounds.
 - [x] Stage C: Rust core types in `tei-core`.
 - [x] Stage D: XML streaming parser states and handlers.
 - [x] Stage E: XML emitter (custom hybrid emitter bypassing serde for body).
-- [ ] Stage F: ODD and Relax NG schema updates.
-- [ ] Stage G: Python `msgspec` structs, projection layer, and type stubs.
-- [ ] Stage H: JSON schema regeneration and profile constraints.
-- [ ] Stage I: validation updates (`xml:id` uniqueness and pointer
+- [x] Stage F: ODD and Relax NG schema updates.
+- [x] Stage G: Python `msgspec` structs, projection layer, and type stubs.
+- [x] Stage H: JSON schema regeneration and profile constraints.
+- [x] Stage I: validation updates (`xml:id` uniqueness and pointer
   resolution across `Div`, `List`, and `Item`).
-- [ ] Stage J: BDD behavioural tests and unit tests.
-- [ ] Stage K: documentation updates (user's guide, design document,
+- [x] Stage J: BDD behavioural tests and unit tests.
+- [x] Stage K: documentation updates (user's guide, design document,
   roadmap).
-- [ ] Stage L: final validation and commit gating.
+- [x] Stage L: final validation and commit gating.
 
 ## Surprises & discoveries
 
@@ -143,6 +143,13 @@ These are hard invariants. Violation requires escalation, not workarounds.
   (`tei-xml/src/emitter.rs`) was written: header and stand-off are emitted via
   serde (no `Vec<Inline>` fields), while the body is handwritten using direct
   string construction with XML-escaped text.
+- Stage F: the externally published Relax NG snapshot lives in two places:
+  `schemas/tei-episodic-profile.rng` and the embedded copy at
+  `tei-xml/resources/tei-episodic-profile.rng`. Both must be updated together
+  or `write_relax_ng_schema()` drifts from the checked-in schema.
+- Stage L: XML property tests need text-only `Label` generation for the same
+  reason text-only paragraph and utterance strategies exist — adjacent XML text
+  nodes merge on round-trip.
 
 ## Decision log
 
@@ -185,7 +192,22 @@ These are hard invariants. Violation requires escalation, not workarounds.
 
 ## Outcomes & retrospective
 
-(To be completed after implementation.)
+- Structural body elements now round-trip end-to-end across the Rust core
+  model, XML parser/emitter, Relax NG schema, JSON Schema, Python projection,
+  and Python `msgspec.Struct` surface.
+- Validation now traverses `Div`, `List`, and `Item` content for duplicate
+  `xml:id` detection and internal pointer resolution, including `Item`
+  `@corresp`.
+- XML fixtures now include a `div-list` example validated with `jing` against
+  the updated Relax NG schema.
+- Python callers can now decode and encode `DivBlock`, `ListBlock`, `Item`,
+  `Label`, and `DivEvent` values through `tei_rapporteur.structs`.
+- Property-based tests now generate `Div` variants, which caught two important
+  XML-specific constraints during implementation: XML-forbidden characters in
+  generated `@type` values and adjacent text-node merging inside `Label`.
+- Final validation completed successfully with:
+  `make fmt`, `make json-schema`, `make check-fmt`, `make lint`, `make test`,
+  `make validate-xml`, `make markdownlint`, and `make nixie`.
 
 ## Context and orientation
 

--- a/docs/execplans/tei-p5-body-block-structural-elements.md
+++ b/docs/execplans/tei-p5-body-block-structural-elements.md
@@ -205,7 +205,7 @@ These are hard invariants. Violation requires escalation, not workarounds.
 - Property-based tests now generate `Div` variants, which caught two important
   XML-specific constraints during implementation: XML-forbidden characters in
   generated `@type` values and adjacent text-node merging inside `Label`.
-- Final validation completed successfully with:
+- Final validation completed successfully. The following commands passed:
   `make fmt`, `make json-schema`, `make check-fmt`, `make lint`, `make test`,
   `make validate-xml`, `make markdownlint`, and `make nixie`.
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -174,8 +174,8 @@ for handling very large documents.
 
 ### Step 3.4: Structural body elements
 
-This step extends the episodic profile beyond a flat body so show notes and
-chaptered material can retain their structure across Rust, XML, schema, and
+This step extends the episodic profile beyond a flat body so that show notes
+and chaptered material can retain their structure across Rust, XML, schema, and
 Python layers.
 
 - [x] Add `Div`, `List`, `Item`, and `Label` to the core body model and XML

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -171,3 +171,18 @@ for handling very large documents.
       dictionaries.
 - [x] Write performance benchmarks comparing the memory and time usage of the
       full-document parser versus the streaming parser for large TEI files.
+
+### Step 3.4: Structural body elements
+
+This step extends the episodic profile beyond a flat body so show notes and
+chaptered material can retain their structure across Rust, XML, schema, and
+Python layers.
+
+- [x] Add `Div`, `List`, `Item`, and `Label` to the core body model and XML
+      parser/emitter.
+- [x] Extend document validation to cover `xml:id` uniqueness and pointer
+      resolution across divisions and list items.
+- [x] Publish the updated ODD, Relax NG schema, and JSON Schema snapshots for
+      the new structural body elements.
+- [x] Expose structural body content through Python `msgspec.Struct` classes
+      and streaming event unions.

--- a/docs/tei-rapporteur-design-document.md
+++ b/docs/tei-rapporteur-design-document.md
@@ -48,9 +48,11 @@ output, and the semantic content remains consistent across round-trips.
   fully typed structures without resorting to `Any`. Inline content is a tagged
   union on the `type` field (`text`, `hi`, `pause`) with pause metadata renamed
   to `dur` and `kind` to avoid discriminator collisions.
-- Body blocks are likewise tagged (`paragraph`, `utterance`) and unwrapped
-  (fields live alongside the discriminator), enabling streaming events to share
-  the same shapes.
+- Body blocks are likewise tagged (`paragraph`, `utterance`, `div`) and
+  unwrapped (fields live alongside the discriminator), enabling streaming
+  events to share the same shapes. Divisions carry nested `DivContent`
+  projections, including `list` blocks composed of `item` and optional `label`
+  structures.
 - A dedicated projection layer in `tei-py` translates between the canonical
   Rust TEI model and the tagged Python representation, isolating the breaking
   change to the FFI boundary while keeping the XML/serde shapes unchanged.
@@ -64,6 +66,20 @@ architectural overview and a comparison of serialization pathways between Rust
 and Python. Throughout, the design focuses on writing clear, maintainable code
 – **Rust remains idiomatic and free of Python-specific cruft, and Python APIs
 feel natural to Python users**.
+
+## Structural body elements (April 2026)
+
+- The body model now treats `BodyBlock` as a three-variant enum:
+  `Paragraph`, `Utterance`, and `Div`.
+- `Div` is intentionally shallow for now. It groups `Paragraph`,
+  `Utterance`, and `List` children, but nested `Div` elements remain deferred.
+- `List` holds ordered `Item` values, and each `Item` may expose a dedicated
+  `Label` node plus inline content and an optional `@corresp` pointer list.
+- The streaming parser buffers an entire `Div` before yielding a single
+  `BodyBlock::Div` event. This preserves the existing event model instead of
+  introducing enter/exit events for structural containers.
+- XML emission uses the hybrid body emitter for these structures rather than
+  relying on `quick_xml` serde output for `Vec<Inline>` fields.
 
 ## Workspace scaffolding decisions
 

--- a/docs/tei-rapporteur-design-document.md
+++ b/docs/tei-rapporteur-design-document.md
@@ -81,6 +81,48 @@ feel natural to Python users**.
 - XML emission uses the hybrid body emitter for these structures rather than
   relying on `quick_xml` serde output for `Vec<Inline>` fields.
 
+This design keeps the structural extension narrow enough to preserve the
+original ergonomics of the flat body model while still representing chaptered
+material, show notes, and itemized references. The core distinction is between
+top-level body blocks (`BodyBlock`) and content that is only valid inside a
+division (`DivContent`). `List`, `Item`, and `Label` remain nested-only types,
+which keeps the XML profile, JSON schema, and Python `msgspec.Struct` surface
+aligned around the same containment rules.
+
+The hybrid emitter is a deliberate compatibility choice. `quick_xml` remains
+responsible for header and stand-off serialization, where serde-derived output
+works well, but the body is emitted manually once structural blocks are
+present. This avoids the serialization failure mode around inline vectors while
+still preserving a single authoritative Rust model for `Div`, `List`, `Item`,
+and `Label`. The emitter therefore acts as a thin projection layer over
+validated domain objects rather than a second source of truth for document
+structure.
+
+The streaming parser follows the same boundary. Paragraphs and utterances can
+still be emitted as soon as their closing tags arrive, but a `Div` event is not
+yielded until the parser has accumulated all nested paragraphs, utterances,
+lists, items, and labels inside that division. This buffering keeps the event
+surface simple for consumers and avoids introducing paired container-open and
+container-close events that would complicate both Python decoding and behaviour
+tests.
+
+Future structural variants should extend the system feature-first rather than
+layer-first. Adding a new nested body element requires coordinated updates to:
+
+- the `tei-core` enums and constructors, with validation rules encoded at the
+  domain boundary
+- the XML streaming parser state machine and the hybrid emitter
+- the ODD plus both checked-in Relax NG copies
+- JSON schema assertions and arbitrary-data generators
+- the Python structs, projection layer, stubs, and streaming event unions
+- behavioural tests, fixtures, and user/developer documentation
+
+Nested `Div` remains intentionally deferred until a concrete use case requires
+it. Supporting recursive divisions would change the Rust enums, the Python type
+aliases, the streaming parser buffering strategy, and the published schemas, so
+it should arrive as an explicit model revision rather than an incidental
+follow-on.
+
 ## Workspace scaffolding decisions
 
 The workspace now follows the layout described in `docs/workspace-layout.md`.

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -429,13 +429,14 @@ let parser = TeiPullParser::from_str(xml_string);
 
 ### Event types
 
-The parser yields four high-level event types:
+The parser yields the following high-level event types:
 
 - **`DocumentStart`**: Emitted once at the beginning of parsing
 - **`Header(TeiHeader)`**: The complete header metadata, emitted once after the
   header section is fully parsed
-- **`BodyBlock(BodyBlock)`**: A paragraph or utterance from the body, emitted
-  one at a time as each block is parsed
+- **`BodyBlock(BodyBlock)`**: A paragraph, utterance, or structural division
+  (`DivBlock`) from the body, emitted one at a time as each block is parsed. An
+  entire `Div` is buffered before the event is emitted
 - **`DocumentEnd`**: Emitted once after all content has been successfully parsed
 
 The streaming parser currently streams the header and body only. Root-level
@@ -481,6 +482,8 @@ Events use internal tagging (`type`), covering:
 - `header` (with a structured `header` field)
 - `paragraph` / `utterance` (unwrapped, carrying inline `content` as tagged
   `Inline` values)
+- `div` (carries `div_type`, `content: list[DivContent]`, and optional
+  `xml_id`; decodes into `DivEvent`)
 - `document_end`
 
 Inline content is also tagged (`text`, `hi`, `pause`), so Python callers can

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -8,30 +8,34 @@ available today and how to exercise it.
 
 - `tei-core` now models the top-level `TeiDocument` together with its
   `TeiHeader` and body-aware `TeiText`. The text model records ordered
-  paragraphs (`P`) and utterances with optional speaker references. Each block
-  stores a sequence of `Inline` nodes, allowing clients to mix plain text with
+  paragraphs (`P`), utterances, and structural divisions (`Div`) containing
+  paragraphs, utterances, and lists (`List`/`Item`/`Label`). Each block stores
+  a sequence of `Inline` nodes, allowing clients to mix plain text with
   emphasised `<hi>` spans and `<pause/>` cues without hand-rolling XML. Plain
-  strings flow through the new `P::from_text_segments` and
-  `Utterance::from_text_segments` helpers; the older `new` constructors remain
-  as deprecated shims for existing callers. `TeiDocument` now exposes
-  `validate()` to enforce document-wide rules: it rejects duplicate `xml:id`
-  values across annotation systems, paragraphs, and utterances, and ensures
-  utterance speakers appear in the profile cast when it exists. An empty cast
-  still counts as declared—every `who` fails until the speakers are populated—
-  whereas the absence of a cast allows speaker references, so drafts can be
-  validated incrementally. Identifier checks span the header as well, catching
-  clashes between annotation systems and body blocks. Violations surface as
-  `TeiError::Validation`. Utterances now also carry local provenance and
-  citation attributes (`@n`, `@source`, `@resp`, `@cert`, `@corresp`, `@ana`),
-  and XML deserialization remains strict for `<u>`: misspelled or unsupported
-  attributes are rejected instead of being silently discarded.
+  strings flow through `P::from_text_segments`,
+  `Utterance::from_text_segments`, `Item::from_text_segments`, and
+  `Label::from_text`; the older `new` constructors remain as deprecated shims
+  for existing callers where applicable. `TeiDocument` now exposes `validate()`
+  to enforce document-wide rules: it rejects duplicate `xml:id` values across
+  annotation systems, paragraphs, utterances, divisions, lists, and items, and
+  ensures utterance speakers appear in the profile cast when it exists. An
+  empty cast still counts as declared, so every `who` fails until the speakers
+  are populated, whereas the absence of a cast allows speaker references, so
+  drafts can be validated incrementally. Identifier checks span the header as
+  well, catching clashes between annotation systems and body blocks. Violations
+  surface as `TeiError::Validation`. Utterances and list items now also carry
+  local provenance and citation attributes where applicable, and XML
+  deserialization remains strict for `<u>` and `<item>`: misspelt or
+  unsupported attributes are rejected instead of being silently discarded.
 - `tei-xml` depends on the core crate and now covers both directions of XML
   flow. `serialize_document_title(raw_title)` still emits a `<title>` snippet,
   `parse_xml(xml)` wraps `quick-xml` to materialize full `TeiDocument` values,
-  and the new `emit_xml(&document)` helper uses `quick_xml::se::to_string` to
-  produce canonical Text Encoding Initiative (TEI) strings. All helpers return
-  `TeiError`, so callers see consistent diagnostics whether parsing malformed
-  input or attempting to emit control characters that XML forbids.
+  and `emit_xml(&document)` now uses a hybrid emitter: header and stand-off
+  sections are serialized via `quick_xml`, while body content is handwritten so
+  mixed inline content and structural divisions round-trip correctly. All
+  helpers return `TeiError`, so callers see consistent diagnostics whether
+  parsing malformed input or attempting to emit control characters that XML
+  forbids.
 - `tei-serde` centralizes JSON and `MessagePack` serialization, allowing the
   rest of the workspace to depend on a stable wrapper API (`tei_serde::json`,
   `tei_serde::msgpack`) instead of taking direct dependencies on `serde_json`
@@ -83,24 +87,26 @@ unhappy paths. Core scenarios validate that header metadata can be assembled,
 that blank revision notes are rejected, and that the body model preserves
 paragraph/utterance order while rejecting empty utterances. Additional cases
 demonstrate inline emphasis, rend-aware mixed content, pause cues with duration
-metadata, and ensure empty `<hi>` segments are rejected. The XML crate now
-tests title serialization, full-document parsing, and XML emission: feature
-files cover successful parsing, missing header errors, syntax failures
-triggered by truncated documents, as well as emission of canonical minimal TEI
-output and the error surfaced when a document sneaks in forbidden control
-characters. These tests run alongside the unit suite, so developers receive
-fast feedback when modifying the scaffolding. The `tei-py` suite layers on
-`rstest-bdd` scenarios for the Python module, covering successful construction
-of `Document` from a valid title, rejection of blank titles via `ValueError`,
-round-tripping markup through the module-level helper, both directions of the
-MessagePack bridge, and the new XML exchange APIs. Behaviour-driven coverage
-now parses canonical TEI fixtures, rejects malformed payloads, emits canonical
-strings, and proves forbidden characters bubble up as `ValueError` with an
-actionable message. New dictionary scenarios cover happy-path decoding, missing
-fields, blank titles, and the `TypeError` raised when `to_dict` is called with
-the wrong object. New validation scenarios assert that duplicate `xml:id`
-values are rejected and that utterance speakers must be declared when a profile
-cast exists, while documents without a cast still pass validation.
+metadata, structural `Div`/`List`/`Item` handling, and ensure empty `<hi>`
+segments are rejected. The XML crate now tests title serialization,
+full-document parsing, streaming of assembled divisions, Relax NG validation,
+and XML emission: feature files cover successful parsing, missing header
+errors, syntax failures triggered by truncated documents, as well as emission
+of canonical minimal TEI output and the error surfaced when a document sneaks
+in forbidden control characters. These tests run alongside the unit suite, so
+developers receive fast feedback when modifying the scaffolding. The `tei-py`
+suite layers on `rstest-bdd` scenarios for the Python module, covering
+successful construction of `Document` from a valid title, rejection of blank
+titles via `ValueError`, round-tripping markup through the module-level helper,
+both directions of the `MessagePack` bridge, and the XML exchange APIs.
+Behaviour-driven coverage now parses canonical TEI fixtures, rejects malformed
+payloads, emits canonical strings, and proves forbidden characters bubble up as
+`ValueError` with an actionable message. New dictionary scenarios cover
+happy-path decoding, missing fields, blank titles, and the `TypeError` raised
+when `to_dict` is called with the wrong object. New validation scenarios assert
+that duplicate `xml:id` values are rejected, including within divisions, and
+that utterance speakers must be declared when a profile cast exists, while
+documents without a cast still pass validation.
 
 The `tei-serde` crate now publishes a versioned JSON Schema for `TeiDocument`.
 Its unit tests assert that the checked-in schema snapshot stays in sync with
@@ -139,13 +145,20 @@ healthy.
 
 Python data classes now live in `tei_rapporteur.structs`. The submodule defines
 `msgspec.Struct` projections (`Episode`, `TeiHeader`, `FileDesc`, `Paragraph`,
-`Utterance`, `StandOff`, `SpanGroup`, `Span`, and the citation-declaration
-types) that mirror the Python-facing Rust projection. Inline nodes decode into
-plain Python objects, and TEI pointer-list attributes such as `source`, `resp`,
-`corresp`, and `ana` are exposed as `list[str]` instead of TEI's
-whitespace-separated attribute strings. MessagePack emitted by `to_msgpack`
-decodes directly into these classes, and encoding them feeds the payload
-straight back into `from_msgpack`.
+`Utterance`, `DivBlock`, `ListBlock`, `Item`, `Label`, `StandOff`, `SpanGroup`,
+`Span`, and the citation-declaration types) that mirror the Python-facing Rust
+projection. Inline nodes decode into plain Python objects, and TEI pointer-list
+attributes such as `source`, `resp`, `corresp`, and `ana` are exposed as
+`list[str]` instead of TEI's whitespace-separated attribute strings.
+MessagePack emitted by `to_msgpack` decodes directly into these classes, and
+encoding them feeds the payload straight back into `from_msgpack`.
+
+Structural body content is exposed through tagged unions:
+
+- `BodyBlock = Paragraph | Utterance | DivBlock`
+- `DivContent = Paragraph | Utterance | ListBlock`
+- `Event = DocumentStart | HeaderEvent | ParagraphEvent | UtteranceEvent |
+  DivEvent | DocumentEnd`
 
 Citation metadata is split along TEI-native boundaries. Canonical citation
 declarations live under `header.encoding_desc.refs_decl`, utterance-local
@@ -233,10 +246,11 @@ the API expands.
 The `Document` class exposes a `validate()` method that performs document-wide
 integrity checks. It verifies that all `xml:id` values are unique across the
 document (including annotation systems, stand-off span groups, stand-off spans,
-paragraphs, and utterances), that utterance speaker references match the
-declared cast list when present, that `refsDecl` entries keep their required
-`@match` and `@property` values, and that internal `#id` pointers in utterance
-and stand-off provenance attributes resolve against existing identifiers.
+paragraphs, utterances, divisions, lists, and items), that utterance speaker
+references match the declared cast list when present, that `refsDecl` entries
+keep their required `@match` and `@property` values, and that internal `#id`
+pointers in utterance, item, and stand-off provenance attributes resolve
+against existing identifiers.
 
 ```python
 import tei_rapporteur as tei
@@ -257,6 +271,7 @@ Validation raises `ValueError` with a descriptive message when:
   still counts as declared, so all speaker references fail until the cast is
   populated)
 - A `citeStructure` or `citeData` declaration leaves a required attribute blank
+- A `Div` leaves `@type` blank after trimming
 - A stand-off `spanGrp` leaves `@type` blank after trimming
 - A stand-off `span` omits both `@target` and `@from`, or uses `@to` without
   `@from`

--- a/python/tei_rapporteur/structs.pyi
+++ b/python/tei_rapporteur/structs.pyi
@@ -55,7 +55,7 @@ class Utterance(
     corresp: list[str] = ...  # type: ignore[assignment]
     ana: list[str] = ...  # type: ignore[assignment]
 
-BodyBlock: TypeAlias = Paragraph | Utterance
+TextBlock: TypeAlias = Paragraph | Utterance
 
 class Label(msgspec.Struct, omit_defaults=True):
     """Label prefix attached to a list item."""
@@ -79,7 +79,7 @@ class ListBlock(
     items: list[Item] = ...  # type: ignore[assignment]
     xml_id: str | None = None
 
-DivContent: TypeAlias = Paragraph | Utterance | ListBlock
+DivContent: TypeAlias = TextBlock | ListBlock
 
 class DivBlock(
     msgspec.Struct, tag="div", tag_field="type", omit_defaults=True
@@ -90,7 +90,7 @@ class DivBlock(
     content: list[DivContent] = ...  # type: ignore[assignment]
     xml_id: str | None = None
 
-BodyBlock: TypeAlias = Paragraph | Utterance | DivBlock
+BodyBlock: TypeAlias = TextBlock | DivBlock
 
 class TeiBody(msgspec.Struct):
     """Ordered TEI body content."""

--- a/python/tei_rapporteur/structs.pyi
+++ b/python/tei_rapporteur/structs.pyi
@@ -57,6 +57,41 @@ class Utterance(
 
 BodyBlock: TypeAlias = Paragraph | Utterance
 
+class Label(msgspec.Struct, omit_defaults=True):
+    """Label prefix attached to a list item."""
+
+    content: list[Inline] = ...  # type: ignore[assignment]
+
+class Item(msgspec.Struct, omit_defaults=True):
+    """Structured list item contained within a division list."""
+
+    content: list[Inline] = ...  # type: ignore[assignment]
+    xml_id: str | None = None
+    n: str | None = None
+    corresp: list[str] = ...  # type: ignore[assignment]
+    label: Label | None = None
+
+class ListBlock(
+    msgspec.Struct, tag="list", tag_field="type", omit_defaults=True
+):
+    """List block nested inside a division."""
+
+    items: list[Item] = ...  # type: ignore[assignment]
+    xml_id: str | None = None
+
+DivContent: TypeAlias = Paragraph | Utterance | ListBlock
+
+class DivBlock(
+    msgspec.Struct, tag="div", tag_field="type", omit_defaults=True
+):
+    """Structural division within the TEI body."""
+
+    div_type: str
+    content: list[DivContent] = ...  # type: ignore[assignment]
+    xml_id: str | None = None
+
+BodyBlock: TypeAlias = Paragraph | Utterance | DivBlock
+
 class TeiBody(msgspec.Struct):
     """Ordered TEI body content."""
 
@@ -234,7 +269,16 @@ class UtteranceEvent(
     corresp: list[str] = ...  # type: ignore[assignment]
     ana: list[str] = ...  # type: ignore[assignment]
 
+class DivEvent(
+    msgspec.Struct, tag="div", tag_field="type", omit_defaults=True
+):
+    """Streaming event carrying an assembled division body block."""
+
+    div_type: str
+    content: list[DivContent] = ...  # type: ignore[assignment]
+    xml_id: str | None = None
+
 Event: TypeAlias = (
-    DocumentStart | HeaderEvent | ParagraphEvent | UtteranceEvent
+    DocumentStart | HeaderEvent | ParagraphEvent | UtteranceEvent | DivEvent
     | DocumentEnd
 )

--- a/schemas/tei-episodic-profile.odd
+++ b/schemas/tei-episodic-profile.odd
@@ -467,6 +467,17 @@
                 <elementRef key="pause"/>
               </alternate>
             </content>
+            <constraintSpec ident="label-non-empty" scheme="schematron">
+              <constraint>
+                <sch:rule context="tei:label">
+                  <sch:assert
+                    test="string-length(normalize-space(.)) &gt; 0 or .//tei:pause"
+                  >
+                    Labels must contain non-whitespace text or a pause element.
+                  </sch:assert>
+                </sch:rule>
+              </constraint>
+            </constraintSpec>
           </elementSpec>
 
           <elementSpec ident="standOff" mode="change">

--- a/schemas/tei-episodic-profile.odd
+++ b/schemas/tei-episodic-profile.odd
@@ -400,7 +400,7 @@
           <elementSpec ident="list" mode="change">
             <desc>A list of structured body items.</desc>
             <content>
-              <elementRef key="item" minOccurs="0" maxOccurs="unbounded"/>
+              <elementRef key="item" minOccurs="1" maxOccurs="unbounded"/>
             </content>
             <attList>
               <attDef ident="xml:id" mode="change" usage="opt">

--- a/schemas/tei-episodic-profile.odd
+++ b/schemas/tei-episodic-profile.odd
@@ -72,10 +72,10 @@
           <!-- ============================================================ -->
 
 	          <moduleRef key="tei"/>
-	          <moduleRef key="core" include="p hi title desc"/>
+	          <moduleRef key="core" include="p hi title desc list item label"/>
 	          <moduleRef key="header"
 	                     include="teiHeader fileDesc profileDesc encodingDesc revisionDesc change annotationSystem refsDecl citeStructure citeData series synopsis speaker lang resp"/>
-	          <moduleRef key="textstructure" include="TEI text body"/>
+	          <moduleRef key="textstructure" include="TEI text body div"/>
 	          <moduleRef key="spoken" include="u pause"/>
 	          <moduleRef key="linking" include="standOff"/>
 	          <moduleRef key="analysis" include="spanGrp span"/>
@@ -351,11 +351,120 @@
 
           <elementSpec ident="body" mode="change">
             <desc>Contains the main content of the episode as a sequence of
-            paragraphs and utterances.</desc>
+            paragraphs, utterances, and structural divisions.</desc>
             <content>
               <alternate minOccurs="0" maxOccurs="unbounded">
                 <elementRef key="p"/>
                 <elementRef key="u"/>
+                <elementRef key="div"/>
+              </alternate>
+            </content>
+          </elementSpec>
+
+          <elementSpec ident="div" mode="change">
+            <desc>A structural body division grouping related narrative,
+            utterance, and list content.</desc>
+            <content>
+              <alternate minOccurs="0" maxOccurs="unbounded">
+                <elementRef key="p"/>
+                <elementRef key="u"/>
+                <elementRef key="list"/>
+              </alternate>
+            </content>
+            <attList>
+              <attDef ident="xml:id" mode="change" usage="opt">
+                <desc>Unique identifier for the division.</desc>
+                <datatype>
+                  <dataRef key="teidata.xmlName"/>
+                </datatype>
+              </attDef>
+              <attDef ident="type" mode="change" usage="req">
+                <desc>Classification of the division.</desc>
+                <datatype>
+                  <dataRef key="teidata.text"/>
+                </datatype>
+              </attDef>
+            </attList>
+            <constraintSpec ident="div-type-not-empty" scheme="schematron">
+              <constraint>
+                <sch:ns prefix="tei" uri="http://www.tei-c.org/ns/1.0"/>
+                <sch:rule context="tei:div[@type]">
+                  <sch:assert test="normalize-space(@type) != ''">
+                    Division @type values must not be empty or whitespace only.
+                  </sch:assert>
+                </sch:rule>
+              </constraint>
+            </constraintSpec>
+          </elementSpec>
+
+          <elementSpec ident="list" mode="change">
+            <desc>A list of structured body items.</desc>
+            <content>
+              <elementRef key="item" minOccurs="0" maxOccurs="unbounded"/>
+            </content>
+            <attList>
+              <attDef ident="xml:id" mode="change" usage="opt">
+                <desc>Unique identifier for the list.</desc>
+                <datatype>
+                  <dataRef key="teidata.xmlName"/>
+                </datatype>
+              </attDef>
+            </attList>
+          </elementSpec>
+
+          <elementSpec ident="item" mode="change">
+            <desc>A single list entry with optional labelling and
+            correspondence pointers.</desc>
+            <content>
+              <sequence>
+                <elementRef key="label" minOccurs="0" maxOccurs="1"/>
+                <alternate minOccurs="1" maxOccurs="unbounded">
+                  <textNode/>
+                  <elementRef key="hi"/>
+                  <elementRef key="pause"/>
+                </alternate>
+              </sequence>
+            </content>
+            <attList>
+              <attDef ident="xml:id" mode="change" usage="opt">
+                <desc>Unique identifier for the item.</desc>
+                <datatype>
+                  <dataRef key="teidata.xmlName"/>
+                </datatype>
+              </attDef>
+              <attDef ident="n" mode="change" usage="opt">
+                <desc>Optional item number or short label.</desc>
+                <datatype>
+                  <dataRef key="teidata.text"/>
+                </datatype>
+              </attDef>
+              <attDef ident="corresp" mode="change" usage="opt">
+                <desc>Optional pointer list linking the item to related
+                structures elsewhere in the document.</desc>
+                <datatype>
+                  <dataRef key="teidata.text"/>
+                </datatype>
+              </attDef>
+            </attList>
+            <constraintSpec ident="item-not-empty" scheme="schematron">
+              <constraint>
+                <sch:ns prefix="tei" uri="http://www.tei-c.org/ns/1.0"/>
+                <sch:rule context="tei:item">
+                  <sch:assert test="normalize-space(.) != '' or .//tei:pause">
+                    Items must contain non-whitespace text or a pause element.
+                  </sch:assert>
+                </sch:rule>
+              </constraint>
+            </constraintSpec>
+          </elementSpec>
+
+          <elementSpec ident="label" mode="change">
+            <desc>A label prefix attached to a list item.</desc>
+            <content>
+              <alternate minOccurs="1" maxOccurs="unbounded">
+                <textNode/>
+                <elementRef key="hi"/>
+                <elementRef key="pause"/>
               </alternate>
             </content>
           </elementSpec>
@@ -707,7 +816,7 @@
             `xml:id` in the document.</desc>
             <constraint>
               <sch:ns prefix="tei" uri="http://www.tei-c.org/ns/1.0"/>
-              <sch:rule context="tei:u[@source or @resp or @corresp or @ana] | tei:spanGrp[@resp or @corresp or @ana] | tei:span[@target or @from or @to or @source or @resp or @corresp or @ana]">
+              <sch:rule context="tei:u[@source or @resp or @corresp or @ana] | tei:item[@corresp] | tei:spanGrp[@resp or @corresp or @ana] | tei:span[@target or @from or @to or @source or @resp or @corresp or @ana]">
                 <sch:assert test="every $token in tokenize(string-join((@target, @from, @to, @source, @resp, @corresp, @ana), ' '), '\s+') satisfies (not(starts-with($token, '#')) or exists(//tei:*[@xml:id = substring-after($token, '#')]))">
                   All internal `#id` pointer tokens must resolve to an existing
                   xml:id in the document.

--- a/schemas/tei-episodic-profile.rng
+++ b/schemas/tei-episodic-profile.rng
@@ -325,9 +325,9 @@
           <text/>
         </attribute>
       </optional>
-      <zeroOrMore>
+      <oneOrMore>
         <ref name="item"/>
-      </zeroOrMore>
+      </oneOrMore>
     </element>
   </define>
 

--- a/schemas/tei-episodic-profile.rng
+++ b/schemas/tei-episodic-profile.rng
@@ -292,8 +292,72 @@
         <choice>
           <ref name="p"/>
           <ref name="u"/>
+          <ref name="div"/>
         </choice>
       </zeroOrMore>
+    </element>
+  </define>
+
+  <define name="div">
+    <element name="div" ns="http://www.tei-c.org/ns/1.0">
+      <optional>
+        <attribute name="xml:id" ns="http://www.w3.org/XML/1998/namespace">
+          <text/>
+        </attribute>
+      </optional>
+      <attribute name="type">
+        <text/>
+      </attribute>
+      <zeroOrMore>
+        <choice>
+          <ref name="p"/>
+          <ref name="u"/>
+          <ref name="list"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+
+  <define name="list">
+    <element name="list" ns="http://www.tei-c.org/ns/1.0">
+      <optional>
+        <attribute name="xml:id" ns="http://www.w3.org/XML/1998/namespace">
+          <text/>
+        </attribute>
+      </optional>
+      <zeroOrMore>
+        <ref name="item"/>
+      </zeroOrMore>
+    </element>
+  </define>
+
+  <define name="item">
+    <element name="item" ns="http://www.tei-c.org/ns/1.0">
+      <optional>
+        <attribute name="xml:id" ns="http://www.w3.org/XML/1998/namespace">
+          <text/>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="n">
+          <text/>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="corresp">
+          <text/>
+        </attribute>
+      </optional>
+      <optional>
+        <ref name="label"/>
+      </optional>
+      <ref name="inlineContent"/>
+    </element>
+  </define>
+
+  <define name="label">
+    <element name="label" ns="http://www.tei-c.org/ns/1.0">
+      <ref name="inlineContent"/>
     </element>
   </define>
 

--- a/tei-core/src/text/body/div.rs
+++ b/tei-core/src/text/body/div.rs
@@ -216,7 +216,7 @@ mod tests {
 
         let item = Item::from_text_segments(["List item"])
             .unwrap_or_else(|error| panic!("valid item: {error}"));
-        let list = super::List::new([item]);
+        let list = super::List::new([item]).unwrap_or_else(|error| panic!("valid list: {error}"));
         div.push_list(list.clone());
 
         assert_eq!(div.content().len(), 3);

--- a/tei-core/src/text/body/list.rs
+++ b/tei-core/src/text/body/list.rs
@@ -27,6 +27,10 @@ pub struct List {
 impl List {
     /// Builds a list from the provided items.
     ///
+    /// # Errors
+    ///
+    /// Returns [`BodyContentError::EmptyContent`] when the list has no items.
+    ///
     /// # Examples
     ///
     /// ```
@@ -37,15 +41,20 @@ impl List {
     /// let item2 = Item::from_text_segments(["Second item"])
     ///     .unwrap_or_else(|error| panic!("valid item: {error}"));
     ///
-    /// let list = List::new([item1, item2]);
+    /// let list = List::new([item1, item2])
+    ///     .unwrap_or_else(|error| panic!("valid list: {error}"));
     /// assert_eq!(list.items().len(), 2);
     /// ```
-    #[must_use]
-    pub fn new(items: impl IntoIterator<Item = Item>) -> Self {
-        Self {
-            id: None,
-            items: items.into_iter().collect(),
+    pub fn new(items: impl IntoIterator<Item = Item>) -> Result<Self, BodyContentError> {
+        let collected: Vec<Item> = items.into_iter().collect();
+        if collected.is_empty() {
+            return Err(BodyContentError::EmptyContent { container: "list" });
         }
+
+        Ok(Self {
+            id: None,
+            items: collected,
+        })
     }
 
     /// Sets an `xml:id` attribute on the list.
@@ -106,14 +115,26 @@ mod tests {
         let item2 = Item::from_text_segments(["Second"])
             .unwrap_or_else(|error| panic!("valid item: {error}"));
 
-        let list = List::new([item1.clone(), item2.clone()]);
+        let list = List::new([item1.clone(), item2.clone()])
+            .unwrap_or_else(|error| panic!("valid list: {error}"));
         assert_eq!(list.items(), [item1, item2]);
         assert!(!list.is_empty());
     }
 
     #[test]
+    fn list_new_rejects_empty_items() {
+        let result = List::new(Vec::<Item>::new());
+        assert!(matches!(
+            result,
+            Err(BodyContentError::EmptyContent { container }) if container == "list"
+        ));
+    }
+
+    #[test]
     fn list_set_id_round_trips() {
-        let list_instance = List::new(Vec::<Item>::new());
+        let item = Item::from_text_segments(["Only"])
+            .unwrap_or_else(|error| panic!("valid item: {error}"));
+        let list_instance = List::new([item]).unwrap_or_else(|error| panic!("valid list: {error}"));
         let mut list = list_instance;
         list.set_id("list1")
             .unwrap_or_else(|error| panic!("valid id: {error}"));
@@ -124,10 +145,13 @@ mod tests {
 
     #[test]
     fn list_push_item() {
-        let mut list = List::new(Vec::<Item>::new());
+        let first = Item::from_text_segments(["First item"])
+            .unwrap_or_else(|error| panic!("valid item: {error}"));
+        let mut list =
+            List::new([first.clone()]).unwrap_or_else(|error| panic!("valid list: {error}"));
         let item = Item::from_text_segments(["New item"])
             .unwrap_or_else(|error| panic!("valid item: {error}"));
         list.push_item(item.clone());
-        assert_eq!(list.items(), [item]);
+        assert_eq!(list.items(), [first, item]);
     }
 }

--- a/tei-core/tests/features/validation.feature
+++ b/tei-core/tests/features/validation.feature
@@ -74,3 +74,16 @@ Feature: TEI document validation
     And I add an anchorless stand-off span "sp1" in group "sg1"
     And I validate the document
     Then validation fails with "span must define @target or @from"
+
+  Scenario: Rejecting duplicate xml:id values inside divisions
+    Given a TEI document titled "Night Vale"
+    When I add a paragraph "Intro" with id "dup"
+    And I add a division "show-notes" containing an item with id "dup"
+    And I validate the document
+    Then validation fails with "duplicate xml:id 'dup'"
+
+  Scenario: Rejecting unresolved item corresp pointers inside divisions
+    Given a TEI document titled "Night Vale"
+    When I add a division "show-notes" containing an item with corresp "#missing"
+    And I validate the document
+    Then validation fails with "internal pointer '#missing' in @corresp does not resolve"

--- a/tei-core/tests/validation_behaviour/mod.rs
+++ b/tei-core/tests/validation_behaviour/mod.rs
@@ -4,7 +4,7 @@ use anyhow::{Context, Result, anyhow, ensure};
 use rstest::fixture;
 use rstest_bdd_macros::{given, scenario, then, when};
 use std::cell::RefCell;
-use tei_core::{P, ProfileDesc, TeiDocument, TeiError, Utterance};
+use tei_core::{Div, Item, List, P, ProfileDesc, TeiDocument, TeiError, Utterance};
 use tei_test_helpers::expect_validated_state;
 
 mod stand_off;
@@ -127,6 +127,44 @@ fn i_add_an_utterance(
             .set_id(identifier.as_str())
             .context("identifier should validate")?;
         Ok(add_utterance_to_document(document, utterance))
+    })
+}
+
+#[when("I add a division \"{div_type}\" containing an item with id \"{identifier}\"")]
+fn i_add_a_division_containing_an_item_with_id(
+    #[from(validated_state)] state: &ValidationState,
+    div_type: String,
+    identifier: String,
+) -> Result<()> {
+    state.update_document(|document| {
+        let mut item = Item::from_text_segments(["Linked resource"]).context("item should be valid")?;
+        item.set_id(identifier.as_str())
+            .context("identifier should validate")?;
+        let list = List::new([item]);
+        let mut div = Div::new(div_type.as_str()).context("division should be valid")?;
+        div.push_list(list);
+        let mut text = document.text().clone();
+        text.body_mut().push_div(div);
+        Ok(TeiDocument::new(document.header().clone(), text))
+    })
+}
+
+#[when("I add a division \"{div_type}\" containing an item with corresp \"{corresp}\"")]
+fn i_add_a_division_containing_an_item_with_corresp(
+    #[from(validated_state)] state: &ValidationState,
+    div_type: String,
+    corresp: String,
+) -> Result<()> {
+    state.update_document(|document| {
+        let mut item =
+            Item::from_text_segments(["External reference"]).context("item should be valid")?;
+        item.set_corresp(tei_core::PointerList::new([corresp.as_str()])?);
+        let list = List::new([item]);
+        let mut div = Div::new(div_type.as_str()).context("division should be valid")?;
+        div.push_list(list);
+        let mut text = document.text().clone();
+        text.body_mut().push_div(div);
+        Ok(TeiDocument::new(document.header().clone(), text))
     })
 }
 
@@ -276,6 +314,22 @@ fn allows_speakers_without_cast(
     expect_validated_state(validated_state, "validation");
 }
 
+#[scenario(path = "tests/features/validation.feature", index = 10)]
+fn rejects_duplicate_identifiers_inside_divisions(
+    #[from(validated_state)] _: ValidationState,
+    #[from(validated_state_result)] validated_state: Result<ValidationState>,
+) {
+    expect_validated_state(validated_state, "validation");
+}
+
+#[scenario(path = "tests/features/validation.feature", index = 11)]
+fn rejects_unresolved_item_corresp_pointers_inside_divisions(
+    #[from(validated_state)] _: ValidationState,
+    #[from(validated_state_result)] validated_state: Result<ValidationState>,
+) {
+    expect_validated_state(validated_state, "validation");
+}
+
 #[test]
 fn validation_feature_scenario_order_matches_expectations() {
     use gherkin::Feature;
@@ -302,6 +356,8 @@ fn validation_feature_scenario_order_matches_expectations() {
         "Accepting stand-off spans that target existing utterances",
         "Rejecting stand-off spans that target missing ids",
         "Rejecting stand-off spans without anchors",
+        "Rejecting duplicate xml:id values inside divisions",
+        "Rejecting unresolved item corresp pointers inside divisions",
     ];
 
     assert_eq!(

--- a/tei-core/tests/validation_behaviour/mod.rs
+++ b/tei-core/tests/validation_behaviour/mod.rs
@@ -140,7 +140,7 @@ fn i_add_a_division_containing_an_item_with_id(
         let mut item = Item::from_text_segments(["Linked resource"]).context("item should be valid")?;
         item.set_id(identifier.as_str())
             .context("identifier should validate")?;
-        let list = List::new([item]);
+        let list = List::new([item]).context("list should be valid")?;
         let mut div = Div::new(div_type.as_str()).context("division should be valid")?;
         div.push_list(list);
         let mut text = document.text().clone();
@@ -159,7 +159,7 @@ fn i_add_a_division_containing_an_item_with_corresp(
         let mut item =
             Item::from_text_segments(["External reference"]).context("item should be valid")?;
         item.set_corresp(tei_core::PointerList::new([corresp.as_str()])?);
-        let list = List::new([item]);
+        let list = List::new([item]).context("list should be valid")?;
         let mut div = Div::new(div_type.as_str()).context("division should be valid")?;
         div.push_list(list);
         let mut text = document.text().clone();

--- a/tei-py/python/structs.py
+++ b/tei-py/python/structs.py
@@ -17,8 +17,11 @@ __all__ = [
     "Event",
     "FileDesc",
     "HeaderEvent",
+    "Item",
     "Inline",
     "InlineHi",
+    "Label",
+    "ListBlock",
     "InlinePause",
     "InlineText",
     "Paragraph",
@@ -34,6 +37,9 @@ __all__ = [
     "TeiHeader",
     "TeiText",
     "Utterance",
+    "DivBlock",
+    "DivContent",
+    "DivEvent",
     "UtteranceEvent",
 ]
 
@@ -82,6 +88,39 @@ class Utterance(
 
 
 BodyBlock: TypeAlias = Paragraph | Utterance
+
+
+class Label(msgspec.Struct, omit_defaults=True):
+    """Label prefix attached to a list item."""
+    content: list[Inline] = msgspec.field(default_factory=list)
+
+
+class Item(msgspec.Struct, omit_defaults=True):
+    """Structured list item contained within a division list."""
+    content: list[Inline] = msgspec.field(default_factory=list)
+    xml_id: str | None = None
+    n: str | None = None
+    corresp: list[str] = msgspec.field(default_factory=list)
+    label: Label | None = None
+
+
+class ListBlock(msgspec.Struct, tag="list", tag_field="type", omit_defaults=True):
+    """List block nested inside a division."""
+    items: list[Item] = msgspec.field(default_factory=list)
+    xml_id: str | None = None
+
+
+DivContent: TypeAlias = Paragraph | Utterance | ListBlock
+
+
+class DivBlock(msgspec.Struct, tag="div", tag_field="type", omit_defaults=True):
+    """Structural division within the TEI body."""
+    div_type: str
+    content: list[DivContent] = msgspec.field(default_factory=list)
+    xml_id: str | None = None
+
+
+BodyBlock: TypeAlias = Paragraph | Utterance | DivBlock
 
 
 class TeiBody(msgspec.Struct):
@@ -298,6 +337,13 @@ class UtteranceEvent(
     ana: list[str] = msgspec.field(default_factory=list)
 
 
+class DivEvent(msgspec.Struct, tag="div", tag_field="type", omit_defaults=True):
+    """Streaming event carrying an assembled division body block."""
+    div_type: str
+    content: list[DivContent] = msgspec.field(default_factory=list)
+    xml_id: str | None = None
+
+
 Event: TypeAlias = (
-    DocumentStart | HeaderEvent | ParagraphEvent | UtteranceEvent | DocumentEnd
+    DocumentStart | HeaderEvent | ParagraphEvent | UtteranceEvent | DivEvent | DocumentEnd
 )

--- a/tei-py/python/structs.py
+++ b/tei-py/python/structs.py
@@ -87,7 +87,7 @@ class Utterance(
     ana: list[str] = msgspec.field(default_factory=list)
 
 
-BodyBlock: TypeAlias = Paragraph | Utterance
+TextBlock: TypeAlias = Paragraph | Utterance
 
 
 class Label(msgspec.Struct, omit_defaults=True):
@@ -110,7 +110,7 @@ class ListBlock(msgspec.Struct, tag="list", tag_field="type", omit_defaults=True
     xml_id: str | None = None
 
 
-DivContent: TypeAlias = Paragraph | Utterance | ListBlock
+DivContent: TypeAlias = TextBlock | ListBlock
 
 
 class DivBlock(msgspec.Struct, tag="div", tag_field="type", omit_defaults=True):
@@ -120,7 +120,7 @@ class DivBlock(msgspec.Struct, tag="div", tag_field="type", omit_defaults=True):
     xml_id: str | None = None
 
 
-BodyBlock: TypeAlias = Paragraph | Utterance | DivBlock
+BodyBlock: TypeAlias = TextBlock | DivBlock
 
 
 class TeiBody(msgspec.Struct):

--- a/tei-py/python/structs.py
+++ b/tei-py/python/structs.py
@@ -10,6 +10,9 @@ __all__ = [
     "BodyBlock",
     "CiteData",
     "CiteStructure",
+    "DivBlock",
+    "DivContent",
+    "DivEvent",
     "DocumentEnd",
     "DocumentStart",
     "EncodingDesc",
@@ -17,13 +20,13 @@ __all__ = [
     "Event",
     "FileDesc",
     "HeaderEvent",
-    "Item",
     "Inline",
     "InlineHi",
-    "Label",
-    "ListBlock",
     "InlinePause",
     "InlineText",
+    "Item",
+    "Label",
+    "ListBlock",
     "Paragraph",
     "ParagraphEvent",
     "ProfileDesc",
@@ -37,9 +40,6 @@ __all__ = [
     "TeiHeader",
     "TeiText",
     "Utterance",
-    "DivBlock",
-    "DivContent",
-    "DivEvent",
     "UtteranceEvent",
 ]
 
@@ -159,6 +159,10 @@ class ListBlock(msgspec.Struct, tag="list", tag_field="type", omit_defaults=True
     items: list[Item] = msgspec.field(default_factory=list)
     xml_id: str | None = None
 
+    def __post_init__(self) -> None:
+        if not self.items:
+            raise ValueError("ListBlock must contain at least one Item")
+
 
 DivContent: TypeAlias = TextBlock | ListBlock
 
@@ -185,6 +189,10 @@ class DivBlock(msgspec.Struct, tag="div", tag_field="type", omit_defaults=True):
     div_type: str
     content: list[DivContent] = msgspec.field(default_factory=list)
     xml_id: str | None = None
+
+    def __post_init__(self) -> None:
+        if not self.div_type.strip():
+            raise ValueError("DivBlock.div_type must contain non-whitespace text")
 
 
 BodyBlock: TypeAlias = TextBlock | DivBlock

--- a/tei-py/python/structs.py
+++ b/tei-py/python/structs.py
@@ -91,12 +91,47 @@ TextBlock: TypeAlias = Paragraph | Utterance
 
 
 class Label(msgspec.Struct, omit_defaults=True):
-    """Label prefix attached to a list item."""
+    """Summary
+    -------
+    Label prefix attached to a structured list item.
+
+    Attributes
+    ----------
+    content : list[Inline]
+        Inline nodes rendered before the item's main content.
+
+    Notes
+    -----
+    ``Label`` values typically hold numbering or short lead-in text and attach
+    to :class:`Item` via ``Item.label``.
+    """
     content: list[Inline] = msgspec.field(default_factory=list)
 
 
 class Item(msgspec.Struct, omit_defaults=True):
-    """Structured list item contained within a division list."""
+    """Summary
+    -------
+    Structured list item contained within a division list.
+
+    Attributes
+    ----------
+    content : list[Inline]
+        Inline body content for the list item.
+    xml_id : str | None
+        Optional XML identifier for pointer resolution and linking.
+    n : str | None
+        Optional display number or ordinal marker.
+    corresp : list[str]
+        TEI pointer targets associated with the item.
+    label : Label | None
+        Optional prefix rendered before ``content``.
+
+    Notes
+    -----
+    ``Item`` values belong inside :class:`ListBlock.items`. Use ``label`` for
+    visible prefixes such as numbered bullets while keeping the main text in
+    ``content``.
+    """
     content: list[Inline] = msgspec.field(default_factory=list)
     xml_id: str | None = None
     n: str | None = None
@@ -105,7 +140,22 @@ class Item(msgspec.Struct, omit_defaults=True):
 
 
 class ListBlock(msgspec.Struct, tag="list", tag_field="type", omit_defaults=True):
-    """List block nested inside a division."""
+    """Summary
+    -------
+    List block nested inside a structural division.
+
+    Attributes
+    ----------
+    items : list[Item]
+        Ordered structured items contained by the list.
+    xml_id : str | None
+        Optional XML identifier for the list element.
+
+    Notes
+    -----
+    ``ListBlock`` values appear inside :class:`DivBlock.content` and group one
+    or more :class:`Item` values under a shared list container.
+    """
     items: list[Item] = msgspec.field(default_factory=list)
     xml_id: str | None = None
 
@@ -114,7 +164,24 @@ DivContent: TypeAlias = TextBlock | ListBlock
 
 
 class DivBlock(msgspec.Struct, tag="div", tag_field="type", omit_defaults=True):
-    """Structural division within the TEI body."""
+    """Summary
+    -------
+    Structural division within the TEI body.
+
+    Attributes
+    ----------
+    div_type : str
+        Required TEI ``@type`` value describing the division's role.
+    content : list[DivContent]
+        Ordered child blocks within the division.
+    xml_id : str | None
+        Optional XML identifier for the division.
+
+    Notes
+    -----
+    ``DivBlock`` groups paragraphs, utterances, and lists into a named section
+    such as chaptered material or show notes.
+    """
     div_type: str
     content: list[DivContent] = msgspec.field(default_factory=list)
     xml_id: str | None = None
@@ -338,7 +405,24 @@ class UtteranceEvent(
 
 
 class DivEvent(msgspec.Struct, tag="div", tag_field="type", omit_defaults=True):
-    """Streaming event carrying an assembled division body block."""
+    """Summary
+    -------
+    Streaming event carrying an assembled division body block.
+
+    Attributes
+    ----------
+    div_type : str
+        Required TEI ``@type`` value describing the emitted division.
+    content : list[DivContent]
+        Division children collected before the event is yielded.
+    xml_id : str | None
+        Optional XML identifier preserved from the source document.
+
+    Notes
+    -----
+    ``DivEvent`` is emitted by streaming parses whenever a complete division is
+    assembled, mirroring :class:`DivBlock` in the event union.
+    """
     div_type: str
     content: list[DivContent] = msgspec.field(default_factory=list)
     xml_id: str | None = None

--- a/tei-py/src/projection/body.rs
+++ b/tei-py/src/projection/body.rs
@@ -276,7 +276,7 @@ fn core_div_content_from_py(py_content: PyDivContent) -> Result<DivContent, TeiE
                 .into_iter()
                 .map(core_item_from_py)
                 .collect::<Result<Vec<_>, _>>()?;
-            let mut list = List::new(core_items);
+            let mut list = List::new(core_items)?;
             if let Some(id) = xml_id {
                 list.set_id(id)?;
             }

--- a/tei-py/src/tests/div_structs.rs
+++ b/tei-py/src/tests/div_structs.rs
@@ -65,6 +65,14 @@ fn episode_struct_decodes_div_blocks() {
             .getattr("blocks")
             .expect("TeiBody should expose blocks");
         let first = blocks.get_item(0).expect("division block should exist");
+        let div_block_type = structs.getattr("DivBlock").expect("DivBlock class");
+        let is_div_block = first
+            .is_instance(&div_block_type)
+            .expect("DivBlock isinstance check should succeed");
+        assert!(
+            is_div_block,
+            "first block should be a structs.DivBlock instance"
+        );
 
         let div_type: String = first
             .getattr("div_type")

--- a/tei-py/src/tests/div_structs.rs
+++ b/tei-py/src/tests/div_structs.rs
@@ -1,0 +1,136 @@
+//! Tests covering Python `msgspec.Struct` support for division body blocks.
+
+use super::*;
+use crate::test_support::ensure_msgspec_installed;
+use pyo3::{
+    Python,
+    types::{PyAnyMethods, PyDict, PyModule},
+};
+use tei_core::{BodyBlock, Div, Item, Label, List, TeiBody, TeiDocument, TeiHeader, TeiText};
+use tei_serde::msgpack::to_vec_named;
+use tei_xml::streaming::TeiEvent;
+
+fn division_fixture() -> TeiDocument {
+    let header = TeiHeader::new(
+        tei_core::FileDesc::from_title_str("Bridgewater").expect("title should validate"),
+    );
+    let mut div = Div::new("show-notes").expect("div type should validate");
+    div.set_id("div1").expect("id should validate");
+    div.push_paragraph(
+        tei_core::P::from_text_segments(["Further reading"]).expect("paragraph should validate"),
+    );
+
+    let mut item = Item::from_text_segments(["Transcript"]).expect("item should validate");
+    item.set_label(Label::from_text("1.").expect("label should validate"));
+    let list = List::new([item]);
+    div.push_list(list);
+
+    let text = TeiText::new(TeiBody::new([BodyBlock::Div(div)]));
+    TeiDocument::new(header, text)
+}
+
+#[test]
+fn episode_struct_decodes_div_blocks() {
+    Python::with_gil(|py| {
+        if ensure_msgspec_installed(py).is_err() {
+            return;
+        }
+
+        let module = PyModule::new(py, "tei_rapporteur").expect("module allocation");
+        tei_rapporteur(py, &module).expect("module registration");
+
+        let payload = to_vec_named(&crate::projection::PyTeiDocument::from(&division_fixture()))
+            .expect("MessagePack encoding should succeed");
+
+        let structs = module.getattr("structs").expect("structs module");
+        let episode_type = structs.getattr("Episode").expect("Episode class");
+        let msgpack = py
+            .import("msgspec.msgpack")
+            .expect("msgspec.msgpack import");
+        let decode_kwargs = PyDict::new(py);
+        decode_kwargs
+            .set_item("type", episode_type)
+            .expect("kwargs population");
+
+        let episode = msgpack
+            .getattr("decode")
+            .expect("decode function")
+            .call((payload,), Some(&decode_kwargs))
+            .expect("Episode should decode");
+        let blocks = episode
+            .getattr("text")
+            .expect("Episode should expose text")
+            .getattr("body")
+            .expect("TeiText should expose body")
+            .getattr("blocks")
+            .expect("TeiBody should expose blocks");
+        let first = blocks.get_item(0).expect("division block should exist");
+
+        let div_type: String = first
+            .getattr("div_type")
+            .expect("DivBlock should expose div_type")
+            .extract()
+            .expect("div_type should be a string");
+        assert_eq!(div_type, "show-notes");
+        let content = first
+            .getattr("content")
+            .expect("DivBlock should expose content");
+        let list_block = content.get_item(1).expect("list block should exist");
+        let items = list_block
+            .getattr("items")
+            .expect("ListBlock should expose items");
+        let item = items.get_item(0).expect("item should exist");
+        let label = item.getattr("label").expect("Item should expose label");
+        let label_text: String = label
+            .getattr("content")
+            .expect("Label should expose content")
+            .get_item(0)
+            .expect("label content item")
+            .getattr("value")
+            .expect("text inline should expose value")
+            .extract()
+            .expect("label content value should be a string");
+        assert_eq!(label_text, "1.");
+    });
+}
+
+#[test]
+fn streaming_div_events_decode_into_python_union() {
+    Python::with_gil(|py| {
+        if ensure_msgspec_installed(py).is_err() {
+            return;
+        }
+
+        let module = PyModule::new(py, "tei_rapporteur").expect("module allocation");
+        tei_rapporteur(py, &module).expect("module registration");
+        let structs = module.getattr("structs").expect("structs module");
+        let event_type = structs.getattr("Event").expect("Event union");
+        let converter = py
+            .import("msgspec")
+            .expect("msgspec import")
+            .getattr("convert")
+            .expect("msgspec.convert available");
+
+        let div_event = crate::projection::py_event_from_core(TeiEvent::BodyBlock(
+            division_fixture()
+                .text()
+                .body()
+                .blocks()
+                .first()
+                .expect("fixture body block")
+                .clone(),
+        ));
+        let py_event =
+            pyo3_serde::to_pyobject(py, &div_event).expect("event projection should serialise");
+        let decoded_event = converter
+            .call((py_event, event_type), None)
+            .expect("msgspec conversion should succeed");
+
+        let div_type: String = decoded_event
+            .getattr("div_type")
+            .expect("DivEvent should expose div_type")
+            .extract()
+            .expect("div_type should be a string");
+        assert_eq!(div_type, "show-notes");
+    });
+}

--- a/tei-py/src/tests/div_structs.rs
+++ b/tei-py/src/tests/div_structs.rs
@@ -22,7 +22,7 @@ fn division_fixture() -> TeiDocument {
 
     let mut item = Item::from_text_segments(["Transcript"]).expect("item should validate");
     item.set_label(Label::from_text("1.").expect("label should validate"));
-    let list = List::new([item]);
+    let list = List::new([item]).expect("list should validate");
     div.push_list(list);
 
     let text = TeiText::new(TeiBody::new([BodyBlock::Div(div)]));

--- a/tei-py/src/tests/mod.rs
+++ b/tei-py/src/tests/mod.rs
@@ -11,6 +11,7 @@ use tei_serde::serde_json::json;
 
 mod bindings_tests;
 mod dict;
+mod div_structs;
 mod projection_tests;
 mod streaming;
 mod structs_tests;

--- a/tei-py/src/tests/structs_tests.rs
+++ b/tei-py/src/tests/structs_tests.rs
@@ -4,7 +4,7 @@ use super::*;
 use crate::test_support::ensure_msgspec_installed;
 use pyo3::{
     Py, Python,
-    exceptions::PyAttributeError,
+    exceptions::{PyAttributeError, PyValueError},
     types::{PyAnyMethods, PyDict, PyModule},
 };
 use rstest::{fixture, rstest};
@@ -168,5 +168,57 @@ fn episode_struct_round_trips_messagepack(#[from(registered_module)] module: Opt
             document_from_msgpack(updated_payload.as_slice()).expect("payload should decode");
 
         assert_eq!(round_tripped.title().as_str(), "Bridgewater Remix");
+    });
+}
+
+#[rstest]
+fn list_block_rejects_empty_items(#[from(registered_module)] module: Option<Py<PyModule>>) {
+    let Some(registered_module) = module else {
+        return;
+    };
+    Python::with_gil(|py| {
+        let bound_module = registered_module.bind(py);
+        let structs = bound_module.getattr("structs").expect("structs module");
+        let list_block_type = structs.getattr("ListBlock").expect("ListBlock class");
+
+        let error = list_block_type
+            .call0()
+            .expect_err("ListBlock should reject empty items");
+        assert!(
+            error.is_instance_of::<PyValueError>(py),
+            "empty ListBlock should raise ValueError"
+        );
+        assert!(
+            error
+                .to_string()
+                .contains("ListBlock must contain at least one Item"),
+            "error should explain the ListBlock invariant"
+        );
+    });
+}
+
+#[rstest]
+fn div_block_rejects_blank_type(#[from(registered_module)] module: Option<Py<PyModule>>) {
+    let Some(registered_module) = module else {
+        return;
+    };
+    Python::with_gil(|py| {
+        let bound_module = registered_module.bind(py);
+        let structs = bound_module.getattr("structs").expect("structs module");
+        let div_block_type = structs.getattr("DivBlock").expect("DivBlock class");
+
+        let error = div_block_type
+            .call1(("   ",))
+            .expect_err("DivBlock should reject blank div_type values");
+        assert!(
+            error.is_instance_of::<PyValueError>(py),
+            "blank DivBlock div_type should raise ValueError"
+        );
+        assert!(
+            error
+                .to_string()
+                .contains("DivBlock.div_type must contain non-whitespace text"),
+            "error should explain the DivBlock invariant"
+        );
     });
 }

--- a/tei-serde/tests/arbitrary/text.rs
+++ b/tei-serde/tests/arbitrary/text.rs
@@ -191,7 +191,7 @@ where
 {
     (
         proptest::option::of(xml_id_strategy()),
-        prop::collection::vec(item_strategy, 0..=4),
+        prop::collection::vec(item_strategy, 1..=4),
     )
         .prop_map(|(id, items)| {
             let mut list = List::new(items);

--- a/tei-serde/tests/arbitrary/text.rs
+++ b/tei-serde/tests/arbitrary/text.rs
@@ -18,7 +18,9 @@
 //! Choose the strategy variant that matches the serializer being exercised in your test.
 
 use proptest::prelude::*;
-use tei_core::{BodyBlock, Inline, P, TeiBody, TeiText, Utterance};
+use tei_core::{
+    BodyBlock, Div, DivContent, Inline, Item, Label, List, P, TeiBody, TeiText, Utterance,
+};
 
 use super::inline::{
     has_visible_content, has_visible_content_slice, inline_strategy, text_only_inline_strategy,
@@ -83,6 +85,7 @@ pub fn body_block_strategy() -> impl Strategy<Value = BodyBlock> {
     prop_oneof![
         paragraph_strategy().prop_map(BodyBlock::Paragraph),
         utterance_strategy().prop_map(BodyBlock::Utterance),
+        div_strategy().prop_map(BodyBlock::Div),
     ]
 }
 
@@ -121,6 +124,7 @@ pub fn text_only_body_block_strategy() -> impl Strategy<Value = BodyBlock> {
     prop_oneof![
         text_only_paragraph_strategy().prop_map(BodyBlock::Paragraph),
         text_only_utterance_strategy().prop_map(BodyBlock::Utterance),
+        text_only_div_strategy().prop_map(BodyBlock::Div),
     ]
 }
 
@@ -132,6 +136,157 @@ pub fn text_only_tei_body_strategy() -> impl Strategy<Value = TeiBody> {
 /// Generates a text-only `TeiText` wrapping a `TeiBody`.
 pub fn text_only_tei_text_strategy() -> impl Strategy<Value = TeiText> {
     text_only_tei_body_strategy().prop_map(TeiText::new)
+}
+
+fn label_with_content_strategy<S>(content_strategy: S) -> impl Strategy<Value = Label>
+where
+    S: Strategy<Value = Vec<Inline>>,
+{
+    content_strategy.prop_map(|content| {
+        Label::new(content)
+            .unwrap_or_else(|error| panic!("generated label content should be valid: {error}"))
+    })
+}
+
+fn item_with_content_strategy<S, L>(
+    content_strategy: S,
+    label_content_strategy: L,
+) -> impl Strategy<Value = Item>
+where
+    S: Strategy<Value = Vec<Inline>>,
+    L: Strategy<Value = Vec<Inline>>,
+{
+    (
+        proptest::option::of(xml_id_strategy()),
+        proptest::option::of(prop::sample::select(vec![
+            String::from("1"),
+            String::from("2"),
+            String::from("intro"),
+            String::from("link"),
+        ])),
+        proptest::option::of(label_with_content_strategy(label_content_strategy)),
+        content_strategy,
+    )
+        .prop_map(|(id, n, label, content)| {
+            let mut item = Item::new(content)
+                .unwrap_or_else(|error| panic!("generated item content should be valid: {error}"));
+            if let Some(id_value) = id {
+                item.set_id(id_value)
+                    .unwrap_or_else(|error| panic!("generated id should be valid: {error}"));
+            }
+            if let Some(n_value) = n {
+                item.set_n(n_value)
+                    .unwrap_or_else(|error| panic!("generated @n should be valid: {error}"));
+            }
+            if let Some(label_value) = label {
+                item.set_label(label_value);
+            }
+            item
+        })
+}
+
+fn list_with_item_strategy<S>(item_strategy: S) -> impl Strategy<Value = List>
+where
+    S: Strategy<Value = Item>,
+{
+    (
+        proptest::option::of(xml_id_strategy()),
+        prop::collection::vec(item_strategy, 0..=4),
+    )
+        .prop_map(|(id, items)| {
+            let mut list = List::new(items);
+            if let Some(id_value) = id {
+                list.set_id(id_value)
+                    .unwrap_or_else(|error| panic!("generated id should be valid: {error}"));
+            }
+            list
+        })
+}
+
+fn div_strategy() -> impl Strategy<Value = Div> {
+    let paragraph_content = paragraph_strategy().prop_map(DivContent::Paragraph);
+    let utterance_content = utterance_strategy().prop_map(DivContent::Utterance);
+    let list_content = list_with_item_strategy(item_with_content_strategy(
+        prop::collection::vec(inline_strategy(), 1..=5)
+            .prop_filter("item must have visible content", |v| has_visible_content(v)),
+        prop::collection::vec(inline_strategy(), 1..=3)
+            .prop_filter("label must have visible content", |v| {
+                has_visible_content(v)
+            }),
+    ))
+    .prop_map(DivContent::List);
+
+    (
+        proptest::option::of(xml_id_strategy()),
+        prop::sample::select(vec![
+            String::from("chapter"),
+            String::from("intro"),
+            String::from("show-notes"),
+            String::from("links"),
+            String::from("sponsors"),
+        ]),
+        prop::collection::vec(
+            prop_oneof![paragraph_content, utterance_content, list_content],
+            0..=4,
+        ),
+    )
+        .prop_map(|(id, div_type, content)| {
+            let mut div = Div::new(div_type)
+                .unwrap_or_else(|error| panic!("generated div type should be valid: {error}"));
+            if let Some(id_value) = id {
+                div.set_id(id_value)
+                    .unwrap_or_else(|error| panic!("generated id should be valid: {error}"));
+            }
+            for child in content {
+                match child {
+                    DivContent::Paragraph(paragraph_block) => div.push_paragraph(paragraph_block),
+                    DivContent::Utterance(utterance_block) => div.push_utterance(utterance_block),
+                    DivContent::List(list_block) => div.push_list(list_block),
+                }
+            }
+            div
+        })
+}
+
+fn text_only_div_strategy() -> impl Strategy<Value = Div> {
+    let paragraph_content = text_only_paragraph_strategy().prop_map(DivContent::Paragraph);
+    let utterance_content = text_only_utterance_strategy().prop_map(DivContent::Utterance);
+    let list_content = list_with_item_strategy(item_with_content_strategy(
+        text_only_inline_strategy().prop_map(|inline| vec![inline]),
+        text_only_inline_strategy().prop_map(|inline| vec![inline]),
+    ))
+    .prop_map(DivContent::List);
+
+    (
+        proptest::option::of(xml_id_strategy()),
+        prop::sample::select(vec![
+            String::from("chapter"),
+            String::from("intro"),
+            String::from("show-notes"),
+            String::from("links"),
+            String::from("sponsors"),
+        ]),
+        prop::collection::vec(
+            prop_oneof![paragraph_content, utterance_content, list_content],
+            0..=4,
+        ),
+    )
+        .prop_map(|(id, div_type, content)| {
+            let mut div = Div::new(div_type)
+                .unwrap_or_else(|error| panic!("generated div type should be valid: {error}"));
+            if let Some(id_value) = id {
+                div.set_id(id_value)
+                    .unwrap_or_else(|error| panic!("generated id should be valid: {error}"));
+            }
+            for child in content {
+                match child {
+                    DivContent::Paragraph(paragraph_block) => div.push_paragraph(paragraph_block),
+                    DivContent::Utterance(utterance_block) => div.push_utterance(utterance_block),
+                    DivContent::List(list_block) => div.push_list(list_block),
+                }
+            }
+            div
+        })
 }
 
 #[cfg(test)]
@@ -160,14 +315,7 @@ mod tests {
             body.blocks().iter().all(|block| match block {
                 BodyBlock::Paragraph(p) => has_visible_content_slice(p.content()),
                 BodyBlock::Utterance(u) => has_visible_content_slice(u.content()),
-                BodyBlock::Div(_) => {
-                    // Div generation is not yet implemented in body_block_strategy()
-                    debug_assert!(
-                        false,
-                        "body_block_strategy() does not generate Div variants"
-                    );
-                    false
-                }
+                BodyBlock::Div(div) => !div.div_type().trim().is_empty(),
             })
         });
     }

--- a/tei-serde/tests/arbitrary/text.rs
+++ b/tei-serde/tests/arbitrary/text.rs
@@ -203,32 +203,24 @@ where
         })
 }
 
-fn div_strategy() -> impl Strategy<Value = Div> {
-    let paragraph_content = paragraph_strategy().prop_map(DivContent::Paragraph);
-    let utterance_content = utterance_strategy().prop_map(DivContent::Utterance);
-    let list_content = list_with_item_strategy(item_with_content_strategy(
-        prop::collection::vec(inline_strategy(), 1..=5)
-            .prop_filter("item must have visible content", |v| has_visible_content(v)),
-        prop::collection::vec(inline_strategy(), 1..=3)
-            .prop_filter("label must have visible content", |v| {
-                has_visible_content(v)
-            }),
-    ))
-    .prop_map(DivContent::List);
+fn div_type_strategy() -> impl Strategy<Value = String> {
+    prop::sample::select(vec![
+        String::from("chapter"),
+        String::from("intro"),
+        String::from("show-notes"),
+        String::from("links"),
+        String::from("sponsors"),
+    ])
+}
 
+fn div_with_content_strategy<S>(content_strategy: S) -> impl Strategy<Value = Div>
+where
+    S: Strategy<Value = Vec<DivContent>>,
+{
     (
         proptest::option::of(xml_id_strategy()),
-        prop::sample::select(vec![
-            String::from("chapter"),
-            String::from("intro"),
-            String::from("show-notes"),
-            String::from("links"),
-            String::from("sponsors"),
-        ]),
-        prop::collection::vec(
-            prop_oneof![paragraph_content, utterance_content, list_content],
-            0..=4,
-        ),
+        div_type_strategy(),
+        content_strategy,
     )
         .prop_map(|(id, div_type, content)| {
             let mut div = Div::new(div_type)
@@ -248,6 +240,25 @@ fn div_strategy() -> impl Strategy<Value = Div> {
         })
 }
 
+fn div_strategy() -> impl Strategy<Value = Div> {
+    let paragraph_content = paragraph_strategy().prop_map(DivContent::Paragraph);
+    let utterance_content = utterance_strategy().prop_map(DivContent::Utterance);
+    let list_content = list_with_item_strategy(item_with_content_strategy(
+        prop::collection::vec(inline_strategy(), 1..=5)
+            .prop_filter("item must have visible content", |v| has_visible_content(v)),
+        prop::collection::vec(inline_strategy(), 1..=3)
+            .prop_filter("label must have visible content", |v| {
+                has_visible_content(v)
+            }),
+    ))
+    .prop_map(DivContent::List);
+
+    div_with_content_strategy(prop::collection::vec(
+        prop_oneof![paragraph_content, utterance_content, list_content],
+        0..=4,
+    ))
+}
+
 fn text_only_div_strategy() -> impl Strategy<Value = Div> {
     let paragraph_content = text_only_paragraph_strategy().prop_map(DivContent::Paragraph);
     let utterance_content = text_only_utterance_strategy().prop_map(DivContent::Utterance);
@@ -257,36 +268,10 @@ fn text_only_div_strategy() -> impl Strategy<Value = Div> {
     ))
     .prop_map(DivContent::List);
 
-    (
-        proptest::option::of(xml_id_strategy()),
-        prop::sample::select(vec![
-            String::from("chapter"),
-            String::from("intro"),
-            String::from("show-notes"),
-            String::from("links"),
-            String::from("sponsors"),
-        ]),
-        prop::collection::vec(
-            prop_oneof![paragraph_content, utterance_content, list_content],
-            0..=4,
-        ),
-    )
-        .prop_map(|(id, div_type, content)| {
-            let mut div = Div::new(div_type)
-                .unwrap_or_else(|error| panic!("generated div type should be valid: {error}"));
-            if let Some(id_value) = id {
-                div.set_id(id_value)
-                    .unwrap_or_else(|error| panic!("generated id should be valid: {error}"));
-            }
-            for child in content {
-                match child {
-                    DivContent::Paragraph(paragraph_block) => div.push_paragraph(paragraph_block),
-                    DivContent::Utterance(utterance_block) => div.push_utterance(utterance_block),
-                    DivContent::List(list_block) => div.push_list(list_block),
-                }
-            }
-            div
-        })
+    div_with_content_strategy(prop::collection::vec(
+        prop_oneof![paragraph_content, utterance_content, list_content],
+        0..=4,
+    ))
 }
 
 #[cfg(test)]

--- a/tei-serde/tests/arbitrary/text.rs
+++ b/tei-serde/tests/arbitrary/text.rs
@@ -19,7 +19,8 @@
 
 use proptest::prelude::*;
 use tei_core::{
-    BodyBlock, Div, DivContent, Inline, Item, Label, List, P, TeiBody, TeiText, Utterance,
+    BodyBlock, Div, DivContent, Inline, Item, Label, List, P, PointerList, TeiBody, TeiText,
+    Utterance,
 };
 
 use super::inline::{
@@ -164,10 +165,11 @@ where
             String::from("intro"),
             String::from("link"),
         ])),
+        proptest::option::of(prop::collection::vec(xml_id_strategy(), 1..=3)),
         proptest::option::of(label_with_content_strategy(label_content_strategy)),
         content_strategy,
     )
-        .prop_map(|(id, n, label, content)| {
+        .prop_map(|(id, n, corresp_ids, label, content)| {
             let mut item = Item::new(content)
                 .unwrap_or_else(|error| panic!("generated item content should be valid: {error}"));
             if let Some(id_value) = id {
@@ -177,6 +179,15 @@ where
             if let Some(n_value) = n {
                 item.set_n(n_value)
                     .unwrap_or_else(|error| panic!("generated @n should be valid: {error}"));
+            }
+            if let Some(corresp_values) = corresp_ids {
+                let corresp = PointerList::new(
+                    corresp_values
+                        .into_iter()
+                        .map(|pointer_id| format!("#{pointer_id}")),
+                )
+                .unwrap_or_else(|error| panic!("generated @corresp should be valid: {error}"));
+                item.set_corresp(corresp);
             }
             if let Some(label_value) = label {
                 item.set_label(label_value);
@@ -279,6 +290,27 @@ mod tests {
     use super::*;
     use crate::arbitrary::test_utils::assert_strategy_produces_valid_values;
 
+    fn label_is_valid(label: &Label) -> bool {
+        has_visible_content_slice(label.content())
+    }
+
+    fn item_is_valid(item: &Item) -> bool {
+        has_visible_content_slice(item.content()) && item.label().is_none_or(label_is_valid)
+    }
+
+    fn list_is_valid(list: &List) -> bool {
+        !list.items().is_empty() && list.items().iter().all(item_is_valid)
+    }
+
+    fn div_is_valid(div: &Div) -> bool {
+        !div.div_type().trim().is_empty()
+            && div.content().iter().all(|content| match content {
+                DivContent::Paragraph(paragraph) => has_visible_content_slice(paragraph.content()),
+                DivContent::Utterance(utterance) => has_visible_content_slice(utterance.content()),
+                DivContent::List(list) => list_is_valid(list),
+            })
+    }
+
     #[test]
     fn paragraph_strategy_produces_valid_paragraphs() {
         assert_strategy_produces_valid_values(paragraph_strategy(), |paragraph| {
@@ -300,7 +332,7 @@ mod tests {
             body.blocks().iter().all(|block| match block {
                 BodyBlock::Paragraph(p) => has_visible_content_slice(p.content()),
                 BodyBlock::Utterance(u) => has_visible_content_slice(u.content()),
-                BodyBlock::Div(div) => !div.div_type().trim().is_empty(),
+                BodyBlock::Div(div) => div_is_valid(div),
             })
         });
     }

--- a/tei-serde/tests/arbitrary/text.rs
+++ b/tei-serde/tests/arbitrary/text.rs
@@ -205,7 +205,8 @@ where
         prop::collection::vec(item_strategy, 1..=4),
     )
         .prop_map(|(id, items)| {
-            let mut list = List::new(items);
+            let mut list = List::new(items)
+                .unwrap_or_else(|error| panic!("generated list items should be valid: {error}"));
             if let Some(id_value) = id {
                 list.set_id(id_value)
                     .unwrap_or_else(|error| panic!("generated id should be valid: {error}"));

--- a/tei-serde/tests/json_schema_behaviour.rs
+++ b/tei-serde/tests/json_schema_behaviour.rs
@@ -344,7 +344,7 @@ fn structural_document() -> TeiDocument {
     item.set_label(
         Label::from_text("1.").unwrap_or_else(|error| panic!("label should validate: {error}")),
     );
-    let list = List::new([item]);
+    let list = List::new([item]).unwrap_or_else(|error| panic!("list should validate: {error}"));
     let mut div =
         Div::new("show-notes").unwrap_or_else(|error| panic!("div should validate: {error}"));
     div.push_paragraph(

--- a/tei-serde/tests/json_schema_behaviour.rs
+++ b/tei-serde/tests/json_schema_behaviour.rs
@@ -4,7 +4,10 @@ use anyhow::{Context, Result, ensure};
 use rstest::fixture;
 use rstest_bdd_macros::{given, scenario, then, when};
 use std::cell::RefCell;
-use tei_core::{BodyBlock, Hi, Inline, P, TeiBody, TeiDocument, TeiHeader, TeiText};
+use tei_core::{
+    BodyBlock, Div, DivContent, Hi, Inline, Item, Label, List, P, TeiBody, TeiDocument, TeiHeader,
+    TeiText,
+};
 use tei_test_helpers::expect_validated_state;
 
 fn compile_validator(schema: &serde_json::Value) -> Result<jsonschema::Validator> {
@@ -333,4 +336,113 @@ pub fn rejects_hi_nodes_with_unknown_properties(
     #[from(validated_state_result)] result: Result<JsonSchemaState>,
 ) {
     expect_validated_state(result, "json schema");
+}
+
+fn structural_document() -> TeiDocument {
+    let mut item = Item::from_text_segments(["Reference"])
+        .unwrap_or_else(|error| panic!("item should validate: {error}"));
+    item.set_label(
+        Label::from_text("1.").unwrap_or_else(|error| panic!("label should validate: {error}")),
+    );
+    let list = List::new([item]);
+    let mut div =
+        Div::new("show-notes").unwrap_or_else(|error| panic!("div should validate: {error}"));
+    div.push_paragraph(
+        P::from_text_segments(["Intro"])
+            .unwrap_or_else(|error| panic!("paragraph should validate: {error}")),
+    );
+    div.push_list(list);
+
+    TeiDocument::new(
+        TeiHeader::new(
+            tei_core::FileDesc::from_title_str("fixture")
+                .unwrap_or_else(|error| panic!("title should validate: {error}")),
+        ),
+        TeiText::new(TeiBody::new([BodyBlock::Div(div)])),
+    )
+}
+
+fn schema_has_variant(
+    schema: &serde_json::Value,
+    variant_path: &str,
+    expected_property_path: &str,
+) -> bool {
+    schema
+        .pointer(variant_path)
+        .and_then(serde_json::Value::as_array)
+        .is_some_and(|variants| {
+            variants.iter().any(|variant| {
+                variant
+                    .pointer(expected_property_path)
+                    .and_then(serde_json::Value::as_str)
+                    .is_some()
+            })
+        })
+}
+
+fn assert_schema_definitions(schema: &serde_json::Value) -> Result<()> {
+    for definition in ["/$defs/div", "/$defs/list", "/$defs/item", "/$defs/label"] {
+        ensure!(
+            schema.pointer(definition).is_some(),
+            "schema should define {definition}"
+        );
+    }
+    Ok(())
+}
+
+fn assert_schema_variants(schema: &serde_json::Value) -> Result<()> {
+    ensure!(
+        schema_has_variant(schema, "/$defs/BodyBlock/oneOf", "/properties/div/$ref"),
+        "BodyBlock schema should include the `div` variant"
+    );
+    ensure!(
+        schema_has_variant(schema, "/$defs/DivContent/oneOf", "/properties/list/$ref"),
+        "DivContent schema should include the `list` variant"
+    );
+    Ok(())
+}
+
+fn assert_document_shape(document: &TeiDocument) -> Result<()> {
+    ensure!(
+        matches!(
+            document.text().body().blocks().first(),
+            Some(BodyBlock::Div(Div { .. }))
+        ),
+        "fixture document should contain a `Div` body block"
+    );
+    ensure!(
+        matches!(
+            document
+                .text()
+                .body()
+                .blocks()
+                .first()
+                .and_then(|block| match block {
+                    BodyBlock::Div(division) => division.content().get(1),
+                    _ => None,
+                }),
+            Some(DivContent::List(_))
+        ),
+        "fixture division should contain a list"
+    );
+    Ok(())
+}
+
+#[test]
+fn schema_includes_structural_body_definitions() -> Result<()> {
+    let document = structural_document();
+    let schema = tei_serde::schema::tei_document_schema().to_value();
+    let validator = compile_validator(&schema)?;
+    let instance =
+        tei_serde::json::to_value(&document).context("document should serialize to JSON")?;
+    let errors = collect_validation_errors(validator.iter_errors(&instance));
+
+    ensure!(
+        errors.is_empty(),
+        "document should satisfy schema: {errors:?}"
+    );
+    assert_schema_definitions(&schema)?;
+    assert_schema_variants(&schema)?;
+    assert_document_shape(&document)?;
+    Ok(())
 }

--- a/tei-serde/tests/json_schema_behaviour.rs
+++ b/tei-serde/tests/json_schema_behaviour.rs
@@ -366,6 +366,7 @@ fn schema_has_variant(
     schema: &serde_json::Value,
     variant_path: &str,
     expected_property_path: &str,
+    expected_ref_suffix: &str,
 ) -> bool {
     schema
         .pointer(variant_path)
@@ -375,7 +376,7 @@ fn schema_has_variant(
                 variant
                     .pointer(expected_property_path)
                     .and_then(serde_json::Value::as_str)
-                    .is_some()
+                    .is_some_and(|reference| reference.ends_with(expected_ref_suffix))
             })
         })
 }
@@ -392,19 +393,39 @@ fn assert_schema_definitions(schema: &serde_json::Value) -> Result<()> {
 
 fn assert_schema_variants(schema: &serde_json::Value) -> Result<()> {
     ensure!(
-        schema_has_variant(schema, "/$defs/BodyBlock/oneOf", "/properties/div/$ref"),
+        schema_has_variant(
+            schema,
+            "/$defs/BodyBlock/oneOf",
+            "/properties/div/$ref",
+            "#/$defs/div",
+        ),
         "BodyBlock schema should include the `div` variant"
     );
     ensure!(
-        schema_has_variant(schema, "/$defs/DivContent/oneOf", "/properties/p/$ref"),
+        schema_has_variant(
+            schema,
+            "/$defs/DivContent/oneOf",
+            "/properties/p/$ref",
+            "#/$defs/p",
+        ),
         "DivContent schema should include the `p` variant"
     );
     ensure!(
-        schema_has_variant(schema, "/$defs/DivContent/oneOf", "/properties/u/$ref"),
+        schema_has_variant(
+            schema,
+            "/$defs/DivContent/oneOf",
+            "/properties/u/$ref",
+            "#/$defs/u",
+        ),
         "DivContent schema should include the `u` variant"
     );
     ensure!(
-        schema_has_variant(schema, "/$defs/DivContent/oneOf", "/properties/list/$ref"),
+        schema_has_variant(
+            schema,
+            "/$defs/DivContent/oneOf",
+            "/properties/list/$ref",
+            "#/$defs/list",
+        ),
         "DivContent schema should include the `list` variant"
     );
     Ok(())
@@ -436,6 +457,16 @@ fn assert_document_shape(document: &TeiDocument) -> Result<()> {
     Ok(())
 }
 
+fn assert_instance_shape(instance: &serde_json::Value) -> Result<()> {
+    ensure!(
+        instance
+            .pointer("/text/body/$value/0/div/$value/1/list/$value/0/label")
+            .is_some_and(|label| !label.is_null()),
+        "serialized document should include the list item label"
+    );
+    Ok(())
+}
+
 #[test]
 fn schema_includes_structural_body_definitions() -> Result<()> {
     let document = structural_document();
@@ -452,5 +483,6 @@ fn schema_includes_structural_body_definitions() -> Result<()> {
     assert_schema_definitions(&schema)?;
     assert_schema_variants(&schema)?;
     assert_document_shape(&document)?;
+    assert_instance_shape(&instance)?;
     Ok(())
 }

--- a/tei-serde/tests/json_schema_behaviour.rs
+++ b/tei-serde/tests/json_schema_behaviour.rs
@@ -396,6 +396,14 @@ fn assert_schema_variants(schema: &serde_json::Value) -> Result<()> {
         "BodyBlock schema should include the `div` variant"
     );
     ensure!(
+        schema_has_variant(schema, "/$defs/DivContent/oneOf", "/properties/p/$ref"),
+        "DivContent schema should include the `p` variant"
+    );
+    ensure!(
+        schema_has_variant(schema, "/$defs/DivContent/oneOf", "/properties/u/$ref"),
+        "DivContent schema should include the `u` variant"
+    );
+    ensure!(
         schema_has_variant(schema, "/$defs/DivContent/oneOf", "/properties/list/$ref"),
         "DivContent schema should include the `list` variant"
     );

--- a/tei-xml/resources/tei-episodic-profile.rng
+++ b/tei-xml/resources/tei-episodic-profile.rng
@@ -325,9 +325,9 @@
           <text/>
         </attribute>
       </optional>
-      <zeroOrMore>
+      <oneOrMore>
         <ref name="item"/>
-      </zeroOrMore>
+      </oneOrMore>
     </element>
   </define>
 

--- a/tei-xml/resources/tei-episodic-profile.rng
+++ b/tei-xml/resources/tei-episodic-profile.rng
@@ -292,8 +292,72 @@
         <choice>
           <ref name="p"/>
           <ref name="u"/>
+          <ref name="div"/>
         </choice>
       </zeroOrMore>
+    </element>
+  </define>
+
+  <define name="div">
+    <element name="div" ns="http://www.tei-c.org/ns/1.0">
+      <optional>
+        <attribute name="xml:id" ns="http://www.w3.org/XML/1998/namespace">
+          <text/>
+        </attribute>
+      </optional>
+      <attribute name="type">
+        <text/>
+      </attribute>
+      <zeroOrMore>
+        <choice>
+          <ref name="p"/>
+          <ref name="u"/>
+          <ref name="list"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+
+  <define name="list">
+    <element name="list" ns="http://www.tei-c.org/ns/1.0">
+      <optional>
+        <attribute name="xml:id" ns="http://www.w3.org/XML/1998/namespace">
+          <text/>
+        </attribute>
+      </optional>
+      <zeroOrMore>
+        <ref name="item"/>
+      </zeroOrMore>
+    </element>
+  </define>
+
+  <define name="item">
+    <element name="item" ns="http://www.tei-c.org/ns/1.0">
+      <optional>
+        <attribute name="xml:id" ns="http://www.w3.org/XML/1998/namespace">
+          <text/>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="n">
+          <text/>
+        </attribute>
+      </optional>
+      <optional>
+        <attribute name="corresp">
+          <text/>
+        </attribute>
+      </optional>
+      <optional>
+        <ref name="label"/>
+      </optional>
+      <ref name="inlineContent"/>
+    </element>
+  </define>
+
+  <define name="label">
+    <element name="label" ns="http://www.tei-c.org/ns/1.0">
+      <ref name="inlineContent"/>
     </element>
   </define>
 

--- a/tei-xml/src/fixtures/mod.rs
+++ b/tei-xml/src/fixtures/mod.rs
@@ -193,7 +193,7 @@ pub fn document_with_div_and_list() -> Result<TeiDocument, TeiError> {
     let mut second_item = Item::from_text_segments(["Secondary reference"])?;
     second_item.set_id("item-2")?;
 
-    let mut list = List::new([first_item, second_item]);
+    let mut list = List::new([first_item, second_item])?;
     list.set_id("list-1")?;
 
     let mut div = Div::new("show-notes")?;

--- a/tei-xml/src/fixtures/mod.rs
+++ b/tei-xml/src/fixtures/mod.rs
@@ -19,9 +19,9 @@ mod bench;
 pub use bench::{BenchFixtureConfig, generate_benchmark_document, generate_benchmark_xml};
 
 use tei_core::{
-    AnnotationSystem, BodyBlock, CiteData, CiteStructure, EncodingDesc, FileDesc, P, PointerList,
-    ProfileDesc, RefsDecl, RevisionChange, RevisionDesc, Span, SpanGroup, StandOff, TeiBody,
-    TeiDocument, TeiError, TeiHeader, TeiText, Utterance,
+    AnnotationSystem, BodyBlock, CiteData, CiteStructure, Div, EncodingDesc, FileDesc, Item, Label,
+    List, P, PointerList, ProfileDesc, RefsDecl, RevisionChange, RevisionDesc, Span, SpanGroup,
+    StandOff, TeiBody, TeiDocument, TeiError, TeiHeader, TeiText, Utterance,
 };
 
 /// A function that builds a TEI document fixture.
@@ -166,6 +166,47 @@ pub fn comprehensive_document() -> Result<TeiDocument, TeiError> {
     Ok(TeiDocument::new(header, text).with_stand_off(stand_off))
 }
 
+/// Returns a document whose body contains a structural division with a list.
+///
+/// # Errors
+///
+/// Returns [`TeiError`] when any component of the document cannot be
+/// constructed.
+pub fn document_with_div_and_list() -> Result<TeiDocument, TeiError> {
+    let file_desc = FileDesc::from_title_str("Division Fixture")?;
+    let header = TeiHeader::new(file_desc);
+
+    let mut intro = P::from_text_segments(["Show notes follow below."])?;
+    intro.set_id("p-div-intro")?;
+
+    let mut utterance =
+        Utterance::from_text_segments(Some("host"), ["These links are in the notes."])?;
+    utterance.set_id("u-div-1")?;
+
+    let label = Label::from_text("1.")?;
+    let mut first_item = Item::from_text_segments(["Primary reference"])?;
+    first_item.set_id("item-1")?;
+    first_item.set_n("1")?;
+    first_item.set_corresp(PointerList::new(["#u-div-1"])?);
+    first_item.set_label(label);
+
+    let mut second_item = Item::from_text_segments(["Secondary reference"])?;
+    second_item.set_id("item-2")?;
+
+    let mut list = List::new([first_item, second_item]);
+    list.set_id("list-1")?;
+
+    let mut div = Div::new("show-notes")?;
+    div.set_id("div-1")?;
+    div.push_paragraph(intro);
+    div.push_utterance(utterance);
+    div.push_list(list);
+
+    let body = TeiBody::new([BodyBlock::Div(div)]);
+    let text = TeiText::new(body);
+    Ok(TeiDocument::new(header, text))
+}
+
 /// Returns an iterator over all fixture builders with their names.
 ///
 /// This is used by the `generate-fixtures` binary to produce XML files.
@@ -176,6 +217,7 @@ pub fn fixture_builders() -> Vec<NamedFixture> {
         ("paragraphs", document_with_paragraphs),
         ("utterances", document_with_utterances),
         ("comprehensive", comprehensive_document),
+        ("div-list", document_with_div_and_list),
     ]
 }
 
@@ -210,6 +252,12 @@ mod tests {
         assert!(doc.header().revision_desc().is_some());
         assert!(doc.stand_off().is_some());
         assert_eq!(doc.text().body().blocks().len(), 4);
+    }
+
+    #[test]
+    fn document_with_div_and_list_builds_successfully() {
+        let doc = document_with_div_and_list().expect("division fixture should build");
+        assert_eq!(doc.text().body().blocks().len(), 1);
     }
 
     #[test]

--- a/tei-xml/src/streaming/helpers.rs
+++ b/tei-xml/src/streaming/helpers.rs
@@ -222,7 +222,7 @@ pub fn build_div(
 
 /// Builds a List from optional ID and items.
 pub fn build_list(id: Option<String>, items: Vec<Item>) -> Result<List, TeiError> {
-    let mut list = List::new(items);
+    let mut list = List::new(items)?;
     apply_id(&mut list, id, List::set_id)?;
     Ok(list)
 }

--- a/tei-xml/tests/jing_validation.rs
+++ b/tei-xml/tests/jing_validation.rs
@@ -82,6 +82,7 @@ macro_rules! require_jing {
 #[case::paragraphs("paragraphs", fixtures::document_with_paragraphs)]
 #[case::utterances("utterances", fixtures::document_with_utterances)]
 #[case::comprehensive("comprehensive", fixtures::comprehensive_document)]
+#[case::div_list("div-list", fixtures::document_with_div_and_list)]
 fn validates_fixture(
     #[case] name: &str,
     #[case] builder: fn() -> Result<tei_core::TeiDocument, tei_core::TeiError>,


### PR DESCRIPTION
## Summary
- Completes TEI P5 structural body support across core Rust, XML schemas, Python projections, and tests, including DivEvent streaming for assembled divisions. Also introduces DivContent and updates BodyBlock unions to accommodate new structural elements.

## Changes
- Core model updates
  - Added structural body blocks: DivBlock, ListBlock, Item, Label, plus DivContent (as a union for DivBlock content) and updated BodyBlock to include DivBlock.
  - Expanded content handling to include DivEvent for streaming events when divisions are assembled.
  - Python-facing projections and TS-like exposure updated to reflect the new types and unions.
- TEI schemas and XML schema snapshots
  - Updated Relax NG and ODD schemas to include div, list, item, and label definitions.
  - Updated RNG snapshots and XML RNG fixture to support new elements and constraints (e.g., Div/@type not empty, List with Item, Item with optional Label).
- JSON and Python projections
  - tei-py: added DivBlock, DivContent, ListBlock, Item, Label, DivEvent; updated Event union accordingly.
  - Python stubs and pyi: updated to reflect new structural elements and unions.
- Validation and tests
  - Added validation scenarios for structural elements (e.g., rejecting duplicate xml:id values inside divisions; rejecting unresolved item corresp pointers inside divisions).
  - Extended tests to cover Div/List/Item/Label in core and serialization layers; added div-list fixture paths and Jing validation support.
- Documentation and roadmaps
  - Roadmap and design docs updated to reflect full structural body support and April 2026 planning.
  - User guide updated with new division/list/item/label semantics and validation behavior.

## Why this matters
- Structural body elements enable richer TEI documents with divisions, lists, and labeled items that round-trip through Rust core, XML parsing/emitting, Relax NG/ODD, JSON schema, and Python projections. Validation now guards against duplicate IDs and unresolved pointers inside divisions.

## How to test
- Build and run tests across crates, including:
  - tei-core validation feature: new scenarios for divisions and pointers.
  - tei-serde and tei-xml: updated fixtures for div/list/item/label, plus Jing validation for div-list.
  - tei-py: run Python tests for div blocks, list blocks, and event streaming.
  - tei-xml: ensure fixtures compile and Jing validates new structures.
- Example targets (adjust to your environment):
  - cargo test
  - cargo test -p tei-xml
  - cargo test -p tei-py
  - make json-schema && make validate-xml

## Notes
- This PR completes several exec plan stages (F, G, H, I, J, K, L) by aligning ODD/RNG, Python projections, JSON schemas, validation rules, tests, and docs around structural body elements. No user-facing API surface was removed; there are additional struct variants and unions to support new TEI bodies.

📎 Task: https://www.devboxer.com/task/be6b3039-657f-421b-a68a-db1abd4e35f5