### PR TITLE
Refactor handle_empty_element; Recursive Div with head/subtype

### DIFF
--- a/docs/execplans/additional-div-elements.md
+++ b/docs/execplans/additional-div-elements.md
@@ -5,7 +5,7 @@ This ExecPlan (execution plan) is a living document. The sections
 `Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
 proceeds.
 
-Status: DRAFT
+Status: COMPLETE
 
 ## Purpose / big picture
 
@@ -120,14 +120,27 @@ that should be a separate, explicit extension.
 
 - [x] 2026-04-10: Reviewed project guidance, existing structural-body work, and
   official TEI P5 references; drafted this ExecPlan.
-- [ ] Add failing unit and behavioural tests covering nested divisions,
-  `@subtype`, and `<head>`.
-- [ ] Extend the Rust core model and validation.
-- [ ] Extend the XML parser, emitter, fixtures, and schema validation.
-- [ ] Extend JSON Schema generation and property-based generators.
-- [ ] Extend Python projections, struct definitions, and streaming projections.
-- [ ] Update user-facing documentation and the design document.
-- [ ] Run the full repository quality gates and capture outcomes here.
+- [x] 2026-04-10 15:50 UTC: Added and updated unit, integration, BDD, schema,
+  fixture, and Python projection coverage for nested divisions, `@subtype`,
+  and optional `<head>`.
+- [x] 2026-04-10 15:50 UTC: Extended the Rust core model with `Head`,
+  `DivSubtype`, recursive `DivContent::Div`, and recursive validation for IDs
+  and pointers.
+- [x] 2026-04-10 15:50 UTC: Extended the XML parser, emitter, fixtures, and
+  Relax NG profile to support nested divisions, headings, and subtypes while
+  preserving the assembled `BodyBlock::Div` streaming contract.
+- [x] 2026-04-10 15:50 UTC: Extended JSON Schema generation, schema assertions,
+  and bounded arbitrary-data generators for recursive divisions.
+- [x] 2026-04-10 15:50 UTC: Extended Python projections, `msgspec.Struct`
+  definitions, and streaming payloads with recursive divisions plus optional
+  `head` and `subtype`.
+- [x] 2026-04-10 15:50 UTC: Updated `docs/users-guide.md` and
+  `docs/tei-rapporteur-design-document.md` to describe the recursive division
+  model and the single-head profile rule.
+- [x] 2026-04-10 16:05 UTC: Ran `make fmt`, `make json-schema`,
+  `make check-fmt`, `make lint`, `make test`, `make markdownlint`, and
+  `make nixie`. `make validate-xml` could not run to completion in this
+  environment because `jing` is not installed.
 
 ## Surprises & Discoveries
 
@@ -143,6 +156,13 @@ that should be a separate, explicit extension.
   the design document still says nested divisions are intentionally deferred,
   while the user’s guide already presents `Div` as a standard part of the
   supported body model. Both must be reconciled during implementation.
+- Splitting `tei-xml/src/streaming/handlers.rs` and
+  `tei-core/src/text/types.rs` became necessary during implementation because
+  the new recursive/division-heading logic would otherwise leave touched files
+  above the repository's 400-line ceiling.
+- `make validate-xml` is wired correctly but depends on an external `jing`
+  binary that is not installed in this environment, so XML-schema validation
+  must be rerun on a machine with `jing` available.
 
 ## Decision Log
 
@@ -166,16 +186,38 @@ that should be a separate, explicit extension.
 - Decision: retain the assembled-division streaming contract. Rationale:
   Python streaming consumers and existing tests already assume that each body
   event is a complete semantic block. Date: 2026-04-10.
+- Decision: split the streaming handler implementation into dedicated
+  start-element, finish-element, and content-handler modules during delivery.
+  Rationale: the recursive division work would otherwise leave the touched
+  handler file far above the repository’s 400-line limit. Date: 2026-04-10.
+- Decision: extract `DivType` and `DivSubtype` into
+  `tei-core/src/text/div_types.rs`. Rationale: the additional subtype support
+  would otherwise push `tei-core/src/text/types.rs` above the file-size limit
+  while mixing division-specific wrappers with unrelated identifier types.
+  Date: 2026-04-10.
 
 ## Outcomes & Retrospective
 
-This section is intentionally provisional because no implementation work has
-started yet. When the plan is executed, replace this paragraph with:
+Nested `<div>` elements, optional `@subtype`, and a single optional leading
+`<head>` now work end-to-end across the Rust core model, XML parsing/emission,
+JSON Schema publication, Python projections, and user-facing documentation.
+The canonical nested-division fixture parses, emits, validates inside Rust,
+serializes to JSON/MessagePack, projects to Python `msgspec.Struct` types, and
+round-trips through the updated tests.
 
-- the behaviour that now works end-to-end,
-- the commands that passed,
-- any deviations from the draft plan,
-- and the lessons learned that should guide future TEI subset work.
+The repository gates that completed successfully were:
+
+- `make fmt`
+- `make json-schema`
+- `make check-fmt`
+- `make lint`
+- `make test`
+- `make markdownlint`
+- `make nixie`
+
+The only incomplete gate is `make validate-xml`, which failed because `jing`
+is not installed in this environment. No code-level blocker remains for that
+step; it should pass once rerun where `jing` is available.
 
 ## Context and orientation
 

--- a/docs/execplans/additional-div-elements.md
+++ b/docs/execplans/additional-div-elements.md
@@ -121,8 +121,8 @@ that should be a separate, explicit extension.
 - [x] 2026-04-10: Reviewed project guidance, existing structural-body work, and
   official TEI P5 references; drafted this ExecPlan.
 - [x] 2026-04-10 15:50 UTC: Added and updated unit, integration, BDD, schema,
-  fixture, and Python projection coverage for nested divisions, `@subtype`,
-  and optional `<head>`.
+  fixture, and Python projection coverage for nested divisions, `@subtype`, and
+  optional `<head>`.
 - [x] 2026-04-10 15:50 UTC: Extended the Rust core model with `Head`,
   `DivSubtype`, recursive `DivContent::Div`, and recursive validation for IDs
   and pointers.
@@ -200,8 +200,8 @@ that should be a separate, explicit extension.
 
 Nested `<div>` elements, optional `@subtype`, and a single optional leading
 `<head>` now work end-to-end across the Rust core model, XML parsing/emission,
-JSON Schema publication, Python projections, and user-facing documentation.
-The canonical nested-division fixture parses, emits, validates inside Rust,
+JSON Schema publication, Python projections, and user-facing documentation. The
+canonical nested-division fixture parses, emits, validates inside Rust,
 serializes to JSON/MessagePack, projects to Python `msgspec.Struct` types, and
 round-trips through the updated tests.
 
@@ -215,9 +215,9 @@ The repository gates that completed successfully were:
 - `make markdownlint`
 - `make nixie`
 
-The only incomplete gate is `make validate-xml`, which failed because `jing`
-is not installed in this environment. No code-level blocker remains for that
-step; it should pass once rerun where `jing` is available.
+The only incomplete gate is `make validate-xml`, which failed because `jing` is
+not installed in this environment. No code-level blocker remains for that step;
+it should pass once rerun where `jing` is available.
 
 ## Context and orientation
 

--- a/docs/execplans/additional-div-elements.md
+++ b/docs/execplans/additional-div-elements.md
@@ -28,8 +28,9 @@ fields, and the user-facing documentation explains the updated subset clearly.
 
 ## Standards grounding
 
-This plan is based on the official TEI P5 references, which should be treated
-as the standards source during implementation:
+This plan is based on the official Text Encoding Initiative (TEI) P5
+references, which should be treated as the standards source during
+implementation:
 
 1. `ref-div`: the TEI `<div>` element is a text division and may contain nested
    `<div>` elements.

--- a/docs/execplans/additional-div-elements.md
+++ b/docs/execplans/additional-div-elements.md
@@ -216,9 +216,14 @@ The repository gates that completed successfully were:
 - `make markdownlint`
 - `make nixie`
 
-The only incomplete gate is `make validate-xml`, which failed because `jing` is
-not installed in this environment. No code-level blocker remains for that step;
-it should pass once rerun where `jing` is available.
+Two distinct blockers surfaced around `make validate-xml` during
+implementation. First, the command initially could not run in the local
+environment because the `jing` binary was not installed. Second, the Relax NG
+profile still needed follow-up work to align `<head>` support and nested
+`<div>` semantics with the updated Rust/XML model. The actionable next steps
+were therefore separate: install `jing` anywhere the XML validation gate is
+expected to run, including CI, and track the Relax NG follow-up so
+`<head>`/nested-division support remains synchronized with the profile.
 
 ## Context and orientation
 

--- a/docs/execplans/additional-div-elements.md
+++ b/docs/execplans/additional-div-elements.md
@@ -1,0 +1,437 @@
+# Support nested `<div>`, `@subtype`, and optional `<head>` in body divisions
+
+This ExecPlan (execution plan) is a living document. The sections
+`Constraints`, `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`,
+`Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
+proceeds.
+
+Status: DRAFT
+
+## Purpose / big picture
+
+Episodic roadmap items 2.3.2, 2.3.3, and 2.3.4 need richer structural TEI than
+the current shallow division model provides. Right now `tei-rapporteur` can
+represent `<div>` blocks, but each `Div` is flat: it accepts paragraphs,
+utterances, and lists only; it has `@type` but not `@subtype`; and it cannot
+carry a division heading. That is enough for simple show notes, but not for
+chapter markers containing nested sections, guest-bio sections within larger
+segments, or sponsor-read sections with explicit headings.
+
+After this change, a caller will be able to parse, emit, validate, serialize,
+and project TEI such as a top-level `chapter` division headed by
+`<head>Guest bios</head>`, containing nested child divisions with more specific
+`@subtype` values like `guest-bio` or `sponsor-read`. Observable success means:
+the Rust model round-trips these structures, the streaming parser still emits a
+single assembled `BodyBlock::Div` event, the Relax NG and JSON Schema outputs
+accept the new shapes, Python `msgspec.Struct` projections expose the new
+fields, and the user-facing documentation explains the updated subset clearly.
+
+## Standards grounding
+
+This plan is based on the official TEI P5 references, which should be treated
+as the standards source during implementation:
+
+1. `ref-div`: the TEI `<div>` element is a text division and may contain nested
+   `<div>` elements.
+2. `ref-att.typed`: `@subtype` is part of `att.typed` and is meant as a finer
+   classification layered on top of `@type`; TEI explicitly warns against using
+   `@subtype` without `@type`.
+3. `DS.html` section 4.1: `<head>` is a heading prefixed to the start of a
+   textual division. Full TEI allows more than one `<head>`, but Episodic only
+   needs a single optional heading per division to satisfy the roadmap items.
+
+The implementation should therefore be TEI-informed but profile-constrained:
+support recursive `<div>` content, allow optional `@subtype`, and allow zero or
+one `<head>` at the start of each `<div>`. If later work needs multiple heads,
+that should be a separate, explicit extension.
+
+## Constraints
+
+- Keep the current top-level body model stable. `BodyBlock` must remain the
+  ordered surface for `<body>` content, with `BodyBlock::Div(Div)` continuing
+  to represent whole assembled divisions.
+- Preserve additive compatibility for existing callers. Existing paragraph,
+  utterance, list, item, label, and flat-division documents must continue to
+  parse, validate, emit, and serialize without changing their wire shape.
+- Do not widen the Episodic profile beyond what the request asks for. This plan
+  adds nested `<div>`, optional `@subtype`, and a single optional `<head>`
+  child on `<div>`. It does not add arbitrary TEI body children or generic
+  `att.typed` support across unrelated elements.
+- Keep the streaming event contract unchanged. The XML pull parser must still
+  yield a complete `TeiEvent::BodyBlock(BodyBlock::Div(_))`, not paired
+  division-open and division-close events.
+- Keep documentation and schemas in lock-step. Any change to
+  `schemas/tei-episodic-profile.odd` must be reflected in both checked-in Relax
+  NG copies: `schemas/tei-episodic-profile.rng` and
+  `tei-xml/resources/tei-episodic-profile.rng`.
+- Keep JSON Schema generation additive. The published schema snapshots under
+  `schemas/tei-document.schema*.json` must be regenerated via
+  `make json-schema`, not hand-edited.
+- Keep file sizes under 400 lines. If the recursive-division work pushes a file
+  over the limit, split it into a new module instead of growing it in place.
+- Use en-GB-oxendict spelling in code comments and docs.
+
+## Tolerances (exception triggers)
+
+- Scope: if the implementation needs changes to more than 35 files or roughly
+  1,500 net lines, stop and escalate with a narrowed milestone proposal.
+- Interface: if satisfying the work requires removing or changing an existing
+  public method signature on `Div`, `TeiBody`, `BodyBlock`, Python struct
+  aliases, or streaming event tags, stop and escalate. Additive methods and
+  fields are acceptable.
+- Dependencies: if a new Rust or Python dependency is required, stop and
+  escalate.
+- Standards mismatch: if a credible TEI requirement emerges that makes a
+  single optional `<head>` incorrect for Episodic’s reduced profile, stop and
+  present the trade-off between strict-TEI multi-head support and the narrower
+  roadmap scope.
+- Recursion complexity: if recursive Serde, `schemars`, or `proptest`
+  generation cannot be made stable after three focused attempts, stop and
+  escalate with the concrete failing behaviour.
+- Validation churn: if full validation still fails after five focused red-green
+  cycles on the same failing area, stop and document the blocker before
+  proceeding.
+
+## Risks
+
+- Risk: recursive `DivContent::Div(Div)` can introduce unbounded test-data
+  generation or schema recursion surprises. Severity: high. Likelihood: medium.
+  Mitigation: add bounded-depth constructors and bounded-depth `proptest`
+  strategies immediately, and assert that the generated JSON Schema validator
+  still compiles.
+- Risk: the current streaming parser uses `pending_div_state` plus a flat
+  `InDiv` state and explicitly errors on nested `<div>`. Severity: high.
+  Likelihood: high. Mitigation: replace the flat hand-off with a parent-state
+  model that can return completed nested divisions to their enclosing division.
+- Risk: the current docs explicitly say nested `Div` is deferred. Severity:
+  medium. Likelihood: certain. Mitigation: update `docs/users-guide.md` and
+  `docs/tei-rapporteur-design-document.md` in the same change that lands the
+  code.
+- Risk: TEI allows multiple `<head>` elements on a division, while this plan
+  deliberately supports at most one. Severity: low. Likelihood: medium.
+  Mitigation: encode the restriction clearly in the ODD, JSON Schema, Python
+  structs, and documentation so the profile remains internally consistent.
+- Risk: Python tagged unions may become awkward if recursive divisions are
+  modelled carelessly. Severity: medium. Likelihood: medium. Mitigation: keep
+  the tags stable (`div`, `paragraph`, `utterance`, `list`) and add recursion
+  through the `DivContent` alias rather than inventing new container tags.
+
+## Progress
+
+- [x] 2026-04-10: Reviewed project guidance, existing structural-body work, and
+  official TEI P5 references; drafted this ExecPlan.
+- [ ] Add failing unit and behavioural tests covering nested divisions,
+  `@subtype`, and `<head>`.
+- [ ] Extend the Rust core model and validation.
+- [ ] Extend the XML parser, emitter, fixtures, and schema validation.
+- [ ] Extend JSON Schema generation and property-based generators.
+- [ ] Extend Python projections, struct definitions, and streaming projections.
+- [ ] Update user-facing documentation and the design document.
+- [ ] Run the full repository quality gates and capture outcomes here.
+
+## Surprises & Discoveries
+
+- TEI P5 allows a division to carry more than one `<head>`, but the user
+  request only requires an optional child for division headings. Narrowing the
+  Episodic profile to zero-or-one `<head>` keeps the implementation aligned
+  with the roadmap without pretending to implement the entire TEI text
+  structure chapter.
+- The current streaming parser already has a `DivChildKind::NestedDiv` branch,
+  but it hard-fails with `"nested <div> elements are not supported"`. This is a
+  useful starting point because the unsupported path is localized.
+- Current documentation is internally inconsistent with the requested feature:
+  the design document still says nested divisions are intentionally deferred,
+  while the user’s guide already presents `Div` as a standard part of the
+  supported body model. Both must be reconciled during implementation.
+
+## Decision Log
+
+- Decision: model division headings as a dedicated `Head` wrapper type rather
+  than reusing `P` or `Label`. Rationale: a division heading is not a paragraph
+  and not a list label; giving it a dedicated type keeps the TEI meaning clear,
+  allows inline content, and preserves room for future heading-specific rules.
+  Date: 2026-04-10.
+- Decision: extend `DivContent` with a recursive `Div(Div)` variant rather than
+  introducing a second top-level body abstraction. Rationale: nested divisions
+  are content within a parent division, not a new kind of top-level body block.
+  Date: 2026-04-10.
+- Decision: add `@subtype` only on `Div` for now, even though the TEI
+  `att.typed` class is broader. Rationale: the request is explicitly scoped to
+  division support needed by Episodic roadmap items, and broader `att.typed`
+  work would expand the blast radius unnecessarily. Date: 2026-04-10.
+- Decision: support at most one `<head>` per `Div`, and require it to appear
+  before any other division content. Rationale: this is sufficient for chapter
+  markers, guest bios, and sponsor reads, while keeping the XML model,
+  streaming parser, and Python projection straightforward. Date: 2026-04-10.
+- Decision: retain the assembled-division streaming contract. Rationale:
+  Python streaming consumers and existing tests already assume that each body
+  event is a complete semantic block. Date: 2026-04-10.
+
+## Outcomes & Retrospective
+
+This section is intentionally provisional because no implementation work has
+started yet. When the plan is executed, replace this paragraph with:
+
+- the behaviour that now works end-to-end,
+- the commands that passed,
+- any deviations from the draft plan,
+- and the lessons learned that should guide future TEI subset work.
+
+## Context and orientation
+
+The work spans all of the existing TEI transport layers. A novice implementer
+should start with the files below and keep them open together:
+
+- `tei-core/src/text/body/div.rs` and `tei-core/src/text/body/mod.rs` define
+  `Div`, `DivContent`, and `BodyBlock`.
+- `tei-core/src/validation/mod.rs` and `tei-core/src/validation/pointers.rs`
+  walk divisions recursively for `xml:id` uniqueness and internal pointer
+  resolution.
+- `tei-xml/src/streaming/state.rs`, `tei-xml/src/streaming/helpers.rs`, and
+  `tei-xml/src/streaming/handlers.rs` implement the state machine that must be
+  upgraded from flat to recursive divisions.
+- `tei-xml/src/emitter.rs` hand-emits body XML and must gain `@subtype`,
+  `<head>`, and recursive `<div>` output.
+- `schemas/tei-episodic-profile.odd`,
+  `schemas/tei-episodic-profile.rng`, and
+  `tei-xml/resources/tei-episodic-profile.rng` define the published XML profile.
+- `tei-serde/src/schema.rs`, `tei-serde/tests/json_schema_behaviour.rs`, and
+  `tei-serde/tests/arbitrary/text.rs` govern JSON Schema publication and
+  recursive arbitrary-data generation.
+- `tei-py/src/projection/mod.rs`, `tei-py/src/projection/body.rs`,
+  `tei-py/src/projection/events.rs`, and `tei-py/python/structs.py` are the
+  Python-facing surfaces that must learn about `head`, `subtype`, and nested
+  divisions.
+- `docs/users-guide.md` and `docs/tei-rapporteur-design-document.md` currently
+  describe the division model in ways that will be stale as soon as recursion
+  lands.
+
+The recommended canonical fixture for this work should model the three roadmap
+targets in one tree so every layer exercises the same semantics:
+
+```xml
+<div type="segment" subtype="chapter-markers" xml:id="seg1">
+  <head>Chapter markers</head>
+  <div type="segment" subtype="chapter-marker" xml:id="ch1">
+    <head>Cold open</head>
+    <u who="host">Welcome back.</u>
+  </div>
+  <div type="segment" subtype="guest-bios" xml:id="bios">
+    <head>Guest bios</head>
+    <list>
+      <item><label>A.</label>Guest biography summary.</item>
+    </list>
+  </div>
+  <div type="segment" subtype="sponsor-read" xml:id="ad1">
+    <head>Sponsored by ExampleCo</head>
+    <p>Use code EXAMPLE at checkout.</p>
+  </div>
+</div>
+```
+
+This single shape proves all three requested features at once: recursion,
+`@subtype`, and division headings.
+
+## Implementation plan
+
+### Stage 1: Add failing tests first
+
+Start with red tests before touching the model. Add narrow unit tests in
+`tei-core/src/text/body/div.rs` covering:
+
+- constructing a `Div` with an optional subtype,
+- setting and clearing an optional heading,
+- appending nested child divisions,
+- and serde round-tripping a `Div` that contains both a `<head>` and a nested
+  `<div>`.
+
+Add behavioural and integration coverage that exercises the canonical roadmap
+fixture:
+
+- `tei-xml/tests/features/parse_xml.feature`: a scenario that parses the
+  canonical nested-division fixture successfully.
+- `tei-xml/tests/streaming_behaviour.rs`: a focused test that confirms one
+  `BodyBlock::Div` event contains the nested child `Div`s, each with the
+  expected `head` and `subtype`.
+- `tei-xml/tests/emit_div.rs`: round-trip emission assertions for nested
+  divisions and heading placement.
+- `tei-core/tests/features/validation.feature` plus
+  `tei-core/tests/validation_behaviour/mod.rs`: recursive duplicate-`xml:id`
+  and unresolved-pointer coverage inside nested divisions.
+- `tei-serde/tests/json_schema_behaviour.rs`: assertions that the generated
+  schema includes `@subtype`, `head`, and recursive `div` variants inside
+  `DivContent`.
+- `tei-py/src/tests/div_structs.rs` and `tei-py/src/tests/projection_tests.rs`:
+  decode and round-trip nested divisions with headings through the Python
+  projection.
+
+Do not proceed to implementation until these tests fail for the expected
+reasons.
+
+### Stage 2: Extend the Rust core model
+
+Implement the new domain types in `tei-core` first. Create a dedicated `Head`
+type in a new module such as `tei-core/src/text/body/head.rs`, shaped like
+`Label`: it should wrap `Vec<Inline>`, validate non-empty visible content, and
+support convenient constructors for plain text and inline content.
+
+Then update `tei-core/src/text/body/div.rs`:
+
+- add `subtype: Option<DivSubtype>` or equivalent validated optional field,
+- add `head: Option<Head>`,
+- add `DivContent::Div(Div)`,
+- add additive helpers such as `set_subtype`, `clear_subtype`, `subtype()`,
+  `set_head`, `clear_head`, `head()`, and `push_div`.
+
+If a new validated scalar type is needed, add it in
+`tei-core/src/text/types.rs` beside `DivType`, keeping the same trim and
+non-empty guarantees.
+
+Update exports in `tei-core/src/text/body/mod.rs`, `tei-core/src/text/mod.rs`,
+and `tei-core/src/lib.rs` so the new types are visible at the crate root.
+
+### Stage 3: Make validation recursive
+
+Update `tei-core/src/validation/mod.rs` and
+`tei-core/src/validation/pointers.rs` so nested divisions are traversed
+recursively. The validator must continue to reject duplicate `xml:id` values
+and unresolved internal pointers anywhere in the document tree, including list
+items nested several divisions deep.
+
+Keep the recursion local and explicit. A small helper like
+`validate_div_contents(contents, seen_ids, known_speakers)` is preferable to
+deeply nested `match` blocks repeated in multiple modules.
+
+### Stage 4: Upgrade XML parsing and emission
+
+Replace the flat division streaming state with a recursive one. The current
+parser holds a flat `InDiv` state and uses `pending_div_state` to reattach
+paragraphs and utterances; that is not sufficient for nested `<div>`.
+
+The cleanest path is:
+
+1. extend `ParserState::InDiv` to carry the raw fields needed for `type`,
+   optional `subtype`, optional `head`, accumulated child content, and an
+   optional parent state for nested divisions;
+2. teach `handle_div_content_start` to treat `<head>` as a legal child at the
+   start of a division and to recurse into child `<div>` elements instead of
+   erroring;
+3. teach `finish_div` to build a `Div` and either emit it as a body block or
+   push it back into its parent division as `DivContent::Div`.
+
+Update `tei-xml/src/streaming/helpers.rs` to build `Head` and to populate
+`subtype` when present. Update `tei-xml/src/emitter.rs` so emitted divisions
+write attributes in the order `type`, optional `subtype`, optional `xml:id`,
+then optional `<head>`, then the rest of the division content. Keep heading
+emission before all other content to preserve the profile rule.
+
+Also update fixture builders in `tei-xml/src/fixtures/mod.rs` if they are used
+by schema or parser tests.
+
+### Stage 5: Update the TEI profile schemas
+
+Edit `schemas/tei-episodic-profile.odd` so the `<div>` content model becomes:
+
+1. optional `<head>` with maxOccurs `1`,
+2. zero or more children from `p`, `u`, `list`, and `div`,
+3. optional `@subtype` alongside required `@type`.
+
+Add a Schematron rule that rejects blank `@subtype` values if present. The TEI
+`att.typed` rule that `@subtype` should not appear without `@type` is already
+satisfied because the Episodic profile keeps `@type` required on `div`.
+
+Regenerate and check in both Relax NG outputs:
+
+- `schemas/tei-episodic-profile.rng`
+- `tei-xml/resources/tei-episodic-profile.rng`
+
+Then extend `tei-xml/tests/features/schema.feature` or the existing schema
+validation tests so the canonical nested-division fixture validates against the
+updated Relax NG profile.
+
+### Stage 6: Extend JSON Schema and arbitrary-data generation
+
+Update `tei-serde/tests/arbitrary/text.rs` to generate recursive divisions with
+a bounded depth parameter. Do not let `proptest` recurse freely. A maximum
+depth of 2 or 3 is enough to prove the recursive model without risking
+non-termination.
+
+Regenerate the JSON Schema via `make json-schema` after teaching the schema
+constraints layer about the new shape in `tei-serde/src/schema.rs`, if that
+post-processing is needed. Then strengthen
+`tei-serde/tests/json_schema_behaviour.rs` so it asserts:
+
+- `BodyBlock` still includes the top-level `div` variant,
+- `DivContent` now includes a recursive `div` variant,
+- `div` properties include `@subtype` and optional `head`,
+- serialized fixtures place `head` in the expected TEI-style `$value` path.
+
+### Stage 7: Extend Python projections and streaming payloads
+
+Update the Python-facing tagged shapes without changing their existing tags.
+`tei-py/src/projection/mod.rs`, `tei-py/src/projection/body.rs`, and
+`tei-py/src/projection/events.rs` should gain:
+
+- optional `subtype` on `PyBodyBlock::Div` and `PyEvent::Div`,
+- optional `head` on the same division structs,
+- recursive `PyDivContent::Div` so nested divisions can appear inside
+  `DivContent`.
+
+Mirror that in `tei-py/python/structs.py` by extending `DivBlock`, `DivEvent`,
+and the `DivContent` alias. Add a Python `Head` struct if needed so the
+semantic role remains explicit instead of overloading `Paragraph` or raw lists.
+
+Update the existing Python tests that currently assume `DivContent` is only
+`Paragraph | Utterance | ListBlock`. They should assert nested `DivBlock`
+instances round-trip through MessagePack, dictionary conversion, and streaming
+events.
+
+### Stage 8: Update documentation in the same change
+
+Update `docs/users-guide.md` so it accurately describes:
+
+- nested structural divisions,
+- optional division headings,
+- optional `@subtype`,
+- and the updated Python union shapes.
+
+Update `docs/tei-rapporteur-design-document.md` in at least three places:
+
+- the April 2026 “Structural body elements” section, which currently says
+  nested `Div` is deferred;
+- the Rust data model section, which still contains older prose about future
+  divisions;
+- the streaming/parser and schema sections, so they describe the recursive
+  model and the zero-or-one heading rule.
+
+Keep the documentation honest about the profile restriction: full TEI allows
+multiple heads, but Episodic currently allows one optional heading per division.
+
+### Stage 9: Final validation and evidence capture
+
+Once the focused tests are green, run the full repository gates with captured
+logs:
+
+```bash
+set -o pipefail
+make fmt 2>&1 | tee /tmp/additional-div-elements.make-fmt.log
+make json-schema 2>&1 | tee /tmp/additional-div-elements.make-json-schema.log
+make check-fmt 2>&1 | tee /tmp/additional-div-elements.make-check-fmt.log
+make lint 2>&1 | tee /tmp/additional-div-elements.make-lint.log
+make test 2>&1 | tee /tmp/additional-div-elements.make-test.log
+make validate-xml 2>&1 | tee /tmp/additional-div-elements.make-validate-xml.log
+make markdownlint 2>&1 | tee /tmp/additional-div-elements.make-markdownlint.log
+make nixie 2>&1 | tee /tmp/additional-div-elements.make-nixie.log
+```
+
+Success is not “the code compiles”. Success is all of the following:
+
+1. the canonical nested-division fixture parses, emits, validates, and
+   round-trips;
+2. recursive duplicate IDs and unresolved pointers are rejected at any nesting
+   depth exercised by the tests;
+3. Python projections can decode and encode nested divisions with headings and
+   subtypes;
+4. the published XML and JSON schemas both describe the new structure;
+5. the user guide and design document no longer claim that nested divisions are
+   deferred.

--- a/docs/tei-rapporteur-design-document.md
+++ b/docs/tei-rapporteur-design-document.md
@@ -1571,6 +1571,7 @@ stateDiagram-v2
 
     InBody --> InParagraph : <p> start
     InBody --> InUtterance : <u> start
+    InBody --> InDiv : <div> start
     InBody --> InBody : other elements
     InBody --> AfterBody : </body>
     InBody --> DocumentComplete : eof (graceful)
@@ -1585,14 +1586,46 @@ stateDiagram-v2
     InUtterance --> InUtterance : text, inline
     InUtterance --> InBody : </u> yields BodyBlock Utterance
 
+    InDiv --> InHead : <head> start before children
+    InDiv --> InParagraph : <p> start with pending parent div
+    InDiv --> InUtterance : <u> start with pending parent div
+    InDiv --> InList : <list> start
+    InDiv --> InDiv : nested <div> start
+    InDiv --> InBody : </div> yields BodyBlock Div when top-level
+    InDiv --> InDiv : </div> pushes DivContent Div when nested
+    InDiv --> Error : duplicate <head> or malformed xml
+
+    InHead --> InEmphasis : <hi> start
+    InHead --> InHead : text, inline
+    InHead --> InDiv : </head> stores heading on parent div
+
+    InList --> InItem : <item> start
+    InList --> InDiv : </list> pushes DivContent List
+    InList --> Error : malformed xml
+
+    InItem --> InLabel : <label> start before content
+    InItem --> InEmphasis : <hi> start
+    InItem --> InItem : text, inline
+    InItem --> InList : </item> appends item to parent list
+    InItem --> Error : malformed xml
+
+    InLabel --> InEmphasis : <hi> start
+    InLabel --> InLabel : text, inline
+    InLabel --> InItem : </label> stores label on parent item
+
     InEmphasis --> InEmphasis : nested inline
     InEmphasis --> InParagraph : </hi> when parent paragraph
     InEmphasis --> InUtterance : </hi> when parent utterance
+    InEmphasis --> InHead : </hi> when parent head
+    InEmphasis --> InItem : </hi> when parent item
+    InEmphasis --> InLabel : </hi> when parent label
 
     InBody --> Error : malformed xml
     AfterBody --> Error : malformed xml
     InParagraph --> Error : malformed xml
     InUtterance --> Error : malformed xml
+    InHead --> Error : malformed xml
+    InLabel --> Error : malformed xml
     InEmphasis --> Error : malformed xml
 
     DocumentComplete --> [*]

--- a/docs/tei-rapporteur-design-document.md
+++ b/docs/tei-rapporteur-design-document.md
@@ -2065,6 +2065,116 @@ MessagePack emitted by `to_msgpack` decodes directly into these classes via
 `msgspec.msgpack.decode(payload, type=Episode)`, and encoding the structs feeds
 the bytes straight back into `from_msgpack`.
 
+Figure: class diagram for the Python structural-division projections and their
+Rust-side projection helpers. `DivBlock` and streamed `DivEvent` values both
+carry optional `Head` values plus recursive `DivContent`, while the Rust
+projection enums preserve the same paragraph, utterance, list, and nested
+division shape before conversion across the FFI boundary.
+
+```mermaid
+classDiagram
+    direction TB
+
+    class PyInline {
+        <<enum>>
+        Text
+        Hi
+        Pause
+    }
+
+    class Head {
+        + content: list~PyInline~
+    }
+
+    class DivBlock {
+        <<tagged struct div>>
+        + div_type: str
+        + subtype: str~None~
+        + head: Head~None~
+        + content: list~DivContent~
+        + xml_id: str~None~
+        + __post_init__()
+    }
+
+    class ListBlock {
+        + items: list~Item~
+        + xml_id: str~None~
+    }
+
+    class TextBlock {
+        <<TypeAlias>>
+        Paragraph | Utterance
+    }
+
+    class DivContent {
+        <<TypeAlias>>
+        TextBlock | ListBlock | DivBlock
+    }
+
+    class BodyBlock {
+        <<TypeAlias>>
+        TextBlock | DivBlock
+    }
+
+    class DivEvent {
+        <<tagged struct div>>
+        + div_type: str
+        + subtype: str~None~
+        + head: Head~None~
+        + content: list~DivContent~
+        + xml_id: str~None~
+    }
+
+    class Event {
+        <<enum>>
+        DocumentStart
+        HeaderEvent
+        ParagraphEvent
+        UtteranceEvent
+        DivEvent
+        DocumentEnd
+    }
+
+    class PyBodyBlock_Rust {
+        <<enum>>
+        Paragraph
+        Utterance
+        Div
+    }
+
+    class PyDivContent_Rust {
+        <<enum>>
+        Paragraph
+        Utterance
+        List
+        Div
+    }
+
+    class PyHead_Rust {
+        + content: Vec~PyInline_Rust~
+    }
+
+    class PyInline_Rust {
+    }
+
+    DivBlock "1" --> "*" DivContent : content
+    DivBlock "0..1" --> Head : head
+
+    DivContent --> DivBlock : DivBlock
+    DivContent --> ListBlock : ListBlock
+
+    BodyBlock --> DivBlock : DivBlock
+
+    DivEvent --> DivContent : content
+    DivEvent --> Head : head
+
+    Event --> DivEvent : Div
+
+    PyBodyBlock_Rust --> PyDivContent_Rust : uses
+    PyDivContent_Rust --> PyHead_Rust : head
+    PyHead_Rust --> PyInline_Rust : content
+```
+
 The above Python code shows how seamlessly a workflow can move between TEI (for
 interchange/audit) and a Python JSON-friendly form (for analysis and
 manipulation). Direct interaction with XML libraries is unnecessary, and the

--- a/docs/tei-rapporteur-design-document.md
+++ b/docs/tei-rapporteur-design-document.md
@@ -422,10 +422,10 @@ The text module now models the `<text><body>` hierarchy instead of relying on
 placeholder segments:
 
 - `TeiText` owns a `TeiBody`, and `TeiBody` keeps a `Vec<BodyBlock>` so the
-  order of paragraphs and utterances remains faithful to the source script.
-- `BodyBlock` is an enum with `Paragraph(P)` and `Utterance(Utterance)`
-  variants. This provides a single ordered surface today while leaving room for
-  future variants such as divisions.
+  order of top-level body blocks remains faithful to the source script.
+- `BodyBlock` is an enum with `Paragraph(P)`, `Utterance(Utterance)`, and
+  `Div(Div)` variants so top-level thematic divisions preserve source order
+  without flattening the hierarchy.
 - `P` and `Utterance` wrap a `Vec<Inline>` so plain text, emphasized spans, and
   pauses share a single ordered sequence. Both structs expose helper methods
   for attaching optional `xml:id` values. `Utterance` now also models TEI's
@@ -804,7 +804,9 @@ classDiagram
 
     class Div {
       +DivType div_type
+      +String? subtype
       +String? xml_id
+      +Head? head
       +Vec~DivContent~ children
     }
 
@@ -813,6 +815,7 @@ classDiagram
       +Paragraph
       +Utterance
       +List
+      +Div
     }
 
     class List {
@@ -909,6 +912,7 @@ classDiagram
     DivContent --> Paragraph
     DivContent --> Utterance
     DivContent --> List
+    DivContent --> Div
 
     List --> Item : ordered_items
 
@@ -916,6 +920,7 @@ classDiagram
     Paragraph --> Inline : has_many
     Utterance --> Inline : has_many
     Label --> Inline : has_many
+    Head --> Inline : has_many
 
     Utterance ..> ProfileCast : who_references_speaker
 

--- a/docs/tei-rapporteur-design-document.md
+++ b/docs/tei-rapporteur-design-document.md
@@ -816,6 +816,10 @@ classDiagram
       +Vec~Inline~ content
     }
 
+    class Head {
+      +Vec~Inline~ content
+    }
+
     class Div {
       +DivType div_type
       +String? subtype

--- a/docs/tei-rapporteur-design-document.md
+++ b/docs/tei-rapporteur-design-document.md
@@ -71,8 +71,9 @@ feel natural to Python users**.
 
 - The body model now treats `BodyBlock` as a three-variant enum:
   `Paragraph`, `Utterance`, and `Div`.
-- `Div` is intentionally shallow for now. It groups `Paragraph`,
-  `Utterance`, and `List` children, but nested `Div` elements remain deferred.
+- `Div` is now recursive. It groups `Paragraph`, `Utterance`, `List`, and
+  nested `Div` children, and also carries required `@type`, optional
+  `@subtype`, and a single optional leading `Head` wrapper for `<head>`.
 - `List` holds ordered `Item` values, and each `Item` may expose a dedicated
   `Label` node plus inline content and an optional `@corresp` pointer list.
 - The streaming parser buffers an entire `Div` before yielding a single
@@ -83,28 +84,28 @@ feel natural to Python users**.
 
 This design keeps the structural extension narrow enough to preserve the
 original ergonomics of the flat body model while still representing chaptered
-material, show notes, and itemized references. The core distinction is between
-top-level body blocks (`BodyBlock`) and content that is only valid inside a
-division (`DivContent`). `List`, `Item`, and `Label` remain nested-only types,
-which keeps the XML profile, JSON schema, and Python `msgspec.Struct` surface
-aligned around the same containment rules.
+material, nested show-note sections, and itemized references. The core
+distinction is between top-level body blocks (`BodyBlock`) and content that is
+only valid inside a division (`DivContent`). `List`, `Item`, `Label`, and
+`Head` remain nested-only types, which keeps the XML profile, JSON schema, and
+Python `msgspec.Struct` surface aligned around the same containment rules.
 
 The hybrid emitter is a deliberate compatibility choice. `quick_xml` remains
 responsible for header and stand-off serialization, where serde-derived output
 works well, but the body is emitted manually once structural blocks are
 present. This avoids the serialization failure mode around inline vectors while
-still preserving a single authoritative Rust model for `Div`, `List`, `Item`,
-and `Label`. The emitter therefore acts as a thin projection layer over
+still preserving a single authoritative Rust model for `Div`, `Head`, `List`,
+`Item`, and `Label`. The emitter therefore acts as a thin projection layer over
 validated domain objects rather than a second source of truth for document
 structure.
 
 The streaming parser follows the same boundary. Paragraphs and utterances can
 still be emitted as soon as their closing tags arrive, but a `Div` event is not
-yielded until the parser has accumulated all nested paragraphs, utterances,
-lists, items, and labels inside that division. This buffering keeps the event
-surface simple for consumers and avoids introducing paired container-open and
-container-close events that would complicate both Python decoding and behaviour
-tests.
+yielded until the parser has accumulated nested paragraphs, utterances, lists,
+headings, and child divisions inside that division. This buffering keeps the
+event surface simple for consumers and avoids introducing paired container-open
+and container-close events that would complicate both Python decoding and
+behaviour tests.
 
 Future structural variants should extend the system feature-first rather than
 layer-first. Adding a new nested body element requires coordinated updates to:
@@ -117,11 +118,11 @@ layer-first. Adding a new nested body element requires coordinated updates to:
 - the Python structs, projection layer, stubs, and streaming event unions
 - behavioural tests, fixtures, and user/developer documentation
 
-Nested `Div` remains intentionally deferred until a concrete use case requires
-it. Supporting recursive divisions would change the Rust enums, the Python type
-aliases, the streaming parser buffering strategy, and the published schemas, so
-it should arrive as an explicit model revision rather than an incidental
-follow-on.
+The Episodic profile intentionally narrows TEI here: a division may carry zero
+or one leading `<head>` rather than the full TEI allowance of multiple heads.
+That keeps the Rust enums, the Python type aliases, the streaming parser
+buffering strategy, and the published schemas aligned with the current roadmap
+without claiming to model the full text-structure chapter.
 
 ## Workspace scaffolding decisions
 

--- a/docs/tei-rapporteur-design-document.md
+++ b/docs/tei-rapporteur-design-document.md
@@ -265,11 +265,17 @@ clarity and allows reuse or independent testing of components:
   XML library (the implementation uses `quick-xml`). This crate provides
   functions to parse TEI XML into `tei-core` data structures and to serialize
   `tei-core` structures back to XML. It may also include streaming parse
-  utilities (pull parser) and pretty-printing or canonicalization logic. In
-  practice, `tei-xml` might be merged with `tei-core` if tightly coupled, but
-  conceptually it’s a separate concern (XML I/O). This separation can help if
-  later iterations support alternative input formats (e.g., if someone wanted
-  to import a Markdown transcript and produce TEI).
+  utilities (pull parser) and pretty-printing or canonicalization logic. The
+  streaming implementation is split across focused modules: `handlers.rs` for
+  start-element dispatch, `content_handlers.rs` for text, entity reference,
+  CDATA, and empty-element accumulation, `finish_handlers.rs` for end-element
+  completion and parent-state restoration, `helpers.rs` for shared builder
+  functions such as `build_div` and `build_head`, and `state.rs` for the
+  `ParserState` enum and its constructors. In practice, `tei-xml` might be
+  merged with `tei-core` if tightly coupled, but conceptually it’s a separate
+  concern (XML I/O). This separation can help if later iterations support
+  alternative input formats (e.g., if someone wanted to import a Markdown
+  transcript and produce TEI).
 
 - **`tei-serde`**: A crate providing serde serializers/deserializers for
   converting the TEI data structures to/from other formats like JSON or
@@ -742,6 +748,14 @@ annotations (span groups and spans), document-wide validation rules enforced by
 pointers), and the relationships between document entities. Individual value
 types such as `DivType` perform their own validation (e.g., non-empty division
 type strings).
+
+Recursive structures are also depth-bounded during validation. `Div` and `List`
+nesting is checked against `MAX_DIV_DEPTH = 128` to avoid stack exhaustion on
+adversarially deep documents, and exceeding that limit returns
+`ValidationError::TooDeep { container, max_depth }`. The same guard is applied
+in both the structural-validation pass (`validate_div`, `validate_list`) and
+the pointer-resolution pass (`validate_div_pointers`, `validate_list_pointers`)
+so recursive shape and pointer traversal fail consistently.
 
 ```mermaid
 classDiagram

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -8,34 +8,31 @@ available today and how to exercise it.
 
 - `tei-core` now models the top-level `TeiDocument` together with its
   `TeiHeader` and body-aware `TeiText`. The text model records ordered
-  paragraphs (`P`), utterances with optional speaker references, and thematic
-  divisions (`Div`) that group paragraphs, utterances, and lists as
-  `DivContent` children. Each block stores a sequence of `Inline` nodes,
-  allowing clients to mix plain text with emphasized `<hi>` spans and
+  paragraphs (`P`), utterances, and structural divisions (`Div`) containing
+  paragraphs (`P`), utterances with optional speaker references, and
+  structural divisions (`Div`) containing paragraphs, utterances, lists
+  (`List`/`Item`/`Label`), and nested subdivisions. Each `Div` keeps a
+  validated required `@type` (`DivType`), optional `@subtype`, optional
+  `@xml:id`, and an optional `Head` wrapper for a single leading `<head>`
+  element in the Episodic profile. Each block stores a sequence of `Inline`
+  nodes, allowing clients to mix plain text with emphasised `<hi>` spans and
   `<pause/>` cues without hand-rolling XML. Plain strings flow through
   `P::from_text_segments`, `Utterance::from_text_segments`,
-  `Item::from_text_segments`, and `Label::from_text`; the older `P::new` and
-  `Utterance::new` constructors remain as deprecated shims for existing
-  callers. The `Div` type models `<div>` elements with a validated `@type`
-  attribute (`DivType`), optional `@xml:id`, and a `Vec<DivContent>` of
-  children. `DivContent` permits `Paragraph`, `Utterance`, and `List` children
-  inside a division; see "Text Encoding Initiative (TEI) Episodic Profile
-  schema" below for the formal body content model. `List` holds an ordered
-  `Vec<Item>`, and each `Item` carries optional `@n` (numbering or timestamp),
-  `@corresp` (pointer list), `@xml:id`, an optional `Label` prefix, and inline
-  content. `Label` wraps `Vec<Inline>` content. `TeiDocument` now exposes
-  `validate()` to enforce document-wide rules: it rejects duplicate `xml:id`
-  values across annotation systems, paragraphs, utterances, divisions, lists,
-  and items, and ensures utterance speakers appear in the profile cast when it
-  exists. An empty cast still counts as declared—every `who` fails until the
-  speakers are populated—whereas the absence of a cast allows speaker
-  references, so drafts can be validated incrementally. Identifier checks span
-  the header as well, catching clashes between annotation systems and body
-  blocks. Violations surface as `TeiError::Validation`. Utterances now also
-  carry local provenance and citation attributes (`@n`, `@source`, `@resp`,
-  `@cert`, `@corresp`, `@ana`), and XML deserialization remains strict for
-  `<u>` and `<item>`: misspelt or unsupported attributes are rejected instead
-  of being silently discarded.
+  `Item::from_text_segments`, `Label::from_text`, and `Head::from_text`; the
+  older `new` constructors remain as deprecated shims for existing callers
+  where applicable. `TeiDocument` now exposes `validate()` to enforce
+  document-wide rules: it rejects duplicate `xml:id` values across annotation
+  systems, paragraphs, utterances, divisions, lists, and items, including
+  nested divisions, and ensures utterance speakers appear in the profile cast
+  when it exists. An empty cast still counts as declared, so every `who` fails
+  until the speakers are populated, whereas the absence of a cast allows
+  speaker references, so drafts can be validated incrementally. Identifier
+  checks span the header as well, catching clashes between annotation systems
+  and body blocks. Violations surface as `TeiError::Validation`. Utterances
+  and list items now also carry local provenance and citation attributes where
+  applicable, and XML deserialization remains strict for `<u>` and `<item>`:
+  misspelt or unsupported attributes are rejected instead of being silently
+  discarded.
 - `tei-xml` depends on the core crate and now covers both directions of XML
   flow. `serialize_document_title(raw_title)` still emits a `<title>` snippet,
   `parse_xml(xml)` wraps `quick-xml` to materialize full `TeiDocument` values,
@@ -167,9 +164,14 @@ encoding them feeds the payload straight back into `from_msgpack`.
 Structural body content is exposed through tagged unions:
 
 - `BodyBlock = Paragraph | Utterance | DivBlock`
-- `DivContent = Paragraph | Utterance | ListBlock`
+- `DivContent = Paragraph | Utterance | ListBlock | DivBlock`
 - `Event = DocumentStart | HeaderEvent | ParagraphEvent | UtteranceEvent |
   DivEvent | DocumentEnd`
+
+`DivBlock` and streamed `DivEvent` values now expose `div_type`, optional
+`subtype`, optional `head`, optional `xml_id`, and recursive `content`, so
+chapter markers, guest-bio sections, and sponsor-read sections can be modelled
+without flattening the hierarchy into paragraphs.
 
 Citation metadata is split along TEI-native boundaries. Canonical citation
 declarations live under `header.encoding_desc.refs_decl`, utterance-local
@@ -506,8 +508,8 @@ Events use internal tagging (`type`), covering:
 - `header` (with a structured `header` field)
 - `paragraph` / `utterance` – carrying `content: list[Inline]` as tagged
   `Inline` values (`text`, `hi`, `pause`)
-- `div` – carrying `div_type: str` and `content: list[DivContent]` (each
-  `DivContent` child is itself a `paragraph`, `utterance`, or `list_block`)
+- `div` (carries `div_type`, `content: list[DivContent]`, and optional
+  `subtype`, `head`, and `xml_id`; decodes into `DivEvent`)
 - `document_end`
 
 Inline content is also tagged (`text`, `hi`, `pause`), so Python callers can

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -316,9 +316,9 @@ The profile supports:
 - **Body structure**: paragraphs (`<p>`), utterances (`<u>`) with optional
   speaker attribution via `@who` plus local provenance attributes (`@n`,
   `@source`, `@resp`, `@cert`, `@corresp`, `@ana`), and thematic divisions
-  (`<div>`) with a required validated `@type` (`DivType`), optional `@subtype`,
-  optional `@xml:id`, and an optional `Head` wrapper for a single leading
-  `<head>` element. Divisions can contain paragraphs, utterances, lists
+  (`<div>`) with `@type` (required and validated via `DivType`), optional
+  `@subtype`, optional `@xml:id`, and an optional `Head` wrapper for a single
+  leading `<head>` element. Divisions can contain paragraphs, utterances, lists
   (`<list>`), and nested divisions. Lists hold ordered items (`<item>`) that
   carry optional `@n` (numbering or timestamp metadata), `@corresp` (pointer
   list for cross-references), and `@xml:id`. Each item may include an optional

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -505,6 +505,9 @@ The parser yields four high-level event types:
 
 ### Parser state overview
 
+This diagram shows the main `InBody` to `InDiv` flow and the return paths from
+`InHead`, `InParagraph`, and `InUtterance`.
+
 ```mermaid
 stateDiagram-v2
     [*] --> InBody

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -337,18 +337,21 @@ Use the root `tei_core` re-exports to assemble a division tree before wrapping
 it in a document body block:
 
 ```rust
-use tei_core::{BodyBlock, Div, Head, TeiDocument};
+use tei_core::{Div, Head, TeiDocument, BodyBlock};
 
 fn build_episode_doc() -> Result<(), tei_core::TeiError> {
+    // Parent division.
     let mut parent_div = Div::new("segment")?;
     parent_div.set_subtype("chapter-markers")?;
     parent_div.set_id("ch-01".to_string())?;
     parent_div.set_head(Head::from_text("Chapter markers")?);
 
+    // Nested child division.
     let mut child_div = Div::new("segment")?;
     child_div.set_subtype("cold-open")?;
     child_div.set_head(Head::from_text("Cold open")?);
 
+    // Attach the child and wrap the parent as a body block.
     parent_div.push_div(child_div);
 
     let header = tei_core::TeiHeader::new(tei_core::FileDesc::from_title_str(
@@ -512,8 +515,8 @@ stateDiagram-v2
     InDiv --> InParagraph : <p> start
     InDiv --> InUtterance : <u> start
     InDiv --> InDiv : nested <div> start
-    InDiv --> InBody : </div> yields top-level div event
-    InDiv --> InDiv : </div> pushes nested div child
+    InDiv --> InBody : </div> yields BodyBlock&#58;&#58;Div (top-level)
+    InDiv --> InDiv : </div> pushes DivContent&#58;&#58;Div (nested)
 
     InHead --> InDiv : </head> stores heading on parent div
 
@@ -522,8 +525,7 @@ stateDiagram-v2
 ```
 
 Full state coverage, including list, item, and label states, is documented in
-the design document; top-level closing `</div>` emits `BodyBlock::Div`, while
-nested closing `</div>` restores the parent and records `DivContent::Div`.
+the design document.
 
 The streaming parser currently streams the header and body only. Root-level
 `<standOff>` markup is supported by full-document parsing and emission, but it

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -316,13 +316,20 @@ The profile supports:
 - **Body structure**: paragraphs (`<p>`), utterances (`<u>`) with optional
   speaker attribution via `@who` plus local provenance attributes (`@n`,
   `@source`, `@resp`, `@cert`, `@corresp`, `@ana`), and thematic divisions
-  (`<div>`) with a required `@type` attribute. Divisions can contain
-  paragraphs, utterances, and lists (`<list>`). Lists hold ordered items
-  (`<item>`) that carry optional `@n` (numbering or timestamp metadata),
-  `@corresp` (pointer list for cross-references), and `@xml:id`. Each item may
-  include an optional label prefix (`<label>`) followed by inline content.
-  Lists are permitted within `<div>` elements only; `<list>` cannot appear
-  directly as a child of `<body>` and must instead be wrapped in a `<div>`.
+  (`<div>`) with a required validated `@type` (`DivType`), optional `@subtype`,
+  optional `@xml:id`, and an optional `Head` wrapper for a single leading
+  `<head>` element. Divisions can contain paragraphs, utterances, lists
+  (`<list>`), and nested divisions. Lists hold ordered items (`<item>`) that
+  carry optional `@n` (numbering or timestamp metadata), `@corresp` (pointer
+  list for cross-references), and `@xml:id`. Each item may include an optional
+  label prefix (`<label>`) followed by inline content. Paragraphs, utterances,
+  items, labels, and heads all store ordered `Inline` nodes; plain strings can
+  be constructed via `P::from_text_segments`, `Utterance::from_text_segments`,
+  `Item::from_text_segments`, `Label::from_text`, and `Head::from_text`. Lists
+  are permitted within `<div>` elements only; `<list>` cannot appear directly
+  as a child of `<body>` and must instead be wrapped in a `<div>`. Document
+  validation also rejects duplicate `xml:id` values across nested division
+  content and enforces declared-speaker checks when a profile cast is present.
 - **Stand-off overlays**: root-level `<standOff>` containers with
   `<spanGrp>`/`<span>` layers for many-to-many citation and analytical markup
 - **Inline elements**: emphasis (`<hi>` with optional `@rend` attribute), pause

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -8,31 +8,29 @@ available today and how to exercise it.
 
 - `tei-core` now models the top-level `TeiDocument` together with its
   `TeiHeader` and body-aware `TeiText`. The text model records ordered
-  paragraphs (`P`), utterances, and structural divisions (`Div`) containing
-  paragraphs (`P`), utterances with optional speaker references, and
-  structural divisions (`Div`) containing paragraphs, utterances, lists
-  (`List`/`Item`/`Label`), and nested subdivisions. Each `Div` keeps a
-  validated required `@type` (`DivType`), optional `@subtype`, optional
-  `@xml:id`, and an optional `Head` wrapper for a single leading `<head>`
-  element in the Episodic profile. Each block stores a sequence of `Inline`
-  nodes, allowing clients to mix plain text with emphasised `<hi>` spans and
-  `<pause/>` cues without hand-rolling XML. Plain strings flow through
-  `P::from_text_segments`, `Utterance::from_text_segments`,
-  `Item::from_text_segments`, `Label::from_text`, and `Head::from_text`; the
-  older `new` constructors remain as deprecated shims for existing callers
-  where applicable. `TeiDocument` now exposes `validate()` to enforce
-  document-wide rules: it rejects duplicate `xml:id` values across annotation
-  systems, paragraphs, utterances, divisions, lists, and items, including
-  nested divisions, and ensures utterance speakers appear in the profile cast
-  when it exists. An empty cast still counts as declared, so every `who` fails
-  until the speakers are populated, whereas the absence of a cast allows
-  speaker references, so drafts can be validated incrementally. Identifier
-  checks span the header as well, catching clashes between annotation systems
-  and body blocks. Violations surface as `TeiError::Validation`. Utterances
-  and list items now also carry local provenance and citation attributes where
-  applicable, and XML deserialization remains strict for `<u>` and `<item>`:
-  misspelt or unsupported attributes are rejected instead of being silently
-  discarded.
+  paragraphs (`P`), utterances with optional speaker references, and structural
+  divisions (`Div`) containing paragraphs, utterances, lists
+  (`List`/`Item`/`Label`), and nested subdivisions. Each `Div` keeps a required
+  `@type` (`DivType`), an optional `@subtype`, an optional `@xml:id`, and an
+  optional `Head` wrapper for a single leading `<head>` element in the Episodic
+  profile. Each block stores a sequence of `Inline` nodes, allowing clients to
+  mix plain text with emphasized `<hi>` spans and `<pause/>` cues without
+  hand-rolling XML. Plain strings flow through `P::from_text_segments`,
+  `Utterance::from_text_segments`, `Item::from_text_segments`,
+  `Label::from_text`, and `Head::from_text`; the older `new` constructors
+  remain as deprecated shims for existing callers where applicable.
+  `TeiDocument` now exposes `validate()` to enforce document-wide rules: it
+  rejects duplicate `xml:id` values across annotation systems, paragraphs,
+  utterances, divisions, lists, and items, including nested divisions, and
+  ensures utterance speakers appear in the profile cast when it exists. An
+  empty cast still counts as declared, so every `who` fails until the speakers
+  are populated, whereas the absence of a cast allows speaker references, so
+  drafts can be validated incrementally. Identifier checks span the header as
+  well, catching clashes between annotation systems and body blocks. Violations
+  surface as `TeiError::Validation`. Utterances and list items now also carry
+  local provenance and citation attributes where applicable, and XML
+  deserialization remains strict for `<u>` and `<item>`: misspelt or
+  unsupported attributes are rejected instead of being silently discarded.
 - `tei-xml` depends on the core crate and now covers both directions of XML
   flow. `serialize_document_title(raw_title)` still emits a `<title>` snippet,
   `parse_xml(xml)` wraps `quick-xml` to materialize full `TeiDocument` values,

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -330,6 +330,38 @@ The profile supports:
   as a child of `<body>` and must instead be wrapped in a `<div>`. Document
   validation also rejects duplicate `xml:id` values across nested division
   content and enforces declared-speaker checks when a profile cast is present.
+
+### Building divisions
+
+Use the root `tei_core` re-exports to assemble a division tree before wrapping
+it in a document body block:
+
+```rust
+use tei_core::{BodyBlock, Div, Head, TeiDocument};
+
+fn build_episode_doc() -> Result<(), tei_core::TeiError> {
+    let mut parent_div = Div::new("segment")?;
+    parent_div.set_subtype("chapter-markers")?;
+    parent_div.set_id("ch-01".to_string())?;
+    parent_div.set_head(Head::from_text("Chapter markers")?);
+
+    let mut child_div = Div::new("segment")?;
+    child_div.set_subtype("cold-open")?;
+    child_div.set_head(Head::from_text("Cold open")?);
+
+    parent_div.push_div(child_div);
+
+    let header = tei_core::TeiHeader::new(tei_core::FileDesc::from_title_str(
+        "Episode outline",
+    )?);
+    let mut text = tei_core::TeiText::empty();
+    text.extend([BodyBlock::Div(parent_div)]);
+
+    let _document = TeiDocument::new(header, text);
+    Ok(())
+}
+```
+
 - **Stand-off overlays**: root-level `<standOff>` containers with
   `<spanGrp>`/`<span>` layers for many-to-many citation and analytical markup
 - **Inline elements**: emphasis (`<hi>` with optional `@rend` attribute), pause
@@ -467,6 +499,31 @@ The parser yields four high-level event types:
   accumulated with their full child content (lists, items, nested paragraphs
   and utterances) before being yielded as a single `BodyBlock::Div` event
 - **`DocumentEnd`**: Emitted once after all content has been successfully parsed
+
+### Parser state overview
+
+```mermaid
+stateDiagram-v2
+    [*] --> InBody
+
+    InBody --> InDiv : <div> start
+
+    InDiv --> InHead : <head> start before children
+    InDiv --> InParagraph : <p> start
+    InDiv --> InUtterance : <u> start
+    InDiv --> InDiv : nested <div> start
+    InDiv --> InBody : </div> yields top-level div event
+    InDiv --> InDiv : </div> pushes nested div child
+
+    InHead --> InDiv : </head> stores heading on parent div
+
+    InParagraph --> InDiv : </p> restores parent div
+    InUtterance --> InDiv : </u> restores parent div
+```
+
+Full state coverage, including list, item, and label states, is documented in
+the design document; top-level closing `</div>` emits `BodyBlock::Div`, while
+nested closing `</div>` restores the parent and records `DivContent::Div`.
 
 The streaming parser currently streams the header and body only. Root-level
 `<standOff>` markup is supported by full-document parsing and emission, but it

--- a/python/tei_rapporteur/structs.pyi
+++ b/python/tei_rapporteur/structs.pyi
@@ -79,7 +79,10 @@ class ListBlock(
     items: list[Item] = ...  # type: ignore[assignment]
     xml_id: str | None = None
 
-DivContent: TypeAlias = TextBlock | ListBlock
+class Head(msgspec.Struct, omit_defaults=True):
+    """Division heading attached to the start of a structural division."""
+
+    content: list[Inline] = ...  # type: ignore[assignment]
 
 class DivBlock(
     msgspec.Struct, tag="div", tag_field="type", omit_defaults=True
@@ -87,8 +90,12 @@ class DivBlock(
     """Structural division within the TEI body."""
 
     div_type: str
+    subtype: str | None = None
+    head: Head | None = None
     content: list[DivContent] = ...  # type: ignore[assignment]
     xml_id: str | None = None
+
+DivContent: TypeAlias = TextBlock | ListBlock | DivBlock
 
 BodyBlock: TypeAlias = TextBlock | DivBlock
 

--- a/python/tei_rapporteur/structs.pyi
+++ b/python/tei_rapporteur/structs.pyi
@@ -275,6 +275,8 @@ class DivEvent(
     """Streaming event carrying an assembled division body block."""
 
     div_type: str
+    subtype: str | None = None
+    head: Head | None = None
     content: list[DivContent] = ...  # type: ignore[assignment]
     xml_id: str | None = None
 

--- a/python/tei_rapporteur/structs.pyi
+++ b/python/tei_rapporteur/structs.pyi
@@ -1,7 +1,7 @@
 """Type stubs for the ``tei_rapporteur.structs`` submodule (PEP 561).
 
-The runtime definitions live in ``tei-py/python/structs.py`` and are
-embedded into the native extension at compile time via ``include_str!``.
+The runtime definitions live in ``tei-py/python/structs.py`` plus internal
+helper modules and are embedded into the native extension at compile time.
 """
 
 import msgspec

--- a/schemas/tei-document.schema.json
+++ b/schemas/tei-document.schema.json
@@ -138,8 +138,27 @@
           "required": [
             "list"
           ]
+        },
+        {
+          "description": "Nested division block.",
+          "type": "object",
+          "properties": {
+            "div": {
+              "$ref": "#/$defs/div"
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "div"
+          ]
         }
       ]
+    },
+    "DivSubtype": {
+      "description": "Validated wrapper for division `@subtype` attributes.",
+      "type": "string",
+      "minLength": 1,
+      "pattern": "\\S"
     },
     "DivType": {
       "description": "Validated wrapper for division `@type` attributes.",
@@ -301,6 +320,16 @@
             "$ref": "#/$defs/DivContent"
           }
         },
+        "@subtype": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DivSubtype"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "@type": {
           "$ref": "#/$defs/DivType"
         },
@@ -308,6 +337,16 @@
           "anyOf": [
             {
               "$ref": "#/$defs/XmlId"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "head": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/head"
             },
             {
               "type": "null"
@@ -364,6 +403,19 @@
       "required": [
         "title"
       ]
+    },
+    "head": {
+      "description": "Heading prefix for a structural division, containing inline content.",
+      "type": "object",
+      "properties": {
+        "$value": {
+          "type": "array",
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/Inline"
+          }
+        }
+      }
     },
     "hi": {
       "description": "Emphasised inline element corresponding to `<hi>`.",

--- a/schemas/tei-document.schema.json
+++ b/schemas/tei-document.schema.json
@@ -410,7 +410,6 @@
       "properties": {
         "$value": {
           "type": "array",
-          "default": [],
           "items": {
             "$ref": "#/$defs/Inline"
           },

--- a/schemas/tei-document.schema.json
+++ b/schemas/tei-document.schema.json
@@ -413,9 +413,13 @@
           "default": [],
           "items": {
             "$ref": "#/$defs/Inline"
-          }
+          },
+          "minItems": 1
         }
-      }
+      },
+      "required": [
+        "$value"
+      ]
     },
     "hi": {
       "description": "Emphasised inline element corresponding to `<hi>`.",

--- a/schemas/tei-document.schema.v0.1.0.json
+++ b/schemas/tei-document.schema.v0.1.0.json
@@ -138,8 +138,27 @@
           "required": [
             "list"
           ]
+        },
+        {
+          "description": "Nested division block.",
+          "type": "object",
+          "properties": {
+            "div": {
+              "$ref": "#/$defs/div"
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "div"
+          ]
         }
       ]
+    },
+    "DivSubtype": {
+      "description": "Validated wrapper for division `@subtype` attributes.",
+      "type": "string",
+      "minLength": 1,
+      "pattern": "\\S"
     },
     "DivType": {
       "description": "Validated wrapper for division `@type` attributes.",
@@ -301,6 +320,16 @@
             "$ref": "#/$defs/DivContent"
           }
         },
+        "@subtype": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DivSubtype"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "@type": {
           "$ref": "#/$defs/DivType"
         },
@@ -308,6 +337,16 @@
           "anyOf": [
             {
               "$ref": "#/$defs/XmlId"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "head": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/head"
             },
             {
               "type": "null"
@@ -364,6 +403,19 @@
       "required": [
         "title"
       ]
+    },
+    "head": {
+      "description": "Heading prefix for a structural division, containing inline content.",
+      "type": "object",
+      "properties": {
+        "$value": {
+          "type": "array",
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/Inline"
+          }
+        }
+      }
     },
     "hi": {
       "description": "Emphasised inline element corresponding to `<hi>`.",

--- a/schemas/tei-document.schema.v0.1.0.json
+++ b/schemas/tei-document.schema.v0.1.0.json
@@ -410,7 +410,6 @@
       "properties": {
         "$value": {
           "type": "array",
-          "default": [],
           "items": {
             "$ref": "#/$defs/Inline"
           },

--- a/schemas/tei-document.schema.v0.1.0.json
+++ b/schemas/tei-document.schema.v0.1.0.json
@@ -413,9 +413,13 @@
           "default": [],
           "items": {
             "$ref": "#/$defs/Inline"
-          }
+          },
+          "minItems": 1
         }
-      }
+      },
+      "required": [
+        "$value"
+      ]
     },
     "hi": {
       "description": "Emphasised inline element corresponding to `<hi>`.",

--- a/schemas/tei-episodic-profile.odd
+++ b/schemas/tei-episodic-profile.odd
@@ -72,7 +72,7 @@
           <!-- ============================================================ -->
 
 	          <moduleRef key="tei"/>
-	          <moduleRef key="core" include="p hi title desc list item label"/>
+	          <moduleRef key="core" include="p hi title desc list item label head"/>
 	          <moduleRef key="header"
 	                     include="teiHeader fileDesc profileDesc encodingDesc revisionDesc change annotationSystem refsDecl citeStructure citeData series synopsis speaker lang resp"/>
 	          <moduleRef key="textstructure" include="TEI text body div"/>

--- a/schemas/tei-episodic-profile.odd
+++ b/schemas/tei-episodic-profile.odd
@@ -365,11 +365,15 @@
             <desc>A structural body division grouping related narrative,
             utterance, and list content.</desc>
             <content>
-              <alternate minOccurs="0" maxOccurs="unbounded">
-                <elementRef key="p"/>
-                <elementRef key="u"/>
-                <elementRef key="list"/>
-              </alternate>
+              <sequence>
+                <elementRef key="head" minOccurs="0" maxOccurs="1"/>
+                <alternate minOccurs="0" maxOccurs="unbounded">
+                  <elementRef key="p"/>
+                  <elementRef key="u"/>
+                  <elementRef key="list"/>
+                  <elementRef key="div"/>
+                </alternate>
+              </sequence>
             </content>
             <attList>
               <attDef ident="xml:id" mode="change" usage="opt">
@@ -384,6 +388,12 @@
                   <dataRef key="teidata.text"/>
                 </datatype>
               </attDef>
+              <attDef ident="subtype" mode="change" usage="opt">
+                <desc>Optional finer-grained classification of the division.</desc>
+                <datatype>
+                  <dataRef key="teidata.text"/>
+                </datatype>
+              </attDef>
             </attList>
             <constraintSpec ident="div-type-not-empty" scheme="schematron">
               <constraint>
@@ -391,6 +401,16 @@
                 <sch:rule context="tei:div[@type]">
                   <sch:assert test="normalize-space(@type) != ''">
                     Division @type values must not be empty or whitespace only.
+                  </sch:assert>
+                </sch:rule>
+              </constraint>
+            </constraintSpec>
+            <constraintSpec ident="div-subtype-not-empty" scheme="schematron">
+              <constraint>
+                <sch:ns prefix="tei" uri="http://www.tei-c.org/ns/1.0"/>
+                <sch:rule context="tei:div[@subtype]">
+                  <sch:assert test="normalize-space(@subtype) != ''">
+                    Division @subtype values must not be empty or whitespace only.
                   </sch:assert>
                 </sch:rule>
               </constraint>

--- a/schemas/tei-episodic-profile.rng
+++ b/schemas/tei-episodic-profile.rng
@@ -308,11 +308,20 @@
       <attribute name="type">
         <text/>
       </attribute>
+      <optional>
+        <attribute name="subtype">
+          <text/>
+        </attribute>
+      </optional>
+      <optional>
+        <ref name="head"/>
+      </optional>
       <zeroOrMore>
         <choice>
           <ref name="p"/>
           <ref name="u"/>
           <ref name="list"/>
+          <ref name="div"/>
         </choice>
       </zeroOrMore>
     </element>

--- a/schemas/tei-episodic-profile.rng
+++ b/schemas/tei-episodic-profile.rng
@@ -370,6 +370,12 @@
     </element>
   </define>
 
+  <define name="head">
+    <element name="head" ns="http://www.tei-c.org/ns/1.0">
+      <ref name="inlineContent"/>
+    </element>
+  </define>
+
   <define name="p">
     <element name="p" ns="http://www.tei-c.org/ns/1.0">
       <optional>

--- a/tei-core/src/lib.rs
+++ b/tei-core/src/lib.rs
@@ -20,10 +20,11 @@ pub use header::{
     RevisionDesc, SpeakerName, TeiHeader,
 };
 pub use text::{
-    BodyBlock, BodyContentError, Certainty, CertaintyValidationError, Div, DivContent, DivType,
-    DivTypeValidationError, Hi, IdentifierValidationError, Inline, Item, Label, List, P, Pause,
-    Pointer, PointerList, PointerListValidationError, PointerValidationError, Speaker,
-    SpeakerValidationError, TeiBody, TeiText, Utterance, XmlId,
+    BodyBlock, BodyContentError, Certainty, CertaintyValidationError, Div, DivContent, DivSubtype,
+    DivSubtypeValidationError, DivType, DivTypeValidationError, Head, Hi,
+    IdentifierValidationError, Inline, Item, Label, List, P, Pause, Pointer, PointerList,
+    PointerListValidationError, PointerValidationError, Speaker, SpeakerValidationError, TeiBody,
+    TeiText, Utterance, XmlId,
 };
 pub use title::{DocumentTitle, DocumentTitleError};
 pub use validation::ValidationError;

--- a/tei-core/src/text/body/div.rs
+++ b/tei-core/src/text/body/div.rs
@@ -77,7 +77,7 @@ impl Div {
         set_optional_identifier(&mut self.id, id, "div")
     }
 
-    /// Sets the optional division subtype.
+    /// Sets the optional division subtype, overwriting any existing value.
     ///
     /// # Errors
     ///
@@ -91,7 +91,8 @@ impl Div {
         Ok(())
     }
 
-    /// Sets the optional heading for the division.
+    /// Sets the optional heading for the division, overwriting any existing
+    /// value.
     pub fn set_head(&mut self, head: Head) {
         self.head = Some(head);
     }

--- a/tei-core/src/text/body/div.rs
+++ b/tei-core/src/text/body/div.rs
@@ -114,11 +114,7 @@ impl Div {
 
     /// Returns the division identifier when present.
     #[must_use]
-    #[expect(
-        clippy::missing_const_for_fn,
-        reason = "Option::as_ref is not const-stable on current MSRV."
-    )]
-    pub fn id(&self) -> Option<&XmlId> {
+    pub const fn id(&self) -> Option<&XmlId> {
         self.id.as_ref()
     }
 

--- a/tei-core/src/text/body/div.rs
+++ b/tei-core/src/text/body/div.rs
@@ -1,11 +1,12 @@
 //! Division model for grouping related body content.
 //!
-//! Defines TEI `<div>` elements that organize paragraphs, utterances, and lists
-//! into thematic sections identified by `@type` and optional `@xml:id`.
+//! Defines TEI `<div>` elements that organize paragraphs, utterances, lists,
+//! nested divisions, and optional headings into thematic sections identified by
+//! `@type`, optional `@subtype`, and optional `@xml:id`.
 
-use crate::text::types::{DivType, XmlId};
+use crate::text::types::{DivSubtype, DivType, XmlId};
 
-use super::{BodyContentError, List, P, Utterance, set_optional_identifier};
+use super::{BodyContentError, Head, List, P, Utterance, set_optional_identifier};
 use serde::{Deserialize, Serialize};
 
 /// Thematic or structural division of body content.
@@ -19,6 +20,8 @@ use serde::{Deserialize, Serialize};
 pub struct Div {
     #[serde(rename = "@type")]
     div_type: DivType,
+    #[serde(rename = "@subtype", skip_serializing_if = "Option::is_none", default)]
+    subtype: Option<DivSubtype>,
     #[serde(
         rename = "@xml:id",
         alias = "@id",
@@ -26,6 +29,8 @@ pub struct Div {
         default
     )]
     id: Option<XmlId>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    head: Option<Head>,
     #[serde(rename = "$value", default)]
     content: Vec<DivContent>,
 }
@@ -53,7 +58,9 @@ impl Div {
 
         Ok(Self {
             div_type: validated,
+            subtype: None,
             id: None,
+            head: None,
             content: Vec::new(),
         })
     }
@@ -70,9 +77,38 @@ impl Div {
         set_optional_identifier(&mut self.id, id, "div")
     }
 
+    /// Sets the optional division subtype.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`BodyContentError::EmptySegment`] when the value lacks visible
+    /// characters after trimming.
+    pub fn set_subtype(&mut self, subtype: impl Into<String>) -> Result<(), BodyContentError> {
+        self.subtype = Some(
+            DivSubtype::new(subtype)
+                .map_err(|_| BodyContentError::EmptySegment { container: "div" })?,
+        );
+        Ok(())
+    }
+
+    /// Sets the optional heading for the division.
+    pub fn set_head(&mut self, head: Head) {
+        self.head = Some(head);
+    }
+
     /// Clears any associated `xml:id`.
     pub fn clear_id(&mut self) {
         self.id = None;
+    }
+
+    /// Clears any associated subtype.
+    pub fn clear_subtype(&mut self) {
+        self.subtype = None;
+    }
+
+    /// Clears any associated heading.
+    pub fn clear_head(&mut self) {
+        self.head = None;
     }
 
     /// Returns the division identifier when present.
@@ -87,8 +123,20 @@ impl Div {
 
     /// Returns the division type.
     #[must_use]
-    pub fn div_type(&self) -> &str {
+    pub const fn div_type(&self) -> &str {
         self.div_type.as_str()
+    }
+
+    /// Returns the division subtype when present.
+    #[must_use]
+    pub fn subtype(&self) -> Option<&str> {
+        self.subtype.as_ref().map(DivSubtype::as_str)
+    }
+
+    /// Returns the heading when present.
+    #[must_use]
+    pub const fn head(&self) -> Option<&Head> {
+        self.head.as_ref()
     }
 
     /// Returns the stored content.
@@ -112,10 +160,15 @@ impl Div {
         self.content.push(DivContent::List(list));
     }
 
+    /// Appends a nested division to the division.
+    pub fn push_div(&mut self, div: Self) {
+        self.content.push(DivContent::Div(div));
+    }
+
     /// Reports whether the division contains any content.
     #[must_use]
     pub const fn is_empty(&self) -> bool {
-        self.content.is_empty()
+        self.head.is_none() && self.content.is_empty()
     }
 }
 
@@ -132,6 +185,9 @@ pub enum DivContent {
     /// List block.
     #[serde(rename = "list")]
     List(List),
+    /// Nested division block.
+    #[serde(rename = "div")]
+    Div(Div),
 }
 
 #[cfg(test)]
@@ -140,6 +196,33 @@ mod tests {
 
     use super::*;
     use crate::text::body::Item;
+
+    fn sample_list() -> List {
+        let item = Item::from_text_segments(["List item"])
+            .unwrap_or_else(|error| panic!("valid item: {error}"));
+        List::new([item]).unwrap_or_else(|error| panic!("valid list: {error}"))
+    }
+
+    fn sample_child_div() -> Div {
+        let mut child_div =
+            Div::new("guest-bios").unwrap_or_else(|error| panic!("valid child div: {error}"));
+        child_div.set_head(
+            Head::from_text("Guests").unwrap_or_else(|error| panic!("valid head: {error}")),
+        );
+        child_div
+    }
+
+    fn div_content_kinds(div: &Div) -> Vec<&'static str> {
+        div.content()
+            .iter()
+            .map(|content| match content {
+                DivContent::Paragraph(_) => "p",
+                DivContent::Utterance(_) => "u",
+                DivContent::List(_) => "list",
+                DivContent::Div(_) => "div",
+            })
+            .collect()
+    }
 
     #[test]
     fn div_new_rejects_empty_type() {
@@ -203,32 +286,75 @@ mod tests {
     }
 
     #[test]
+    fn div_subtype_round_trips() {
+        let mut div = Div::new("segment").unwrap_or_else(|error| panic!("valid div: {error}"));
+        div.set_subtype("chapter-marker")
+            .unwrap_or_else(|error| panic!("valid subtype: {error}"));
+        assert_eq!(div.subtype(), Some("chapter-marker"));
+        div.clear_subtype();
+        assert!(div.subtype().is_none());
+    }
+
+    #[test]
+    fn div_head_round_trips() {
+        let mut div = Div::new("segment").unwrap_or_else(|error| panic!("valid div: {error}"));
+        let head = Head::from_text("Chapter markers")
+            .unwrap_or_else(|error| panic!("valid head: {error}"));
+        div.set_head(head.clone());
+        assert_eq!(div.head(), Some(&head));
+        div.clear_head();
+        assert!(div.head().is_none());
+    }
+
+    #[test]
     fn div_push_content() {
         let mut div = Div::new("show-notes").unwrap_or_else(|error| panic!("valid div: {error}"));
 
         let paragraph = P::from_text_segments(["Intro text"])
             .unwrap_or_else(|error| panic!("valid paragraph: {error}"));
-        div.push_paragraph(paragraph.clone());
+        div.push_paragraph(paragraph);
 
         let utterance = Utterance::from_text_segments(Some("host"), ["Hello!"])
             .unwrap_or_else(|error| panic!("valid utterance: {error}"));
-        div.push_utterance(utterance.clone());
+        div.push_utterance(utterance);
 
-        let item = Item::from_text_segments(["List item"])
-            .unwrap_or_else(|error| panic!("valid item: {error}"));
-        let list = super::List::new([item]).unwrap_or_else(|error| panic!("valid list: {error}"));
-        div.push_list(list.clone());
-
-        assert_eq!(div.content().len(), 3);
+        div.push_list(sample_list());
+        div.push_div(sample_child_div());
+        assert_eq!(div_content_kinds(&div), vec!["p", "u", "list", "div"]);
         assert!(!div.is_empty());
-        assert!(matches!(
-            div.content().first(),
-            Some(DivContent::Paragraph(_))
-        ));
-        assert!(matches!(
-            div.content().get(1),
-            Some(DivContent::Utterance(_))
-        ));
-        assert!(matches!(div.content().get(2), Some(DivContent::List(_))));
+    }
+
+    #[test]
+    fn div_serde_round_trips_head_subtype_and_nested_div() {
+        let mut parent = Div::new("segment").unwrap_or_else(|error| panic!("valid div: {error}"));
+        parent
+            .set_subtype("chapter-markers")
+            .unwrap_or_else(|error| panic!("valid subtype: {error}"));
+        parent.set_head(
+            Head::from_text("Chapter markers")
+                .unwrap_or_else(|error| panic!("valid head: {error}")),
+        );
+
+        let mut child =
+            Div::new("segment").unwrap_or_else(|error| panic!("valid child div: {error}"));
+        child
+            .set_subtype("chapter-marker")
+            .unwrap_or_else(|error| panic!("valid subtype: {error}"));
+        child.set_head(
+            Head::from_text("Cold open")
+                .unwrap_or_else(|error| panic!("valid child head: {error}")),
+        );
+        child.push_paragraph(
+            P::from_text_segments(["Welcome back"])
+                .unwrap_or_else(|error| panic!("valid paragraph: {error}")),
+        );
+        parent.push_div(child);
+
+        let json = tei_serde::serde_json::to_string(&parent)
+            .unwrap_or_else(|error| panic!("json: {error}"));
+        let parsed: Div = tei_serde::serde_json::from_str(&json)
+            .unwrap_or_else(|error| panic!("round trip should parse: {error}"));
+
+        assert_eq!(parsed, parent);
     }
 }

--- a/tei-core/src/text/body/head.rs
+++ b/tei-core/src/text/body/head.rs
@@ -1,0 +1,76 @@
+//! Division heading model for structural body sections.
+//!
+//! Defines a profile-constrained TEI `<head>` wrapper used at the start of a
+//! `<div>` to carry inline heading content.
+
+use crate::text::Inline;
+
+use super::{BodyContentError, ensure_container_content, push_validated_text_segment};
+use serde::{Deserialize, Serialize};
+
+/// Heading prefix for a structural division, containing inline content.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
+#[serde(rename = "head")]
+pub struct Head {
+    #[serde(rename = "$value", default)]
+    content: Vec<Inline>,
+}
+
+impl Head {
+    /// Builds a heading from pre-constructed inline content.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`BodyContentError::EmptyContent`] when the content lacks
+    /// visible inline information.
+    pub fn new(content: impl IntoIterator<Item = Inline>) -> Result<Self, BodyContentError> {
+        let collected: Vec<Inline> = content.into_iter().collect();
+        ensure_container_content(&collected, "head")?;
+
+        Ok(Self { content: collected })
+    }
+
+    /// Builds a heading from plain text.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`BodyContentError::EmptyContent`] when the text lacks visible
+    /// characters.
+    pub fn from_text(text: impl Into<String>) -> Result<Self, BodyContentError> {
+        let mut content = Vec::new();
+        push_validated_text_segment(&mut content, text, "head")?;
+        ensure_container_content(&content, "head")?;
+
+        Ok(Self { content })
+    }
+
+    /// Returns the stored inline content.
+    #[must_use]
+    pub const fn content(&self) -> &[Inline] {
+        self.content.as_slice()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    //! Unit tests for division heading construction.
+
+    use super::*;
+
+    #[test]
+    fn head_rejects_empty_text() {
+        let result = Head::from_text("");
+        assert!(matches!(
+            result,
+            Err(BodyContentError::EmptySegment { container }) if container == "head"
+        ));
+    }
+
+    #[test]
+    fn head_accepts_visible_text() {
+        let head = Head::from_text("Chapter markers")
+            .unwrap_or_else(|error| panic!("valid head: {error}"));
+        assert_eq!(head.content(), &[Inline::Text("Chapter markers".into())]);
+    }
+}

--- a/tei-core/src/text/body/head.rs
+++ b/tei-core/src/text/body/head.rs
@@ -22,8 +22,8 @@ impl Head {
     ///
     /// # Errors
     ///
-    /// Returns [`BodyContentError::EmptyContent`] when the content lacks
-    /// visible inline information.
+    /// Returns [`BodyContentError::EmptySegment`] with `container` set to
+    /// `"head"` when the content lacks visible inline information.
     pub fn new(content: impl IntoIterator<Item = Inline>) -> Result<Self, BodyContentError> {
         let collected: Vec<Inline> = content.into_iter().collect();
         ensure_container_content(&collected, "head")?;
@@ -35,8 +35,8 @@ impl Head {
     ///
     /// # Errors
     ///
-    /// Returns [`BodyContentError::EmptyContent`] when the text lacks visible
-    /// characters.
+    /// Returns [`BodyContentError::EmptySegment`] with `container` set to
+    /// `"head"` when the text lacks visible characters.
     pub fn from_text(text: impl Into<String>) -> Result<Self, BodyContentError> {
         let mut content = Vec::new();
         push_validated_text_segment(&mut content, text, "head")?;

--- a/tei-core/src/text/body/mod.rs
+++ b/tei-core/src/text/body/mod.rs
@@ -5,6 +5,7 @@
 
 mod div;
 mod error;
+mod head;
 mod item;
 mod list;
 mod paragraph;
@@ -13,6 +14,7 @@ mod validation;
 
 pub use div::{Div, DivContent};
 pub use error::BodyContentError;
+pub use head::Head;
 pub use item::{Item, Label};
 pub use list::List;
 pub use paragraph::P;

--- a/tei-core/src/text/div_types.rs
+++ b/tei-core/src/text/div_types.rs
@@ -1,0 +1,147 @@
+//! Validated wrapper types for division typing attributes.
+
+use std::fmt;
+
+use serde::de::Error as DeError;
+use serde::{Deserialize, Deserializer, Serialize};
+use thiserror::Error;
+
+use crate::text::body::trim_preserving_original;
+
+/// Validated wrapper for division `@type` attributes.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
+#[serde(transparent)]
+pub struct DivType(String);
+
+/// Validated wrapper for division `@subtype` attributes.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
+#[serde(transparent)]
+pub struct DivSubtype(String);
+
+/// Errors raised when normalizing division type input.
+#[derive(Clone, Debug, Deserialize, Error, Eq, PartialEq, Serialize)]
+pub enum DivTypeValidationError {
+    /// The division type trimmed to an empty string.
+    #[error("division type must not be empty")]
+    Empty,
+}
+
+/// Errors raised when normalizing division subtype input.
+#[derive(Clone, Debug, Deserialize, Error, Eq, PartialEq, Serialize)]
+pub enum DivSubtypeValidationError {
+    /// The division subtype trimmed to an empty string.
+    #[error("division subtype must not be empty")]
+    Empty,
+}
+
+impl DivType {
+    /// Builds a division type from user input.
+    ///
+    /// Leading and trailing whitespace is stripped. The value must contain at
+    /// least one visible character after trimming.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DivTypeValidationError::Empty`] when the trimmed value is
+    /// empty.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tei_core::DivType;
+    ///
+    /// let dt = DivType::new("show-notes")
+    ///     .unwrap_or_else(|error| panic!("valid type: {error}"));
+    /// assert_eq!(dt.as_str(), "show-notes");
+    /// ```
+    pub fn new(value: impl Into<String>) -> Result<Self, DivTypeValidationError> {
+        let trimmed = trim_preserving_original(value.into());
+
+        if trimmed.is_empty() {
+            return Err(DivTypeValidationError::Empty);
+        }
+
+        Ok(Self(trimmed))
+    }
+
+    /// Returns the division type as a string slice.
+    #[must_use]
+    pub const fn as_str(&self) -> &str {
+        self.0.as_str()
+    }
+}
+
+impl DivSubtype {
+    /// Builds a division subtype from user input.
+    ///
+    /// Leading and trailing whitespace is stripped. The value must contain at
+    /// least one visible character after trimming.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DivSubtypeValidationError::Empty`] when the trimmed value is
+    /// empty.
+    pub fn new(value: impl Into<String>) -> Result<Self, DivSubtypeValidationError> {
+        let trimmed = trim_preserving_original(value.into());
+
+        if trimmed.is_empty() {
+            return Err(DivSubtypeValidationError::Empty);
+        }
+
+        Ok(Self(trimmed))
+    }
+
+    /// Returns the division subtype as a string slice.
+    #[must_use]
+    pub const fn as_str(&self) -> &str {
+        self.0.as_str()
+    }
+}
+
+macro_rules! impl_div_string_type {
+    ($name:ident, $error:ident) => {
+        impl AsRef<str> for $name {
+            fn as_ref(&self) -> &str {
+                self.as_str()
+            }
+        }
+
+        impl fmt::Display for $name {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                self.0.fmt(f)
+            }
+        }
+
+        impl TryFrom<String> for $name {
+            type Error = $error;
+
+            fn try_from(value: String) -> Result<Self, Self::Error> {
+                Self::new(value)
+            }
+        }
+
+        impl TryFrom<&str> for $name {
+            type Error = $error;
+
+            fn try_from(value: &str) -> Result<Self, Self::Error> {
+                Self::new(value)
+            }
+        }
+
+        impl<'de> Deserialize<'de> for $name {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: Deserializer<'de>,
+            {
+                let value = String::deserialize(deserializer)?;
+
+                Self::new(value).map_err(DeError::custom)
+            }
+        }
+    };
+}
+
+impl_div_string_type!(DivType, DivTypeValidationError);
+impl_div_string_type!(DivSubtype, DivSubtypeValidationError);

--- a/tei-core/src/text/mod.rs
+++ b/tei-core/src/text/mod.rs
@@ -19,13 +19,13 @@ mod inline;
 mod types;
 
 pub use body::{
-    BodyBlock, BodyContentError, Div, DivContent, Item, Label, List, P, TeiBody, Utterance,
+    BodyBlock, BodyContentError, Div, DivContent, Head, Item, Label, List, P, TeiBody, Utterance,
 };
 pub use inline::{Hi, Inline, Pause};
 pub use types::{
-    Certainty, CertaintyValidationError, DivType, DivTypeValidationError,
-    IdentifierValidationError, Pointer, PointerList, PointerListValidationError,
-    PointerValidationError, Speaker, SpeakerValidationError, XmlId,
+    Certainty, CertaintyValidationError, DivSubtype, DivSubtypeValidationError, DivType,
+    DivTypeValidationError, IdentifierValidationError, Pointer, PointerList,
+    PointerListValidationError, PointerValidationError, Speaker, SpeakerValidationError, XmlId,
 };
 
 /// Body of a TEI document, including paragraphs and utterances.

--- a/tei-core/src/text/types.rs
+++ b/tei-core/src/text/types.rs
@@ -1,8 +1,10 @@
-//! Validated wrapper types for TEI identifiers and speaker attributes.
+//! Validated wrapper types for TEI text-layer attributes and identifiers.
 //!
-//! Pointer and certainty wrappers live in the sibling `pointers` submodule so
-//! this root file can focus on the identifier and speaker primitives shared
-//! across the text layer.
+//! This module collects the normalized wrappers that are reused across the TEI
+//! text model, including `XmlId` identifiers, speaker values, division
+//! classifiers such as `DivType` and `DivSubtype`, pointer and certainty
+//! wrappers re-exported from the sibling `pointers` submodule, and trimming
+//! helpers such as `trim_preserving_original`.
 
 #[path = "div_types.rs"]
 mod div_types;

--- a/tei-core/src/text/types.rs
+++ b/tei-core/src/text/types.rs
@@ -4,6 +4,8 @@
 //! this root file can focus on the identifier and speaker primitives shared
 //! across the text layer.
 
+#[path = "div_types.rs"]
+mod div_types;
 #[path = "pointers.rs"]
 mod pointers;
 
@@ -15,6 +17,7 @@ use thiserror::Error;
 
 use super::body::trim_preserving_original;
 
+pub use div_types::{DivSubtype, DivSubtypeValidationError, DivType, DivTypeValidationError};
 pub use pointers::{
     Certainty, CertaintyValidationError, Pointer, PointerList, PointerListValidationError,
     PointerValidationError,
@@ -105,106 +108,6 @@ impl TryFrom<&str> for XmlId {
 }
 
 impl<'de> Deserialize<'de> for XmlId {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let value = String::deserialize(deserializer)?;
-
-        Self::new(value).map_err(DeError::custom)
-    }
-}
-
-/// Validated wrapper for division `@type` attributes.
-#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
-#[cfg_attr(feature = "json-schema", derive(schemars::JsonSchema))]
-#[serde(transparent)]
-pub struct DivType(String);
-
-/// Errors raised when normalizing division type input.
-#[derive(Clone, Debug, Deserialize, Error, Eq, PartialEq, Serialize)]
-pub enum DivTypeValidationError {
-    /// The division type trimmed to an empty string.
-    #[error("division type must not be empty")]
-    Empty,
-}
-
-impl DivType {
-    /// Builds a division type from user input.
-    ///
-    /// Leading and trailing whitespace is stripped. The value must contain at
-    /// least one visible character after trimming.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`DivTypeValidationError::Empty`] when the trimmed value is
-    /// empty.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use tei_core::DivType;
-    ///
-    /// let dt = DivType::new("show-notes")
-    ///     .unwrap_or_else(|error| panic!("valid type: {error}"));
-    /// assert_eq!(dt.as_str(), "show-notes");
-    /// ```
-    pub fn new(value: impl Into<String>) -> Result<Self, DivTypeValidationError> {
-        let trimmed = trim_preserving_original(value.into());
-
-        if trimmed.is_empty() {
-            return Err(DivTypeValidationError::Empty);
-        }
-
-        Ok(Self(trimmed))
-    }
-
-    /// Returns the division type as a string slice.
-    #[must_use]
-    #[expect(
-        clippy::missing_const_for_fn,
-        reason = "String::as_str is not const-stable on current MSRV."
-    )]
-    pub fn as_str(&self) -> &str {
-        self.0.as_str()
-    }
-
-    /// Consumes the wrapper and returns the owned string.
-    #[must_use]
-    pub fn into_inner(self) -> String {
-        self.0
-    }
-}
-
-impl AsRef<str> for DivType {
-    fn as_ref(&self) -> &str {
-        self.as_str()
-    }
-}
-
-impl fmt::Display for DivType {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.0.fmt(f)
-    }
-}
-
-impl TryFrom<String> for DivType {
-    type Error = DivTypeValidationError;
-
-    fn try_from(value: String) -> Result<Self, Self::Error> {
-        Self::new(value)
-    }
-}
-
-impl TryFrom<&str> for DivType {
-    type Error = DivTypeValidationError;
-
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
-        Self::new(value)
-    }
-}
-
-impl<'de> Deserialize<'de> for DivType {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,

--- a/tei-core/src/validation/mod.rs
+++ b/tei-core/src/validation/mod.rs
@@ -137,9 +137,8 @@ fn validate_div(
                 }
                 validate_speaker_reference(utterance, known_speakers)?;
             }
-            DivContent::List(list) => {
-                validate_list(list, seen_ids)?;
-            }
+            DivContent::List(list) => validate_list(list, seen_ids)?,
+            DivContent::Div(nested_div) => validate_div(nested_div, seen_ids, known_speakers)?,
         }
     }
 

--- a/tei-core/src/validation/mod.rs
+++ b/tei-core/src/validation/mod.rs
@@ -23,6 +23,8 @@ use refs_decl::validate_refs_decl;
 use speakers::{extract_known_speakers, validate_speaker_reference};
 use stand_off::validate_stand_off_structure;
 
+pub(super) const MAX_DIV_DEPTH: usize = 128;
+
 /// Errors raised when validating a [`TeiDocument`].
 #[derive(Clone, Debug, Error, Eq, PartialEq)]
 pub enum ValidationError {
@@ -63,6 +65,15 @@ pub enum ValidationError {
     /// A stand-off span declared `@to` without `@from`.
     #[error("span @to requires @from")]
     SpanToWithoutFrom,
+
+    /// A nested structural container exceeded the supported recursion limit.
+    #[error("{container} nesting exceeds maximum supported depth of {max_depth}")]
+    TooDeep {
+        /// Name of the container whose nesting exceeded the limit.
+        container: &'static str,
+        /// Maximum supported nesting depth.
+        max_depth: usize,
+    },
 }
 
 /// Validates document-wide invariants for a [`TeiDocument`].
@@ -105,7 +116,7 @@ fn validate_body_blocks(
                 validate_speaker_reference(utterance, known_speakers)?;
             }
             BodyBlock::Div(div) => {
-                validate_div(div, seen_ids, known_speakers)?;
+                validate_div(div, seen_ids, known_speakers, 0)?;
             }
         }
     }
@@ -117,8 +128,11 @@ fn validate_div(
     div: &crate::Div,
     seen_ids: &mut HashSet<String>,
     known_speakers: Option<&HashSet<String>>,
+    current_depth: usize,
 ) -> Result<(), ValidationError> {
     use crate::DivContent;
+
+    ensure_within_max_depth("div", current_depth)?;
 
     if let Some(identifier) = div.id() {
         identifiers::record_id(identifier.as_str(), seen_ids)?;
@@ -137,8 +151,10 @@ fn validate_div(
                 }
                 validate_speaker_reference(utterance, known_speakers)?;
             }
-            DivContent::List(list) => validate_list(list, seen_ids)?,
-            DivContent::Div(nested_div) => validate_div(nested_div, seen_ids, known_speakers)?,
+            DivContent::List(list) => validate_list(list, seen_ids, current_depth + 1)?,
+            DivContent::Div(nested_div) => {
+                validate_div(nested_div, seen_ids, known_speakers, current_depth + 1)?;
+            }
         }
     }
 
@@ -148,7 +164,10 @@ fn validate_div(
 fn validate_list(
     list: &crate::List,
     seen_ids: &mut HashSet<String>,
+    current_depth: usize,
 ) -> Result<(), ValidationError> {
+    ensure_within_max_depth("list", current_depth)?;
+
     if let Some(identifier) = list.id() {
         identifiers::record_id(identifier.as_str(), seen_ids)?;
     }
@@ -162,6 +181,20 @@ fn validate_list(
     Ok(())
 }
 
+const fn ensure_within_max_depth(
+    container: &'static str,
+    current_depth: usize,
+) -> Result<(), ValidationError> {
+    if current_depth >= MAX_DIV_DEPTH {
+        return Err(ValidationError::TooDeep {
+            container,
+            max_depth: MAX_DIV_DEPTH,
+        });
+    }
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     //! Unit tests for document-wide validation invariants.
@@ -170,8 +203,8 @@ mod tests {
 
     use super::*;
     use crate::{
-        Certainty, CiteData, CiteStructure, EncodingDesc, FileDesc, Pointer, PointerList, RefsDecl,
-        Span, SpanGroup, StandOff, TeiBody, TeiHeader, TeiText, Utterance,
+        Certainty, CiteData, CiteStructure, Div, EncodingDesc, FileDesc, Pointer, PointerList,
+        RefsDecl, Span, SpanGroup, StandOff, TeiBody, TeiHeader, TeiText, Utterance,
     };
 
     #[fixture]
@@ -215,6 +248,34 @@ mod tests {
     fn accepts_resolved_stand_off_pointers(document_with_stand_off: TeiDocument) {
         let document = document_with_stand_off;
         assert!(validate_document(&document).is_ok());
+    }
+
+    #[test]
+    fn rejects_divisions_that_exceed_maximum_depth() {
+        let header = TeiHeader::new(
+            FileDesc::from_title_str("Too deep").unwrap_or_else(|error| panic!("title: {error}")),
+        );
+        let mut root_div = Div::new("section").unwrap_or_else(|error| panic!("root div: {error}"));
+
+        for _ in 0..MAX_DIV_DEPTH {
+            let mut wrapper =
+                Div::new("section").unwrap_or_else(|error| panic!("wrapper div: {error}"));
+            wrapper.push_div(root_div);
+            root_div = wrapper;
+        }
+
+        let document = TeiDocument::new(
+            header,
+            TeiText::new(TeiBody::new([BodyBlock::Div(root_div)])),
+        );
+
+        assert_eq!(
+            validate_document(&document),
+            Err(ValidationError::TooDeep {
+                container: "div",
+                max_depth: MAX_DIV_DEPTH,
+            })
+        );
     }
 
     #[rstest]

--- a/tei-core/src/validation/pointers.rs
+++ b/tei-core/src/validation/pointers.rs
@@ -47,6 +47,9 @@ fn validate_div_pointers(
             DivContent::List(list) => {
                 validate_list_pointers(list, known_ids)?;
             }
+            DivContent::Div(nested_div) => {
+                validate_div_pointers(nested_div, known_ids)?;
+            }
             DivContent::Paragraph(_) => {}
         }
     }

--- a/tei-core/src/validation/pointers.rs
+++ b/tei-core/src/validation/pointers.rs
@@ -4,7 +4,7 @@ use std::collections::HashSet;
 
 use crate::{BodyBlock, Pointer, PointerList, Span, SpanGroup, TeiDocument, Utterance};
 
-use super::ValidationError;
+use super::{MAX_DIV_DEPTH, ValidationError};
 
 pub(super) fn validate_internal_pointers(
     document: &TeiDocument,
@@ -25,7 +25,7 @@ fn validate_body_utterance_pointers(
                 validate_utterance_pointers(utterance, known_ids)?;
             }
             BodyBlock::Div(div) => {
-                validate_div_pointers(div, known_ids)?;
+                validate_div_pointers(div, known_ids, 0)?;
             }
             BodyBlock::Paragraph(_) => {}
         }
@@ -36,8 +36,11 @@ fn validate_body_utterance_pointers(
 fn validate_div_pointers(
     div: &crate::Div,
     known_ids: &HashSet<String>,
+    current_depth: usize,
 ) -> Result<(), ValidationError> {
     use crate::DivContent;
+
+    ensure_within_max_depth("div", current_depth)?;
 
     for content in div.content() {
         match content {
@@ -45,10 +48,10 @@ fn validate_div_pointers(
                 validate_utterance_pointers(utterance, known_ids)?;
             }
             DivContent::List(list) => {
-                validate_list_pointers(list, known_ids)?;
+                validate_list_pointers(list, known_ids, current_depth + 1)?;
             }
             DivContent::Div(nested_div) => {
-                validate_div_pointers(nested_div, known_ids)?;
+                validate_div_pointers(nested_div, known_ids, current_depth + 1)?;
             }
             DivContent::Paragraph(_) => {}
         }
@@ -59,7 +62,10 @@ fn validate_div_pointers(
 fn validate_list_pointers(
     list: &crate::List,
     known_ids: &HashSet<String>,
+    current_depth: usize,
 ) -> Result<(), ValidationError> {
+    ensure_within_max_depth("list", current_depth)?;
+
     for item in list.items() {
         validate_pointer_list("@corresp", item.corresp(), known_ids)?;
     }
@@ -163,5 +169,49 @@ pub(super) fn validate_pointer(
             attribute,
             pointer: pointer.as_str().to_owned(),
         })
+    }
+}
+
+const fn ensure_within_max_depth(
+    container: &'static str,
+    current_depth: usize,
+) -> Result<(), ValidationError> {
+    if current_depth >= MAX_DIV_DEPTH {
+        return Err(ValidationError::TooDeep {
+            container,
+            max_depth: MAX_DIV_DEPTH,
+        });
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    //! Unit tests for pointer traversal across nested structural containers.
+
+    use std::collections::HashSet;
+
+    use super::*;
+    use crate::Div;
+
+    #[test]
+    fn rejects_pointer_validation_when_divisions_exceed_maximum_depth() {
+        let mut root_div = Div::new("section").unwrap_or_else(|error| panic!("root div: {error}"));
+
+        for _ in 0..MAX_DIV_DEPTH {
+            let mut wrapper =
+                Div::new("section").unwrap_or_else(|error| panic!("wrapper div: {error}"));
+            wrapper.push_div(root_div);
+            root_div = wrapper;
+        }
+
+        assert_eq!(
+            validate_div_pointers(&root_div, &HashSet::new(), 0),
+            Err(ValidationError::TooDeep {
+                container: "div",
+                max_depth: MAX_DIV_DEPTH,
+            })
+        );
     }
 }

--- a/tei-core/tests/features/validation.feature
+++ b/tei-core/tests/features/validation.feature
@@ -87,3 +87,16 @@ Feature: TEI document validation
     When I add a division "show-notes" containing an item with corresp "#missing"
     And I validate the document
     Then validation fails with "internal pointer '#missing' in @corresp does not resolve"
+
+  Scenario: Rejecting duplicate xml:id values inside nested divisions
+    Given a TEI document titled "Night Vale"
+    When I add a nested division "segments" containing a child item with id "dup"
+    And I add a paragraph "Intro" with id "dup"
+    And I validate the document
+    Then validation fails with "duplicate xml:id 'dup'"
+
+  Scenario: Rejecting unresolved item corresp pointers inside nested divisions
+    Given a TEI document titled "Night Vale"
+    When I add a nested division "segments" containing a child item with corresp "#missing"
+    And I validate the document
+    Then validation fails with "internal pointer '#missing' in @corresp does not resolve"

--- a/tei-core/tests/validation_behaviour/mod.rs
+++ b/tei-core/tests/validation_behaviour/mod.rs
@@ -8,6 +8,7 @@ use tei_core::{Div, Item, List, P, ProfileDesc, TeiDocument, TeiError, Utterance
 use tei_test_helpers::expect_validated_state;
 
 mod stand_off;
+mod scenario_order;
 
 #[derive(Default)]
 struct ValidationState {
@@ -164,6 +165,48 @@ fn i_add_a_division_containing_an_item_with_corresp(
         div.push_list(list);
         let mut text = document.text().clone();
         text.body_mut().push_div(div);
+        Ok(TeiDocument::new(document.header().clone(), text))
+    })
+}
+
+#[when("I add a nested division \"{div_type}\" containing a child item with id \"{identifier}\"")]
+fn i_add_a_nested_division_containing_an_item_with_id(
+    #[from(validated_state)] state: &ValidationState,
+    div_type: String,
+    identifier: String,
+) -> Result<()> {
+    state.update_document(|document| {
+        let mut item = Item::from_text_segments(["Nested resource"]).context("item should be valid")?;
+        item.set_id(identifier.as_str())
+            .context("identifier should validate")?;
+        let list = List::new([item]).context("list should be valid")?;
+        let mut child = Div::new(div_type.as_str()).context("division should be valid")?;
+        child.push_list(list);
+        let mut parent = Div::new("parent").context("parent division should be valid")?;
+        parent.push_div(child);
+        let mut text = document.text().clone();
+        text.body_mut().push_div(parent);
+        Ok(TeiDocument::new(document.header().clone(), text))
+    })
+}
+
+#[when("I add a nested division \"{div_type}\" containing a child item with corresp \"{corresp}\"")]
+fn i_add_a_nested_division_containing_an_item_with_corresp(
+    #[from(validated_state)] state: &ValidationState,
+    div_type: String,
+    corresp: String,
+) -> Result<()> {
+    state.update_document(|document| {
+        let mut item =
+            Item::from_text_segments(["Nested reference"]).context("item should be valid")?;
+        item.set_corresp(tei_core::PointerList::new([corresp.as_str()])?);
+        let list = List::new([item]).context("list should be valid")?;
+        let mut child = Div::new(div_type.as_str()).context("division should be valid")?;
+        child.push_list(list);
+        let mut parent = Div::new("parent").context("parent division should be valid")?;
+        parent.push_div(child);
+        let mut text = document.text().clone();
+        text.body_mut().push_div(parent);
         Ok(TeiDocument::new(document.header().clone(), text))
     })
 }
@@ -330,38 +373,18 @@ fn rejects_unresolved_item_corresp_pointers_inside_divisions(
     expect_validated_state(validated_state, "validation");
 }
 
-#[test]
-fn validation_feature_scenario_order_matches_expectations() {
-    use gherkin::Feature;
+#[scenario(path = "tests/features/validation.feature", index = 12)]
+fn rejects_duplicate_identifiers_inside_nested_divisions(
+    #[from(validated_state)] _: ValidationState,
+    #[from(validated_state_result)] validated_state: Result<ValidationState>,
+) {
+    expect_validated_state(validated_state, "validation");
+}
 
-    let feature = Feature::parse_path(
-        "tests/features/validation.feature",
-        gherkin::GherkinEnv::default(),
-    )
-    .expect("parse validation.feature");
-    let names: Vec<&str> = feature
-        .scenarios
-        .iter()
-        .map(|scenario| scenario.name.as_str())
-        .collect();
-
-    let expected = [
-        "Accepting unique ids and declared speakers",
-        "Rejecting duplicate xml:id values",
-        "Rejecting header and body identifier clashes",
-        "Rejecting duplicate header annotation system identifiers",
-        "Rejecting unknown speaker references",
-        "Rejecting speakers when the cast is empty",
-        "Allowing speakers when the cast list is absent",
-        "Accepting stand-off spans that target existing utterances",
-        "Rejecting stand-off spans that target missing ids",
-        "Rejecting stand-off spans without anchors",
-        "Rejecting duplicate xml:id values inside divisions",
-        "Rejecting unresolved item corresp pointers inside divisions",
-    ];
-
-    assert_eq!(
-        names, expected,
-        "Scenario indices in validation_behaviour.rs must stay aligned with validation.feature"
-    );
+#[scenario(path = "tests/features/validation.feature", index = 13)]
+fn rejects_unresolved_item_corresp_pointers_inside_nested_divisions(
+    #[from(validated_state)] _: ValidationState,
+    #[from(validated_state_result)] validated_state: Result<ValidationState>,
+) {
+    expect_validated_state(validated_state, "validation");
 }

--- a/tei-core/tests/validation_behaviour/scenario_order.rs
+++ b/tei-core/tests/validation_behaviour/scenario_order.rs
@@ -1,0 +1,39 @@
+//! Guard test that keeps BDD scenario indices aligned with the feature file.
+
+#[test]
+fn validation_feature_scenario_order_matches_expectations() {
+    use gherkin::Feature;
+
+    let feature = Feature::parse_path(
+        "tests/features/validation.feature",
+        gherkin::GherkinEnv::default(),
+    )
+    .expect("parse validation.feature");
+    let names: Vec<&str> = feature
+        .scenarios
+        .iter()
+        .map(|scenario| scenario.name.as_str())
+        .collect();
+
+    let expected = [
+        "Accepting unique ids and declared speakers",
+        "Rejecting duplicate xml:id values",
+        "Rejecting header and body identifier clashes",
+        "Rejecting duplicate header annotation system identifiers",
+        "Rejecting unknown speaker references",
+        "Rejecting speakers when the cast is empty",
+        "Allowing speakers when the cast list is absent",
+        "Accepting stand-off spans that target existing utterances",
+        "Rejecting stand-off spans that target missing ids",
+        "Rejecting stand-off spans without anchors",
+        "Rejecting duplicate xml:id values inside divisions",
+        "Rejecting unresolved item corresp pointers inside divisions",
+        "Rejecting duplicate xml:id values inside nested divisions",
+        "Rejecting unresolved item corresp pointers inside nested divisions",
+    ];
+
+    assert_eq!(
+        names, expected,
+        "Scenario indices in validation_behaviour.rs must stay aligned with validation.feature"
+    );
+}

--- a/tei-py/python/structs.py
+++ b/tei-py/python/structs.py
@@ -166,7 +166,20 @@ class ListBlock(msgspec.Struct, tag="list", tag_field="type", omit_defaults=True
 
 
 class Head(msgspec.Struct, omit_defaults=True):
-    """Division heading attached to the start of a structural division."""
+    """Summary
+    -------
+    Division heading emitted at the start of a structural division.
+
+    Attributes
+    ----------
+    content : list[Inline]
+        Ordered inline nodes that make up the visible heading text.
+
+    Notes
+    -----
+    ``Head`` is used by :class:`DivBlock` for optional division titles and must
+    contain at least one inline node.
+    """
 
     content: list[Inline] = msgspec.field(default_factory=list)
 

--- a/tei-py/python/structs.py
+++ b/tei-py/python/structs.py
@@ -434,6 +434,10 @@ class DivEvent(msgspec.Struct, tag="div", tag_field="type", omit_defaults=True):
     ----------
     div_type : str
         Required TEI ``@type`` value describing the emitted division.
+    subtype : str | None
+        Optional TEI ``@subtype`` value refining ``div_type``.
+    head : Head | None
+        Optional heading emitted before the division's child blocks.
     content : list[DivContent]
         Division children collected before the event is yielded.
     xml_id : str | None
@@ -445,6 +449,8 @@ class DivEvent(msgspec.Struct, tag="div", tag_field="type", omit_defaults=True):
     assembled, mirroring :class:`DivBlock` in the event union.
     """
     div_type: str
+    subtype: str | None = None
+    head: Head | None = None
     content: list[DivContent] = msgspec.field(default_factory=list)
     xml_id: str | None = None
 

--- a/tei-py/python/structs.py
+++ b/tei-py/python/structs.py
@@ -460,6 +460,12 @@ class DivEvent(msgspec.Struct, tag="div", tag_field="type", omit_defaults=True):
     content: list[DivContent] = msgspec.field(default_factory=list)
     xml_id: str | None = None
 
+    def __post_init__(self) -> None:
+        if not self.div_type.strip():
+            raise ValueError("DivEvent.div_type must contain non-whitespace text")
+        if self.subtype is not None and not self.subtype.strip():
+            raise ValueError("DivEvent.subtype must contain non-whitespace text")
+
 
 Event: TypeAlias = (
     DocumentStart | HeaderEvent | ParagraphEvent | UtteranceEvent | DivEvent | DocumentEnd

--- a/tei-py/python/structs.py
+++ b/tei-py/python/structs.py
@@ -170,6 +170,10 @@ class Head(msgspec.Struct, omit_defaults=True):
 
     content: list[Inline] = msgspec.field(default_factory=list)
 
+    def __post_init__(self) -> None:
+        if not self.content:
+            raise ValueError("Head must contain at least one Inline node")
+
 
 class DivBlock(msgspec.Struct, tag="div", tag_field="type", omit_defaults=True):
     """Summary

--- a/tei-py/python/structs.py
+++ b/tei-py/python/structs.py
@@ -203,6 +203,8 @@ class DivBlock(msgspec.Struct, tag="div", tag_field="type", omit_defaults=True):
     def __post_init__(self) -> None:
         if not self.div_type.strip():
             raise ValueError("DivBlock.div_type must contain non-whitespace text")
+        if self.subtype is not None and not self.subtype.strip():
+            raise ValueError("DivBlock.subtype must contain non-whitespace text")
 
 
 DivContent: TypeAlias = TextBlock | ListBlock | DivBlock

--- a/tei-py/python/structs.py
+++ b/tei-py/python/structs.py
@@ -19,6 +19,7 @@ __all__ = [
     "Episode",
     "Event",
     "FileDesc",
+    "Head",
     "HeaderEvent",
     "Inline",
     "InlineHi",
@@ -164,7 +165,10 @@ class ListBlock(msgspec.Struct, tag="list", tag_field="type", omit_defaults=True
             raise ValueError("ListBlock must contain at least one Item")
 
 
-DivContent: TypeAlias = TextBlock | ListBlock
+class Head(msgspec.Struct, omit_defaults=True):
+    """Division heading attached to the start of a structural division."""
+
+    content: list[Inline] = msgspec.field(default_factory=list)
 
 
 class DivBlock(msgspec.Struct, tag="div", tag_field="type", omit_defaults=True):
@@ -176,6 +180,10 @@ class DivBlock(msgspec.Struct, tag="div", tag_field="type", omit_defaults=True):
     ----------
     div_type : str
         Required TEI ``@type`` value describing the division's role.
+    subtype : str | None
+        Optional TEI ``@subtype`` value refining ``div_type``.
+    head : Head | None
+        Optional heading emitted before the division's child blocks.
     content : list[DivContent]
         Ordered child blocks within the division.
     xml_id : str | None
@@ -187,12 +195,17 @@ class DivBlock(msgspec.Struct, tag="div", tag_field="type", omit_defaults=True):
     such as chaptered material or show notes.
     """
     div_type: str
+    subtype: str | None = None
+    head: Head | None = None
     content: list[DivContent] = msgspec.field(default_factory=list)
     xml_id: str | None = None
 
     def __post_init__(self) -> None:
         if not self.div_type.strip():
             raise ValueError("DivBlock.div_type must contain non-whitespace text")
+
+
+DivContent: TypeAlias = TextBlock | ListBlock | DivBlock
 
 
 BodyBlock: TypeAlias = TextBlock | DivBlock

--- a/tei-py/python/structs.py
+++ b/tei-py/python/structs.py
@@ -51,7 +51,22 @@ class InlineText(msgspec.Struct, tag="text", tag_field="type"):
 
 
 class InlineHi(msgspec.Struct, tag="hi", tag_field="type", omit_defaults=True):
-    """Emphasized inline span."""
+    """Summary
+    -------
+    Emphasized inline span within paragraph, utterance, or heading content.
+
+    ``InlineHi`` represents TEI ``<hi>`` markup and wraps nested inline nodes
+    with an optional rendering hint for downstream styling or interpretation.
+
+    Attributes
+    ----------
+    content : list[Inline]
+        Nested inline nodes contained by the emphasized span. Defaults to an
+        empty list.
+    rend : str | None
+        Optional TEI ``@rend`` hint describing the intended presentation or
+        emphasis style. Defaults to ``None``.
+    """
     content: list[Inline] = msgspec.field(default_factory=list)
     rend: str | None = None
 
@@ -202,14 +217,18 @@ class DivBlock(msgspec.Struct, tag="div", tag_field="type", omit_defaults=True):
     head : Head | None
         Optional heading emitted before the division's child blocks.
     content : list[DivContent]
-        Ordered child blocks within the division.
+        Ordered child blocks within the division, including paragraphs,
+        utterances, lists, and nested ``DivBlock`` instances via
+        ``DivContent``.
     xml_id : str | None
         Optional XML identifier for the division.
 
     Notes
     -----
-    ``DivBlock`` groups paragraphs, utterances, and lists into a named section
-    such as chaptered material or show notes.
+    ``DivBlock`` groups paragraphs, utterances, lists, and recursive child
+    divisions into a named section such as chaptered material or show notes.
+    ``DivContent = TextBlock | ListBlock | DivBlock`` means a division can nest
+    further structural divisions beneath itself.
     """
     div_type: str
     subtype: str | None = None

--- a/tei-py/python/structs.py
+++ b/tei-py/python/structs.py
@@ -3,7 +3,49 @@
 from __future__ import annotations
 
 import msgspec
-from typing import TypeAlias
+
+from _tei_rapporteur_structs_body import (
+    BodyBlock,
+    DivBlock,
+    DivContent,
+    Head,
+    Item,
+    Label,
+    ListBlock,
+    TeiBody,
+    TeiText,
+)
+from _tei_rapporteur_structs_common import (
+    AnnotationSystem,
+    CiteData,
+    CiteStructure,
+    EncodingDesc,
+    FileDesc,
+    Inline,
+    InlineHi,
+    InlinePause,
+    InlineText,
+    Paragraph,
+    ProfileDesc,
+    RefsDecl,
+    RevisionChange,
+    RevisionDesc,
+    Span,
+    SpanGroup,
+    StandOff,
+    TeiHeader,
+    TextBlock,
+    Utterance,
+)
+from _tei_rapporteur_structs_events import (
+    DivEvent,
+    DocumentEnd,
+    DocumentStart,
+    Event,
+    HeaderEvent,
+    ParagraphEvent,
+    UtteranceEvent,
+)
 
 __all__ = [
     "AnnotationSystem",
@@ -40,465 +82,53 @@ __all__ = [
     "TeiBody",
     "TeiHeader",
     "TeiText",
+    "TextBlock",
     "Utterance",
     "UtteranceEvent",
 ]
 
 
-class InlineText(msgspec.Struct, tag="text", tag_field="type"):
-    """Plain text inline node."""
-    value: str
-
-
-class InlineHi(msgspec.Struct, tag="hi", tag_field="type", omit_defaults=True):
-    """Summary
-    -------
-    Emphasized inline span within paragraph, utterance, or heading content.
-
-    ``InlineHi`` represents TEI ``<hi>`` markup and wraps nested inline nodes
-    with an optional rendering hint for downstream styling or interpretation.
-
-    Attributes
-    ----------
-    content : list[Inline]
-        Nested inline nodes contained by the emphasized span. Defaults to an
-        empty list.
-    rend : str | None
-        Optional TEI ``@rend`` hint describing the intended presentation or
-        emphasis style. Defaults to ``None``.
-    """
-    content: list[Inline] = msgspec.field(default_factory=list)
-    rend: str | None = None
-
-
-class InlinePause(msgspec.Struct, tag="pause", tag_field="type", omit_defaults=True):
-    """Pause marker corresponding to ``<pause/>``."""
-    dur: str | None = None
-    kind: str | None = None
-
-
-Inline: TypeAlias = InlineText | InlineHi | InlinePause
-
-
-class Paragraph(
-    msgspec.Struct, tag="paragraph", tag_field="type", omit_defaults=True
-):
-    """Paragraph block from the TEI body."""
-    xml_id: str | None = None
-    content: list[Inline] = msgspec.field(default_factory=list)
-
-
-class Utterance(
-    msgspec.Struct, tag="utterance", tag_field="type", omit_defaults=True
-):
-    """Spoken utterance with inline content and local provenance metadata."""
-    xml_id: str | None = None
-    speaker: str | None = None
-    content: list[Inline] = msgspec.field(default_factory=list)
-    n: str | None = None
-    source: list[str] = msgspec.field(default_factory=list)
-    resp: list[str] = msgspec.field(default_factory=list)
-    cert: str | None = None
-    corresp: list[str] = msgspec.field(default_factory=list)
-    ana: list[str] = msgspec.field(default_factory=list)
-
-
-TextBlock: TypeAlias = Paragraph | Utterance
-
-
-class Label(msgspec.Struct, omit_defaults=True):
-    """Summary
-    -------
-    Label prefix attached to a structured list item.
-
-    Attributes
-    ----------
-    content : list[Inline]
-        Inline nodes rendered before the item's main content.
-
-    Notes
-    -----
-    ``Label`` values typically hold numbering or short lead-in text and attach
-    to :class:`Item` via ``Item.label``.
-    """
-    content: list[Inline] = msgspec.field(default_factory=list)
-
-
-class Item(msgspec.Struct, omit_defaults=True):
-    """Summary
-    -------
-    Structured list item contained within a division list.
-
-    Attributes
-    ----------
-    content : list[Inline]
-        Inline body content for the list item.
-    xml_id : str | None
-        Optional XML identifier for pointer resolution and linking.
-    n : str | None
-        Optional display number or ordinal marker.
-    corresp : list[str]
-        TEI pointer targets associated with the item.
-    label : Label | None
-        Optional prefix rendered before ``content``.
-
-    Notes
-    -----
-    ``Item`` values belong inside :class:`ListBlock.items`. Use ``label`` for
-    visible prefixes such as numbered bullets while keeping the main text in
-    ``content``.
-    """
-    content: list[Inline] = msgspec.field(default_factory=list)
-    xml_id: str | None = None
-    n: str | None = None
-    corresp: list[str] = msgspec.field(default_factory=list)
-    label: Label | None = None
-
-
-class ListBlock(msgspec.Struct, tag="list", tag_field="type", omit_defaults=True):
-    """Summary
-    -------
-    List block nested inside a structural division.
-
-    Attributes
-    ----------
-    items : list[Item]
-        Ordered structured items contained by the list.
-    xml_id : str | None
-        Optional XML identifier for the list element.
-
-    Notes
-    -----
-    ``ListBlock`` values appear inside :class:`DivBlock.content` and group one
-    or more :class:`Item` values under a shared list container.
-    """
-    items: list[Item] = msgspec.field(default_factory=list)
-    xml_id: str | None = None
-
-    def __post_init__(self) -> None:
-        if not self.items:
-            raise ValueError("ListBlock must contain at least one Item")
-
-
-class Head(msgspec.Struct, omit_defaults=True):
-    """Summary
-    -------
-    Division heading emitted at the start of a structural division.
-
-    Attributes
-    ----------
-    content : list[Inline]
-        Ordered inline nodes that make up the visible heading text.
-
-    Notes
-    -----
-    ``Head`` is used by :class:`DivBlock` for optional division titles and must
-    contain at least one inline node.
-    """
-
-    content: list[Inline] = msgspec.field(default_factory=list)
-
-    def __post_init__(self) -> None:
-        if not self.content:
-            raise ValueError("Head must contain at least one Inline node")
-
-
-class DivBlock(msgspec.Struct, tag="div", tag_field="type", omit_defaults=True):
-    """Summary
-    -------
-    Structural division within the TEI body.
-
-    Attributes
-    ----------
-    div_type : str
-        Required TEI ``@type`` value describing the division's role.
-    subtype : str | None
-        Optional TEI ``@subtype`` value refining ``div_type``.
-    head : Head | None
-        Optional heading emitted before the division's child blocks.
-    content : list[DivContent]
-        Ordered child blocks within the division, including paragraphs,
-        utterances, lists, and nested ``DivBlock`` instances via
-        ``DivContent``.
-    xml_id : str | None
-        Optional XML identifier for the division.
-
-    Notes
-    -----
-    ``DivBlock`` groups paragraphs, utterances, lists, and recursive child
-    divisions into a named section such as chaptered material or show notes.
-    ``DivContent = TextBlock | ListBlock | DivBlock`` means a division can nest
-    further structural divisions beneath itself.
-    """
-    div_type: str
-    subtype: str | None = None
-    head: Head | None = None
-    content: list[DivContent] = msgspec.field(default_factory=list)
-    xml_id: str | None = None
-
-    def __post_init__(self) -> None:
-        if not self.div_type.strip():
-            raise ValueError("DivBlock.div_type must contain non-whitespace text")
-        if self.subtype is not None and not self.subtype.strip():
-            raise ValueError("DivBlock.subtype must contain non-whitespace text")
-
-
-DivContent: TypeAlias = TextBlock | ListBlock | DivBlock
-
-
-BodyBlock: TypeAlias = TextBlock | DivBlock
-
-
-class TeiBody(msgspec.Struct):
-    """Ordered TEI body content."""
-    blocks: list[BodyBlock] = msgspec.field(default_factory=list)
-
-
-class TeiText(msgspec.Struct):
-    """Text node containing the TEI body."""
-    body: TeiBody
-
-
-class RevisionChange(msgspec.Struct, kw_only=True, omit_defaults=True):
-    """Single revision note within ``<revisionDesc>``."""
-    description: str = msgspec.field(name="desc")
-    resp: str | None = msgspec.field(default=None, name="resp")
-
-
-class RevisionDesc(msgspec.Struct, kw_only=True, omit_defaults=True):
-    """Revision history container."""
-    changes: list[RevisionChange] = msgspec.field(
-        default_factory=list, name="change"
-    )
-
-
-class AnnotationSystem(msgspec.Struct, kw_only=True, omit_defaults=True):
-    """Metadata describing an annotation system."""
-    xml_id: str
-    desc: str | None = msgspec.field(default=None, name="desc")
-
-
-class CiteData(msgspec.Struct, kw_only=True, omit_defaults=True):
-    """Property extraction rule nested inside a citation declaration.
-
-    Attributes
-    ----------
-    property : str
-        Property name extracted from the matched TEI node.
-    use_expr : str | None
-        Optional TEI expression used to compute the property value.
-
-    Notes
-    -----
-    ``CiteData`` entries hang off :class:`CiteStructure` and describe which
-    citation metadata to pull from each matched node.
-    """
-    property: str
-    use_expr: str | None = None
-
-
-class CiteStructure(msgspec.Struct, kw_only=True, omit_defaults=True):
-    """Canonical citation declaration with optional nesting and extraction.
-
-    Attributes
-    ----------
-    match_expr : str
-        Required TEI match expression selecting the cited nodes.
-    unit : str | None
-        Optional human-facing citation unit label.
-    use_expr : str | None
-        Optional expression used when formatting the citation unit.
-    delim : str | None
-        Optional delimiter applied between nested citation units.
-    cite_data : list[CiteData]
-        Citation metadata extraction entries for the matched nodes.
-    cite_structures : list[CiteStructure]
-        Nested citation structures for hierarchical citation schemes.
-
-    Notes
-    -----
-    ``CiteStructure`` models the TEI ``<citeStructure>`` tree inside
-    :class:`RefsDecl`.
-    """
-    match_expr: str
-    unit: str | None = None
-    use_expr: str | None = None
-    delim: str | None = None
-    cite_data: list[CiteData] = msgspec.field(default_factory=list)
-    cite_structures: list[CiteStructure] = msgspec.field(default_factory=list)
-
-
-class RefsDecl(msgspec.Struct, kw_only=True, omit_defaults=True):
-    """Container for canonical citation declarations.
-
-    Attributes
-    ----------
-    cite_structures : list[CiteStructure]
-        Top-level citation declaration entries.
-
-    Notes
-    -----
-    ``RefsDecl`` belongs under :class:`EncodingDesc` and documents how callers
-    derive canonical references from the TEI body.
-    """
-    cite_structures: list[CiteStructure] = msgspec.field(default_factory=list)
-
-
-class EncodingDesc(msgspec.Struct, kw_only=True, omit_defaults=True):
-    """Encoding metadata for annotation systems and canonical citations.
-
-    Attributes
-    ----------
-    annotation_systems : list[AnnotationSystem]
-        Annotation-system declarations associated with the document.
-    refs_decl : RefsDecl | None
-        Optional canonical citation declaration tree.
-
-    Notes
-    -----
-    ``EncodingDesc`` combines annotation-system documentation with
-    :class:`RefsDecl` so projection consumers can inspect both in one place.
-    """
-    annotation_systems: list[AnnotationSystem] = msgspec.field(default_factory=list)
-    refs_decl: RefsDecl | None = None
-
-
-class ProfileDesc(msgspec.Struct, kw_only=True, omit_defaults=True):
-    """Audience and linguistic profile metadata."""
-    synopsis: str | None = None
-    speakers: list[str] = msgspec.field(default_factory=list, name="speakers")
-    languages: list[str] = msgspec.field(default_factory=list, name="languages")
-
-
-class FileDesc(msgspec.Struct, kw_only=True, omit_defaults=True):
-    """Bibliographic file description."""
-    title: str
-    series: str | None = None
-    synopsis: str | None = None
-
-
-class TeiHeader(msgspec.Struct, kw_only=True, omit_defaults=True):
-    """Aggregated TEI header sections."""
-
-    file_desc: FileDesc = msgspec.field(name="file_desc")
-    profile_desc: ProfileDesc | None = msgspec.field(
-        default=None, name="profile_desc"
-    )
-    encoding_desc: EncodingDesc | None = msgspec.field(
-        default=None, name="encoding_desc"
-    )
-    revision_desc: RevisionDesc | None = msgspec.field(
-        default=None, name="revision_desc"
-    )
-
-
-class Span(msgspec.Struct, kw_only=True, omit_defaults=True):
-    """Stand-off span with many-to-many or range-based targets."""
-    xml_id: str | None = None
-    target: list[str] = msgspec.field(default_factory=list)
-    from_ref: str | None = msgspec.field(default=None, name="from")
-    to_ref: str | None = msgspec.field(default=None, name="to")
-    source: list[str] = msgspec.field(default_factory=list)
-    resp: list[str] = msgspec.field(default_factory=list)
-    cert: str | None = None
-    corresp: list[str] = msgspec.field(default_factory=list)
-    ana: list[str] = msgspec.field(default_factory=list)
-
-
-class SpanGroup(msgspec.Struct, kw_only=True, omit_defaults=True):
-    """Logical stand-off grouping of related spans."""
-    xml_id: str | None = None
-    kind: str
-    resp: list[str] = msgspec.field(default_factory=list)
-    corresp: list[str] = msgspec.field(default_factory=list)
-    ana: list[str] = msgspec.field(default_factory=list)
-    spans: list[Span] = msgspec.field(default_factory=list)
-
-
-class StandOff(msgspec.Struct, kw_only=True, omit_defaults=True):
-    """Root stand-off annotation layer."""
-    span_groups: list[SpanGroup] = msgspec.field(default_factory=list)
-
-
 class Episode(msgspec.Struct, omit_defaults=True):
     """Top-level TEI document projection."""
+
     header: TeiHeader
     text: TeiText
     stand_off: StandOff | None = None
 
 
-class DocumentStart(msgspec.Struct, tag="document_start", tag_field="type"):
-    """Streaming event signalling the start of parsing."""
-
-
-class DocumentEnd(msgspec.Struct, tag="document_end", tag_field="type"):
-    """Streaming event signalling parsing completion."""
-
-
-class HeaderEvent(msgspec.Struct, tag="header", tag_field="type"):
-    """Streaming event carrying the parsed header."""
-    header: TeiHeader
-
-
-class ParagraphEvent(
-    msgspec.Struct, tag="paragraph", tag_field="type", omit_defaults=True
+for _name in (
+    "AnnotationSystem",
+    "CiteData",
+    "CiteStructure",
+    "DivBlock",
+    "DivEvent",
+    "DocumentEnd",
+    "DocumentStart",
+    "EncodingDesc",
+    "FileDesc",
+    "Head",
+    "HeaderEvent",
+    "InlineHi",
+    "InlinePause",
+    "InlineText",
+    "Item",
+    "Label",
+    "ListBlock",
+    "Paragraph",
+    "ParagraphEvent",
+    "ProfileDesc",
+    "RefsDecl",
+    "RevisionChange",
+    "RevisionDesc",
+    "Span",
+    "SpanGroup",
+    "StandOff",
+    "TeiBody",
+    "TeiHeader",
+    "TeiText",
+    "Utterance",
+    "UtteranceEvent",
 ):
-    """Streaming event carrying a paragraph."""
-    xml_id: str | None = None
-    content: list[Inline] = msgspec.field(default_factory=list)
+    globals()[_name].__module__ = __name__
 
-
-class UtteranceEvent(
-    msgspec.Struct, tag="utterance", tag_field="type", omit_defaults=True
-):
-    """Streaming event carrying an utterance."""
-    xml_id: str | None = None
-    speaker: str | None = None
-    content: list[Inline] = msgspec.field(default_factory=list)
-    n: str | None = None
-    source: list[str] = msgspec.field(default_factory=list)
-    resp: list[str] = msgspec.field(default_factory=list)
-    cert: str | None = None
-    corresp: list[str] = msgspec.field(default_factory=list)
-    ana: list[str] = msgspec.field(default_factory=list)
-
-
-class DivEvent(msgspec.Struct, tag="div", tag_field="type", omit_defaults=True):
-    """Summary
-    -------
-    Streaming event carrying an assembled division body block.
-
-    Attributes
-    ----------
-    div_type : str
-        Required TEI ``@type`` value describing the emitted division.
-    subtype : str | None
-        Optional TEI ``@subtype`` value refining ``div_type``.
-    head : Head | None
-        Optional heading emitted before the division's child blocks.
-    content : list[DivContent]
-        Division children collected before the event is yielded.
-    xml_id : str | None
-        Optional XML identifier preserved from the source document.
-
-    Notes
-    -----
-    ``DivEvent`` is emitted by streaming parses whenever a complete division is
-    assembled, mirroring :class:`DivBlock` in the event union.
-    """
-    div_type: str
-    subtype: str | None = None
-    head: Head | None = None
-    content: list[DivContent] = msgspec.field(default_factory=list)
-    xml_id: str | None = None
-
-    def __post_init__(self) -> None:
-        if not self.div_type.strip():
-            raise ValueError("DivEvent.div_type must contain non-whitespace text")
-        if self.subtype is not None and not self.subtype.strip():
-            raise ValueError("DivEvent.subtype must contain non-whitespace text")
-
-
-Event: TypeAlias = (
-    DocumentStart | HeaderEvent | ParagraphEvent | UtteranceEvent | DivEvent | DocumentEnd
-)
+del _name

--- a/tei-py/python/structs.py
+++ b/tei-py/python/structs.py
@@ -51,7 +51,7 @@ class InlineText(msgspec.Struct, tag="text", tag_field="type"):
 
 
 class InlineHi(msgspec.Struct, tag="hi", tag_field="type", omit_defaults=True):
-    """Emphasised inline span."""
+    """Emphasized inline span."""
     content: list[Inline] = msgspec.field(default_factory=list)
     rend: str | None = None
 

--- a/tei-py/python/structs_body.py
+++ b/tei-py/python/structs_body.py
@@ -1,0 +1,171 @@
+"""Body and structural-division projections for the embedded Python structs."""
+
+from __future__ import annotations
+
+import msgspec
+from typing import TypeAlias
+
+from _tei_rapporteur_structs_common import Inline, Paragraph, TextBlock, Utterance
+
+
+class Label(msgspec.Struct, omit_defaults=True):
+    """Summary
+    -------
+    Label prefix attached to a structured list item.
+
+    Attributes
+    ----------
+    content : list[Inline]
+        Inline nodes rendered before the item's main content.
+
+    Notes
+    -----
+    ``Label`` values typically hold numbering or short lead-in text and attach
+    to :class:`Item` via ``Item.label``.
+    """
+
+    content: list[Inline] = msgspec.field(default_factory=list)
+
+
+class Item(msgspec.Struct, omit_defaults=True):
+    """Summary
+    -------
+    Structured list item contained within a division list.
+
+    Attributes
+    ----------
+    content : list[Inline]
+        Inline body content for the list item.
+    xml_id : str | None
+        Optional XML identifier for pointer resolution and linking.
+    n : str | None
+        Optional display number or ordinal marker.
+    corresp : list[str]
+        TEI pointer targets associated with the item.
+    label : Label | None
+        Optional prefix rendered before ``content``.
+
+    Notes
+    -----
+    ``Item`` values belong inside :class:`ListBlock.items`. Use ``label`` for
+    visible prefixes such as numbered bullets while keeping the main text in
+    ``content``.
+    """
+
+    content: list[Inline] = msgspec.field(default_factory=list)
+    xml_id: str | None = None
+    n: str | None = None
+    corresp: list[str] = msgspec.field(default_factory=list)
+    label: Label | None = None
+
+
+class ListBlock(msgspec.Struct, tag="list", tag_field="type", omit_defaults=True):
+    """Summary
+    -------
+    List block nested inside a structural division.
+
+    Attributes
+    ----------
+    items : list[Item]
+        Ordered structured items contained by the list.
+    xml_id : str | None
+        Optional XML identifier for the list element.
+
+    Notes
+    -----
+    ``ListBlock`` values appear inside :class:`DivBlock.content` and group one
+    or more :class:`Item` values under a shared list container.
+    """
+
+    items: list[Item] = msgspec.field(default_factory=list)
+    xml_id: str | None = None
+
+    def __post_init__(self) -> None:
+        if not self.items:
+            raise ValueError("ListBlock must contain at least one Item")
+
+
+class Head(msgspec.Struct, omit_defaults=True):
+    """Summary
+    -------
+    Division heading emitted at the start of a structural division.
+
+    Attributes
+    ----------
+    content : list[Inline]
+        Ordered inline nodes that make up the visible heading text.
+
+    Notes
+    -----
+    ``Head`` is used by :class:`DivBlock` for optional division titles and must
+    contain at least one inline node.
+    """
+
+    content: list[Inline] = msgspec.field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        if not self.content:
+            raise ValueError("Head must contain at least one Inline node")
+
+
+def _validate_div_invariants(div_type: str, subtype: str | None) -> None:
+    if not div_type.strip():
+        raise ValueError("div_type must contain non-whitespace text")
+    if subtype is not None and not subtype.strip():
+        raise ValueError("subtype must contain non-whitespace text")
+
+
+class DivBlock(msgspec.Struct, tag="div", tag_field="type", omit_defaults=True):
+    """Summary
+    -------
+    Structural division within the TEI body.
+
+    Attributes
+    ----------
+    div_type : str
+        Required TEI ``@type`` value describing the division's role.
+    subtype : str | None
+        Optional TEI ``@subtype`` value refining ``div_type``.
+    head : Head | None
+        Optional heading emitted before the division's child blocks.
+    content : list[DivContent]
+        Ordered child blocks within the division, including paragraphs,
+        utterances, lists, and nested ``DivBlock`` instances via
+        ``DivContent``.
+    xml_id : str | None
+        Optional XML identifier for the division.
+
+    Notes
+    -----
+    ``DivBlock`` groups paragraphs, utterances, lists, and recursive child
+    divisions into a named section such as chaptered material or show notes.
+    ``DivContent = TextBlock | ListBlock | DivBlock`` means a division can nest
+    further structural divisions beneath itself.
+    """
+
+    div_type: str
+    subtype: str | None = None
+    head: Head | None = None
+    content: list[DivContent] = msgspec.field(default_factory=list)
+    xml_id: str | None = None
+
+    def __post_init__(self) -> None:
+        _validate_div_invariants(self.div_type, self.subtype)
+
+
+DivContent: TypeAlias = TextBlock | ListBlock | DivBlock
+
+
+BodyBlock: TypeAlias = TextBlock | DivBlock
+
+
+class TeiBody(msgspec.Struct):
+    """Ordered TEI body content."""
+
+    blocks: list[BodyBlock] = msgspec.field(default_factory=list)
+
+
+class TeiText(msgspec.Struct):
+    """Text node containing the TEI body."""
+
+    body: TeiBody

--- a/tei-py/python/structs_common.py
+++ b/tei-py/python/structs_common.py
@@ -7,7 +7,18 @@ from typing import TypeAlias
 
 
 class InlineText(msgspec.Struct, tag="text", tag_field="type"):
-    """Plain text inline node."""
+    """Summary
+    -------
+    Plain text inline node within TEI inline content.
+
+    ``InlineText`` represents unadorned character data inside paragraphs,
+    utterances, headings, and other inline-capable containers.
+
+    Attributes
+    ----------
+    value : str
+        Raw text content preserved from the source document.
+    """
 
     value: str
 
@@ -35,7 +46,22 @@ class InlineHi(msgspec.Struct, tag="hi", tag_field="type", omit_defaults=True):
 
 
 class InlinePause(msgspec.Struct, tag="pause", tag_field="type", omit_defaults=True):
-    """Pause marker corresponding to ``<pause/>``."""
+    """Summary
+    -------
+    Pause marker corresponding to TEI ``<pause/>`` inline markup.
+
+    ``InlinePause`` captures empty-element pause annotations that may carry
+    optional duration and pause-kind metadata.
+
+    Attributes
+    ----------
+    dur : str | None
+        Optional TEI ``@dur`` value describing the pause duration. Defaults to
+        ``None``.
+    kind : str | None
+        Optional TEI ``@type`` value classifying the pause. Defaults to
+        ``None``.
+    """
 
     dur: str | None = None
     kind: str | None = None
@@ -47,7 +73,21 @@ Inline: TypeAlias = InlineText | InlineHi | InlinePause
 class Paragraph(
     msgspec.Struct, tag="paragraph", tag_field="type", omit_defaults=True
 ):
-    """Paragraph block from the TEI body."""
+    """Summary
+    -------
+    Paragraph body block with inline TEI content.
+
+    ``Paragraph`` models a TEI ``<p>`` element after projection into the
+    Python structs layer.
+
+    Attributes
+    ----------
+    xml_id : str | None
+        Optional XML identifier preserved from ``@xml:id``. Defaults to
+        ``None``.
+    content : list[Inline]
+        Inline nodes contained by the paragraph. Defaults to an empty list.
+    """
 
     xml_id: str | None = None
     content: list[Inline] = msgspec.field(default_factory=list)
@@ -56,7 +96,38 @@ class Paragraph(
 class Utterance(
     msgspec.Struct, tag="utterance", tag_field="type", omit_defaults=True
 ):
-    """Spoken utterance with inline content and local provenance metadata."""
+    """Summary
+    -------
+    Spoken utterance with inline TEI content and local provenance metadata.
+
+    ``Utterance`` models a TEI ``<u>`` element together with the speech and
+    annotation attributes preserved by the projection layer.
+
+    Attributes
+    ----------
+    xml_id : str | None
+        Optional XML identifier preserved from ``@xml:id``. Defaults to
+        ``None``.
+    speaker : str | None
+        Optional speaker reference or label from ``@who``. Defaults to
+        ``None``.
+    content : list[Inline]
+        Inline nodes contained by the utterance. Defaults to an empty list.
+    n : str | None
+        Optional utterance number or label from ``@n``. Defaults to ``None``.
+    source : list[str]
+        Source pointers copied from ``@source``. Defaults to an empty list.
+    resp : list[str]
+        Responsibility pointers copied from ``@resp``. Defaults to an empty
+        list.
+    cert : str | None
+        Optional certainty value from ``@cert``. Defaults to ``None``.
+    corresp : list[str]
+        Correspondence pointers copied from ``@corresp``. Defaults to an empty
+        list.
+    ana : list[str]
+        Analysis pointers copied from ``@ana``. Defaults to an empty list.
+    """
 
     xml_id: str | None = None
     speaker: str | None = None
@@ -69,6 +140,20 @@ class Utterance(
     ana: list[str] = msgspec.field(default_factory=list)
 
 
+#: Summary
+#: -------
+#: Union of paragraph and utterance body blocks.
+#:
+#: ``TextBlock`` captures the textual body-block variants that may appear in
+#: the TEI body and inside division content.
+#:
+#: Attributes
+#: ----------
+#: Paragraph
+#:     Paragraph block with inline content and an optional XML identifier.
+#: Utterance
+#:     Spoken utterance block with inline content and local provenance
+#:     metadata.
 TextBlock: TypeAlias = Paragraph | Utterance
 
 
@@ -184,7 +269,24 @@ class EncodingDesc(msgspec.Struct, kw_only=True, omit_defaults=True):
 
 
 class ProfileDesc(msgspec.Struct, kw_only=True, omit_defaults=True):
-    """Audience and linguistic profile metadata."""
+    """Summary
+    -------
+    Audience and linguistic profile metadata from ``<profileDesc>``.
+
+    ``ProfileDesc`` collects high-level descriptive metadata about the
+    document's synopsis, speakers, and languages.
+
+    Attributes
+    ----------
+    synopsis : str | None
+        Optional descriptive synopsis for the document. Defaults to ``None``.
+    speakers : list[str]
+        Speaker identifiers or labels associated with the document. Defaults to
+        an empty list.
+    languages : list[str]
+        Language identifiers or labels associated with the document. Defaults
+        to an empty list.
+    """
 
     synopsis: str | None = None
     speakers: list[str] = msgspec.field(default_factory=list, name="speakers")
@@ -192,7 +294,23 @@ class ProfileDesc(msgspec.Struct, kw_only=True, omit_defaults=True):
 
 
 class FileDesc(msgspec.Struct, kw_only=True, omit_defaults=True):
-    """Bibliographic file description."""
+    """Summary
+    -------
+    Bibliographic file description from ``<fileDesc>``.
+
+    ``FileDesc`` captures the core title-level metadata required for the TEI
+    header projection.
+
+    Attributes
+    ----------
+    title : str
+        Document title.
+    series : str | None
+        Optional series title or grouping label. Defaults to ``None``.
+    synopsis : str | None
+        Optional descriptive synopsis associated with the file description.
+        Defaults to ``None``.
+    """
 
     title: str
     series: str | None = None
@@ -200,7 +318,26 @@ class FileDesc(msgspec.Struct, kw_only=True, omit_defaults=True):
 
 
 class TeiHeader(msgspec.Struct, kw_only=True, omit_defaults=True):
-    """Aggregated TEI header sections."""
+    """Summary
+    -------
+    Aggregated TEI header sections projected into Python structs.
+
+    ``TeiHeader`` groups the major TEI header subsections exposed by the
+    embedded Python API.
+
+    Attributes
+    ----------
+    file_desc : FileDesc
+        Required bibliographic file description for the document.
+    profile_desc : ProfileDesc | None
+        Optional audience and linguistic profile metadata. Defaults to
+        ``None``.
+    encoding_desc : EncodingDesc | None
+        Optional encoding metadata, including annotation systems and canonical
+        citations. Defaults to ``None``.
+    revision_desc : RevisionDesc | None
+        Optional revision-history metadata. Defaults to ``None``.
+    """
 
     file_desc: FileDesc = msgspec.field(name="file_desc")
     profile_desc: ProfileDesc | None = msgspec.field(
@@ -215,7 +352,39 @@ class TeiHeader(msgspec.Struct, kw_only=True, omit_defaults=True):
 
 
 class Span(msgspec.Struct, kw_only=True, omit_defaults=True):
-    """Stand-off span with many-to-many or range-based targets."""
+    """Summary
+    -------
+    Stand-off span with many-to-many or range-based targets.
+
+    ``Span`` models TEI stand-off annotation links that may target explicit
+    pointers, a from/to range, or both, together with provenance metadata.
+
+    Attributes
+    ----------
+    xml_id : str | None
+        Optional XML identifier preserved from ``@xml:id``. Defaults to
+        ``None``.
+    target : list[str]
+        Explicit target pointers copied from ``@target``. Defaults to an empty
+        list.
+    from_ref : str | None
+        Optional range start pointer copied from ``@from``. Defaults to
+        ``None``.
+    to_ref : str | None
+        Optional range end pointer copied from ``@to``. Defaults to ``None``.
+    source : list[str]
+        Source pointers copied from ``@source``. Defaults to an empty list.
+    resp : list[str]
+        Responsibility pointers copied from ``@resp``. Defaults to an empty
+        list.
+    cert : str | None
+        Optional certainty value copied from ``@cert``. Defaults to ``None``.
+    corresp : list[str]
+        Correspondence pointers copied from ``@corresp``. Defaults to an empty
+        list.
+    ana : list[str]
+        Analysis pointers copied from ``@ana``. Defaults to an empty list.
+    """
 
     xml_id: str | None = None
     target: list[str] = msgspec.field(default_factory=list)
@@ -229,7 +398,31 @@ class Span(msgspec.Struct, kw_only=True, omit_defaults=True):
 
 
 class SpanGroup(msgspec.Struct, kw_only=True, omit_defaults=True):
-    """Logical stand-off grouping of related spans."""
+    """Summary
+    -------
+    Logical stand-off grouping of related annotation spans.
+
+    ``SpanGroup`` corresponds to TEI ``<spanGrp>`` and groups related spans
+    under a shared kind and optional provenance metadata.
+
+    Attributes
+    ----------
+    xml_id : str | None
+        Optional XML identifier preserved from ``@xml:id``. Defaults to
+        ``None``.
+    kind : str
+        Required TEI ``@type`` value describing the span group.
+    resp : list[str]
+        Responsibility pointers copied from ``@resp``. Defaults to an empty
+        list.
+    corresp : list[str]
+        Correspondence pointers copied from ``@corresp``. Defaults to an empty
+        list.
+    ana : list[str]
+        Analysis pointers copied from ``@ana``. Defaults to an empty list.
+    spans : list[Span]
+        Span entries contained by the group. Defaults to an empty list.
+    """
 
     xml_id: str | None = None
     kind: str
@@ -240,6 +433,18 @@ class SpanGroup(msgspec.Struct, kw_only=True, omit_defaults=True):
 
 
 class StandOff(msgspec.Struct, kw_only=True, omit_defaults=True):
-    """Root stand-off annotation layer."""
+    """Summary
+    -------
+    Root stand-off annotation layer for TEI overlays.
+
+    ``StandOff`` collects the top-level stand-off annotation groups attached to
+    a TEI document.
+
+    Attributes
+    ----------
+    span_groups : list[SpanGroup]
+        Top-level span groups contained by the stand-off layer. Defaults to an
+        empty list.
+    """
 
     span_groups: list[SpanGroup] = msgspec.field(default_factory=list)

--- a/tei-py/python/structs_common.py
+++ b/tei-py/python/structs_common.py
@@ -1,0 +1,245 @@
+"""Common `msgspec.Struct` projections shared by Python body and event models."""
+
+from __future__ import annotations
+
+import msgspec
+from typing import TypeAlias
+
+
+class InlineText(msgspec.Struct, tag="text", tag_field="type"):
+    """Plain text inline node."""
+
+    value: str
+
+
+class InlineHi(msgspec.Struct, tag="hi", tag_field="type", omit_defaults=True):
+    """Summary
+    -------
+    Emphasized inline span within paragraph, utterance, or heading content.
+
+    ``InlineHi`` represents TEI ``<hi>`` markup and wraps nested inline nodes
+    with an optional rendering hint for downstream styling or interpretation.
+
+    Attributes
+    ----------
+    content : list[Inline]
+        Nested inline nodes contained by the emphasized span. Defaults to an
+        empty list.
+    rend : str | None
+        Optional TEI ``@rend`` hint describing the intended presentation or
+        emphasis style. Defaults to ``None``.
+    """
+
+    content: list[Inline] = msgspec.field(default_factory=list)
+    rend: str | None = None
+
+
+class InlinePause(msgspec.Struct, tag="pause", tag_field="type", omit_defaults=True):
+    """Pause marker corresponding to ``<pause/>``."""
+
+    dur: str | None = None
+    kind: str | None = None
+
+
+Inline: TypeAlias = InlineText | InlineHi | InlinePause
+
+
+class Paragraph(
+    msgspec.Struct, tag="paragraph", tag_field="type", omit_defaults=True
+):
+    """Paragraph block from the TEI body."""
+
+    xml_id: str | None = None
+    content: list[Inline] = msgspec.field(default_factory=list)
+
+
+class Utterance(
+    msgspec.Struct, tag="utterance", tag_field="type", omit_defaults=True
+):
+    """Spoken utterance with inline content and local provenance metadata."""
+
+    xml_id: str | None = None
+    speaker: str | None = None
+    content: list[Inline] = msgspec.field(default_factory=list)
+    n: str | None = None
+    source: list[str] = msgspec.field(default_factory=list)
+    resp: list[str] = msgspec.field(default_factory=list)
+    cert: str | None = None
+    corresp: list[str] = msgspec.field(default_factory=list)
+    ana: list[str] = msgspec.field(default_factory=list)
+
+
+TextBlock: TypeAlias = Paragraph | Utterance
+
+
+class RevisionChange(msgspec.Struct, kw_only=True, omit_defaults=True):
+    """Single revision note within ``<revisionDesc>``."""
+
+    description: str = msgspec.field(name="desc")
+    resp: str | None = msgspec.field(default=None, name="resp")
+
+
+class RevisionDesc(msgspec.Struct, kw_only=True, omit_defaults=True):
+    """Revision history container."""
+
+    changes: list[RevisionChange] = msgspec.field(
+        default_factory=list, name="change"
+    )
+
+
+class AnnotationSystem(msgspec.Struct, kw_only=True, omit_defaults=True):
+    """Metadata describing an annotation system."""
+
+    xml_id: str
+    desc: str | None = msgspec.field(default=None, name="desc")
+
+
+class CiteData(msgspec.Struct, kw_only=True, omit_defaults=True):
+    """Property extraction rule nested inside a citation declaration.
+
+    Attributes
+    ----------
+    property : str
+        Property name extracted from the matched TEI node.
+    use_expr : str | None
+        Optional TEI expression used to compute the property value.
+
+    Notes
+    -----
+    ``CiteData`` entries hang off :class:`CiteStructure` and describe which
+    citation metadata to pull from each matched node.
+    """
+
+    property: str
+    use_expr: str | None = None
+
+
+class CiteStructure(msgspec.Struct, kw_only=True, omit_defaults=True):
+    """Canonical citation declaration with optional nesting and extraction.
+
+    Attributes
+    ----------
+    match_expr : str
+        Required TEI match expression selecting the cited nodes.
+    unit : str | None
+        Optional human-facing citation unit label.
+    use_expr : str | None
+        Optional expression used when formatting the citation unit.
+    delim : str | None
+        Optional delimiter applied between nested citation units.
+    cite_data : list[CiteData]
+        Citation metadata extraction entries for the matched nodes.
+    cite_structures : list[CiteStructure]
+        Nested citation structures for hierarchical citation schemes.
+
+    Notes
+    -----
+    ``CiteStructure`` models the TEI ``<citeStructure>`` tree inside
+    :class:`RefsDecl`.
+    """
+
+    match_expr: str
+    unit: str | None = None
+    use_expr: str | None = None
+    delim: str | None = None
+    cite_data: list[CiteData] = msgspec.field(default_factory=list)
+    cite_structures: list[CiteStructure] = msgspec.field(default_factory=list)
+
+
+class RefsDecl(msgspec.Struct, kw_only=True, omit_defaults=True):
+    """Container for canonical citation declarations.
+
+    Attributes
+    ----------
+    cite_structures : list[CiteStructure]
+        Top-level citation declaration entries.
+
+    Notes
+    -----
+    ``RefsDecl`` belongs under :class:`EncodingDesc` and documents how callers
+    derive canonical references from the TEI body.
+    """
+
+    cite_structures: list[CiteStructure] = msgspec.field(default_factory=list)
+
+
+class EncodingDesc(msgspec.Struct, kw_only=True, omit_defaults=True):
+    """Encoding metadata for annotation systems and canonical citations.
+
+    Attributes
+    ----------
+    annotation_systems : list[AnnotationSystem]
+        Annotation-system declarations associated with the document.
+    refs_decl : RefsDecl | None
+        Optional canonical citation declaration tree.
+
+    Notes
+    -----
+    ``EncodingDesc`` combines annotation-system documentation with
+    :class:`RefsDecl` so projection consumers can inspect both in one place.
+    """
+
+    annotation_systems: list[AnnotationSystem] = msgspec.field(default_factory=list)
+    refs_decl: RefsDecl | None = None
+
+
+class ProfileDesc(msgspec.Struct, kw_only=True, omit_defaults=True):
+    """Audience and linguistic profile metadata."""
+
+    synopsis: str | None = None
+    speakers: list[str] = msgspec.field(default_factory=list, name="speakers")
+    languages: list[str] = msgspec.field(default_factory=list, name="languages")
+
+
+class FileDesc(msgspec.Struct, kw_only=True, omit_defaults=True):
+    """Bibliographic file description."""
+
+    title: str
+    series: str | None = None
+    synopsis: str | None = None
+
+
+class TeiHeader(msgspec.Struct, kw_only=True, omit_defaults=True):
+    """Aggregated TEI header sections."""
+
+    file_desc: FileDesc = msgspec.field(name="file_desc")
+    profile_desc: ProfileDesc | None = msgspec.field(
+        default=None, name="profile_desc"
+    )
+    encoding_desc: EncodingDesc | None = msgspec.field(
+        default=None, name="encoding_desc"
+    )
+    revision_desc: RevisionDesc | None = msgspec.field(
+        default=None, name="revision_desc"
+    )
+
+
+class Span(msgspec.Struct, kw_only=True, omit_defaults=True):
+    """Stand-off span with many-to-many or range-based targets."""
+
+    xml_id: str | None = None
+    target: list[str] = msgspec.field(default_factory=list)
+    from_ref: str | None = msgspec.field(default=None, name="from")
+    to_ref: str | None = msgspec.field(default=None, name="to")
+    source: list[str] = msgspec.field(default_factory=list)
+    resp: list[str] = msgspec.field(default_factory=list)
+    cert: str | None = None
+    corresp: list[str] = msgspec.field(default_factory=list)
+    ana: list[str] = msgspec.field(default_factory=list)
+
+
+class SpanGroup(msgspec.Struct, kw_only=True, omit_defaults=True):
+    """Logical stand-off grouping of related spans."""
+
+    xml_id: str | None = None
+    kind: str
+    resp: list[str] = msgspec.field(default_factory=list)
+    corresp: list[str] = msgspec.field(default_factory=list)
+    ana: list[str] = msgspec.field(default_factory=list)
+    spans: list[Span] = msgspec.field(default_factory=list)
+
+
+class StandOff(msgspec.Struct, kw_only=True, omit_defaults=True):
+    """Root stand-off annotation layer."""
+
+    span_groups: list[SpanGroup] = msgspec.field(default_factory=list)

--- a/tei-py/python/structs_events.py
+++ b/tei-py/python/structs_events.py
@@ -10,15 +10,46 @@ from _tei_rapporteur_structs_common import Inline, TeiHeader
 
 
 class DocumentStart(msgspec.Struct, tag="document_start", tag_field="type"):
-    """Streaming event signalling the start of parsing."""
+    """Summary
+    -------
+    Streaming event emitted when TEI document parsing begins.
+
+    ``DocumentStart`` marks the start of the event stream before any header or
+    body content has been yielded.
+
+    Attributes
+    ----------
+    This event has no public attributes.
+    """
 
 
 class DocumentEnd(msgspec.Struct, tag="document_end", tag_field="type"):
-    """Streaming event signalling parsing completion."""
+    """Summary
+    -------
+    Streaming event emitted when TEI document parsing completes.
+
+    ``DocumentEnd`` marks the end of the event stream after all header and body
+    content has been yielded.
+
+    Attributes
+    ----------
+    This event has no public attributes.
+    """
 
 
 class HeaderEvent(msgspec.Struct, tag="header", tag_field="type"):
-    """Streaming event carrying the parsed header."""
+    """Summary
+    -------
+    Streaming event carrying the parsed TEI header.
+
+    ``HeaderEvent`` is emitted once the parser has assembled the document
+    header.
+
+    Attributes
+    ----------
+    header : TeiHeader
+        Parsed TEI header projection for the current document.
+    """
 
     header: TeiHeader
 
@@ -26,7 +57,21 @@ class HeaderEvent(msgspec.Struct, tag="header", tag_field="type"):
 class ParagraphEvent(
     msgspec.Struct, tag="paragraph", tag_field="type", omit_defaults=True
 ):
-    """Streaming event carrying a paragraph."""
+    """Summary
+    -------
+    Streaming event carrying a paragraph body block.
+
+    ``ParagraphEvent`` is emitted whenever the parser completes a TEI ``<p>``
+    element in the body stream.
+
+    Attributes
+    ----------
+    xml_id : str | None
+        Optional XML identifier preserved from ``@xml:id``. Defaults to
+        ``None``.
+    content : list[Inline]
+        Inline nodes contained by the paragraph. Defaults to an empty list.
+    """
 
     xml_id: str | None = None
     content: list[Inline] = msgspec.field(default_factory=list)
@@ -35,7 +80,38 @@ class ParagraphEvent(
 class UtteranceEvent(
     msgspec.Struct, tag="utterance", tag_field="type", omit_defaults=True
 ):
-    """Streaming event carrying an utterance."""
+    """Summary
+    -------
+    Streaming event carrying an utterance body block.
+
+    ``UtteranceEvent`` is emitted whenever the parser completes a TEI ``<u>``
+    element in the body stream.
+
+    Attributes
+    ----------
+    xml_id : str | None
+        Optional XML identifier preserved from ``@xml:id``. Defaults to
+        ``None``.
+    speaker : str | None
+        Optional speaker reference or label from ``@who``. Defaults to
+        ``None``.
+    content : list[Inline]
+        Inline nodes contained by the utterance. Defaults to an empty list.
+    n : str | None
+        Optional utterance number or label from ``@n``. Defaults to ``None``.
+    source : list[str]
+        Source pointers copied from ``@source``. Defaults to an empty list.
+    resp : list[str]
+        Responsibility pointers copied from ``@resp``. Defaults to an empty
+        list.
+    cert : str | None
+        Optional certainty value from ``@cert``. Defaults to ``None``.
+    corresp : list[str]
+        Correspondence pointers copied from ``@corresp``. Defaults to an empty
+        list.
+    ana : list[str]
+        Analysis pointers copied from ``@ana``. Defaults to an empty list.
+    """
 
     xml_id: str | None = None
     speaker: str | None = None

--- a/tei-py/python/structs_events.py
+++ b/tei-py/python/structs_events.py
@@ -1,0 +1,92 @@
+"""Streaming-event projections for the embedded Python structs module."""
+
+from __future__ import annotations
+
+import msgspec
+from typing import TypeAlias
+
+from _tei_rapporteur_structs_body import DivContent, Head, _validate_div_invariants
+from _tei_rapporteur_structs_common import Inline, TeiHeader
+
+
+class DocumentStart(msgspec.Struct, tag="document_start", tag_field="type"):
+    """Streaming event signalling the start of parsing."""
+
+
+class DocumentEnd(msgspec.Struct, tag="document_end", tag_field="type"):
+    """Streaming event signalling parsing completion."""
+
+
+class HeaderEvent(msgspec.Struct, tag="header", tag_field="type"):
+    """Streaming event carrying the parsed header."""
+
+    header: TeiHeader
+
+
+class ParagraphEvent(
+    msgspec.Struct, tag="paragraph", tag_field="type", omit_defaults=True
+):
+    """Streaming event carrying a paragraph."""
+
+    xml_id: str | None = None
+    content: list[Inline] = msgspec.field(default_factory=list)
+
+
+class UtteranceEvent(
+    msgspec.Struct, tag="utterance", tag_field="type", omit_defaults=True
+):
+    """Streaming event carrying an utterance."""
+
+    xml_id: str | None = None
+    speaker: str | None = None
+    content: list[Inline] = msgspec.field(default_factory=list)
+    n: str | None = None
+    source: list[str] = msgspec.field(default_factory=list)
+    resp: list[str] = msgspec.field(default_factory=list)
+    cert: str | None = None
+    corresp: list[str] = msgspec.field(default_factory=list)
+    ana: list[str] = msgspec.field(default_factory=list)
+
+
+class DivEvent(msgspec.Struct, tag="div", tag_field="type", omit_defaults=True):
+    """Summary
+    -------
+    Streaming event carrying an assembled division body block.
+
+    Attributes
+    ----------
+    div_type : str
+        Required TEI ``@type`` value describing the emitted division.
+    subtype : str | None
+        Optional TEI ``@subtype`` value refining ``div_type``.
+    head : Head | None
+        Optional heading emitted before the division's child blocks.
+    content : list[DivContent]
+        Division children collected before the event is yielded.
+    xml_id : str | None
+        Optional XML identifier preserved from the source document.
+
+    Notes
+    -----
+    ``DivEvent`` is emitted by streaming parses whenever a complete division is
+    assembled, mirroring :class:`DivBlock` in the event union.
+    """
+
+    div_type: str
+    subtype: str | None = None
+    head: Head | None = None
+    content: list[DivContent] = msgspec.field(default_factory=list)
+    xml_id: str | None = None
+
+    def __post_init__(self) -> None:
+        _validate_div_invariants(self.div_type, self.subtype)
+
+
+Event: TypeAlias = (
+    DocumentStart
+    | HeaderEvent
+    | ParagraphEvent
+    | UtteranceEvent
+    | DivEvent
+    | DocumentEnd
+)

--- a/tei-py/src/projection/body.rs
+++ b/tei-py/src/projection/body.rs
@@ -5,11 +5,12 @@
 //! `Utterance`) appears in both [`BodyBlock`] and [`DivContent`] contexts.
 
 use tei_core::{
-    BodyBlock, Div, DivContent, Inline, Item, Label, List, P, PointerList, TeiError, Utterance,
+    BodyBlock, Div, DivContent, Head, Inline, Item, Label, List, P, PointerList, TeiError,
+    Utterance,
 };
 
 use super::{
-    PyBodyBlock, PyDivContent, PyInline, PyItem, PyLabel, apply_optional_pointer_list,
+    PyBodyBlock, PyDivContent, PyHead, PyInline, PyItem, PyLabel, apply_optional_pointer_list,
     certainty_from_option, certainty_to_string, pointer_list_to_vec,
 };
 
@@ -66,6 +67,8 @@ pub(crate) fn py_body_block_from_core(block: &BodyBlock) -> PyBodyBlock {
         BodyBlock::Div(div) => PyBodyBlock::Div {
             xml_id: div.id().map(|id| id.as_str().to_owned()),
             div_type: div.div_type().to_owned(),
+            subtype: div.subtype().map(str::to_owned),
+            head: div.head().map(py_head_from_core),
             content: div.content().iter().map(py_div_content_from_core).collect(),
         },
     }
@@ -112,6 +115,13 @@ pub(crate) fn py_div_content_from_core(div_content: &DivContent) -> PyDivContent
             xml_id: list.id().map(|id| id.as_str().to_owned()),
             items: list.items().iter().map(py_item_from_core).collect(),
         },
+        DivContent::Div(div) => PyDivContent::Div {
+            xml_id: div.id().map(|id| id.as_str().to_owned()),
+            div_type: div.div_type().to_owned(),
+            subtype: div.subtype().map(str::to_owned),
+            head: div.head().map(py_head_from_core),
+            content: div.content().iter().map(py_div_content_from_core).collect(),
+        },
     }
 }
 
@@ -133,6 +143,12 @@ fn py_label_from_core(label: &Label) -> PyLabel {
             .cloned()
             .map(PyInline::from)
             .collect(),
+    }
+}
+
+fn py_head_from_core(head: &Head) -> PyHead {
+    PyHead {
+        content: head.content().iter().cloned().map(PyInline::from).collect(),
     }
 }
 
@@ -169,6 +185,14 @@ pub(crate) struct UtteranceArgs {
     pub(crate) corresp: Vec<String>,
     pub(crate) ana: Vec<String>,
     pub(crate) content: Vec<PyInline>,
+}
+
+struct PyDivArgs {
+    xml_id: Option<String>,
+    div_type: String,
+    subtype: Option<String>,
+    head: Option<PyHead>,
+    content: Vec<PyDivContent>,
 }
 
 /// Builds a core utterance from Python projection fields.
@@ -221,25 +245,36 @@ pub(crate) fn core_block_from_py(block: PyBodyBlock) -> Result<BodyBlock, TeiErr
         PyBodyBlock::Div {
             xml_id,
             div_type,
+            subtype,
+            head,
             content,
-        } => div_block_from_py(xml_id, div_type, content),
+        } => div_block_from_py(PyDivArgs {
+            xml_id,
+            div_type,
+            subtype,
+            head,
+            content,
+        }),
     }
 }
 
-fn div_block_from_py(
-    xml_id: Option<String>,
-    div_type: String,
-    content: Vec<PyDivContent>,
-) -> Result<BodyBlock, TeiError> {
-    let mut div = Div::new(div_type)?;
-    if let Some(id) = xml_id {
+fn div_block_from_py(args: PyDivArgs) -> Result<BodyBlock, TeiError> {
+    let mut div = Div::new(args.div_type)?;
+    if let Some(id) = args.xml_id {
         div.set_id(id)?;
     }
-    for py_content in content {
+    if let Some(subtype_value) = args.subtype {
+        div.set_subtype(subtype_value)?;
+    }
+    if let Some(py_head) = args.head {
+        div.set_head(Head::new(inlines_from_py(py_head.content)?)?);
+    }
+    for py_content in args.content {
         match core_div_content_from_py(py_content)? {
             DivContent::Paragraph(p) => div.push_paragraph(p),
             DivContent::Utterance(u) => div.push_utterance(u),
             DivContent::List(l) => div.push_list(l),
+            DivContent::Div(nested_div) => div.push_div(nested_div),
         }
     }
     Ok(BodyBlock::Div(div))
@@ -282,7 +317,30 @@ fn core_div_content_from_py(py_content: PyDivContent) -> Result<DivContent, TeiE
             }
             Ok(DivContent::List(list))
         }
+        PyDivContent::Div {
+            xml_id,
+            div_type,
+            subtype,
+            head,
+            content,
+        } => div_content_div_from_py(PyDivArgs {
+            xml_id,
+            div_type,
+            subtype,
+            head,
+            content,
+        }),
     }
+}
+
+fn div_content_div_from_py(args: PyDivArgs) -> Result<DivContent, TeiError> {
+    let block = div_block_from_py(args)?;
+    let BodyBlock::Div(div) = block else {
+        return Err(TeiError::xml(
+            "internal error: division projection did not produce a div body block",
+        ));
+    };
+    Ok(DivContent::Div(div))
 }
 
 fn core_item_from_py(item: PyItem) -> Result<Item, TeiError> {

--- a/tei-py/src/projection/body.rs
+++ b/tei-py/src/projection/body.rs
@@ -248,17 +248,18 @@ pub(crate) fn core_block_from_py(block: PyBodyBlock) -> Result<BodyBlock, TeiErr
             subtype,
             head,
             content,
-        } => div_block_from_py(PyDivArgs {
+        } => build_div_from_py(PyDivArgs {
             xml_id,
             div_type,
             subtype,
             head,
             content,
-        }),
+        })
+        .map(BodyBlock::Div),
     }
 }
 
-fn div_block_from_py(args: PyDivArgs) -> Result<BodyBlock, TeiError> {
+fn build_div_from_py(args: PyDivArgs) -> Result<Div, TeiError> {
     let mut div = Div::new(args.div_type)?;
     if let Some(id) = args.xml_id {
         div.set_id(id)?;
@@ -277,7 +278,7 @@ fn div_block_from_py(args: PyDivArgs) -> Result<BodyBlock, TeiError> {
             DivContent::Div(nested_div) => div.push_div(nested_div),
         }
     }
-    Ok(BodyBlock::Div(div))
+    Ok(div)
 }
 
 fn core_div_content_from_py(py_content: PyDivContent) -> Result<DivContent, TeiError> {
@@ -323,24 +324,15 @@ fn core_div_content_from_py(py_content: PyDivContent) -> Result<DivContent, TeiE
             subtype,
             head,
             content,
-        } => div_content_div_from_py(PyDivArgs {
+        } => build_div_from_py(PyDivArgs {
             xml_id,
             div_type,
             subtype,
             head,
             content,
-        }),
+        })
+        .map(DivContent::Div),
     }
-}
-
-fn div_content_div_from_py(args: PyDivArgs) -> Result<DivContent, TeiError> {
-    let block = div_block_from_py(args)?;
-    let BodyBlock::Div(div) = block else {
-        return Err(TeiError::xml(
-            "internal error: division projection did not produce a div body block",
-        ));
-    };
-    Ok(DivContent::Div(div))
 }
 
 fn core_item_from_py(item: PyItem) -> Result<Item, TeiError> {

--- a/tei-py/src/projection/events.rs
+++ b/tei-py/src/projection/events.rs
@@ -66,6 +66,12 @@ pub(crate) enum PyEvent {
         xml_id: Option<String>,
         /// Required `@type` attribute.
         div_type: String,
+        /// Optional `@subtype` attribute.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        subtype: Option<String>,
+        /// Optional heading content.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        head: Option<super::PyHead>,
         /// Content of the division.
         content: Vec<PyDivContent>,
     },
@@ -120,10 +126,14 @@ fn py_event_from_body_block(block: &BodyBlock) -> PyEvent {
         PyBodyBlock::Div {
             xml_id,
             div_type,
+            subtype,
+            head,
             content,
         } => PyEvent::Div {
             xml_id,
             div_type,
+            subtype,
+            head,
             content,
         },
     }

--- a/tei-py/src/projection/mod.rs
+++ b/tei-py/src/projection/mod.rs
@@ -79,6 +79,10 @@ pub(crate) enum PyBodyBlock {
         #[serde(skip_serializing_if = "Option::is_none")]
         xml_id: Option<String>,
         div_type: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        subtype: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        head: Option<PyHead>,
         content: Vec<PyDivContent>,
     },
 }
@@ -119,6 +123,17 @@ pub(crate) enum PyDivContent {
         xml_id: Option<String>,
         items: Vec<PyItem>,
     },
+    #[serde(rename = "div")]
+    Div {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        xml_id: Option<String>,
+        div_type: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        subtype: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        head: Option<PyHead>,
+        content: Vec<PyDivContent>,
+    },
 }
 
 /// A list item projected for Python.
@@ -138,6 +153,12 @@ pub(crate) struct PyItem {
 /// A label prefix projected for Python.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub(crate) struct PyLabel {
+    content: Vec<PyInline>,
+}
+
+/// A division heading projected for Python.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub(crate) struct PyHead {
     content: Vec<PyInline>,
 }
 

--- a/tei-py/src/structs.rs
+++ b/tei-py/src/structs.rs
@@ -1,8 +1,9 @@
 //! Registers the Python `msgspec.Struct` projections as a submodule.
 //!
-//! The definitions live in `python/structs.py` so they remain readable while
-//! being embedded into the extension at compile time. The module is published
-//! as `tei_rapporteur.structs` when the extension loads.
+//! The public façade lives in `python/structs.py`, with supporting body and
+//! event definitions split into embedded helper modules so the Python sources
+//! stay readable while being compiled into the extension. The public module is
+//! published as `tei_rapporteur.structs` when the extension loads.
 
 use pyo3::{
     Bound, PyResult, Python,
@@ -13,43 +14,93 @@ use pyo3::{
 const STRUCTS_MODULE_NAME: &str = "tei_rapporteur.structs";
 const STRUCTS_FILENAME: &str = "tei_rapporteur/structs.py";
 const STRUCTS_SOURCE: &str = include_str!("../python/structs.py");
+const STRUCTS_COMMON_MODULE_NAME: &str = "_tei_rapporteur_structs_common";
+const STRUCTS_COMMON_FILENAME: &str = "tei_rapporteur/_structs_common.py";
+const STRUCTS_COMMON_SOURCE: &str = include_str!("../python/structs_common.py");
+const STRUCTS_BODY_MODULE_NAME: &str = "_tei_rapporteur_structs_body";
+const STRUCTS_BODY_FILENAME: &str = "tei_rapporteur/_structs_body.py";
+const STRUCTS_BODY_SOURCE: &str = include_str!("../python/structs_body.py");
+const STRUCTS_EVENTS_MODULE_NAME: &str = "_tei_rapporteur_structs_events";
+const STRUCTS_EVENTS_FILENAME: &str = "tei_rapporteur/_structs_events.py";
+const STRUCTS_EVENTS_SOURCE: &str = include_str!("../python/structs_events.py");
 
 /// Adds the `tei_rapporteur.structs` module to the parent extension module.
 pub fn register_structs_module(py: Python<'_>, parent: &Bound<'_, PyModule>) -> PyResult<()> {
-    #[expect(
-        deprecated,
-        reason = "PyO3 0.23 retains from_code_bound; new API requires CStr plumbing we avoid here"
-    )]
-    let structs = match PyModule::from_code_bound(
-        py,
-        STRUCTS_SOURCE,
-        STRUCTS_FILENAME,
-        STRUCTS_MODULE_NAME,
-    ) {
-        Ok(module) => module,
-        Err(error) => {
-            if error.is_instance_of::<PyModuleNotFoundError>(py) {
-                // msgspec missing; skip registering structs while leaving core bindings intact.
-                let warnings = py.import("warnings")?;
-                warnings.call_method1(
-                    "warn",
-                    (
-                        "msgspec not installed; tei_rapporteur.structs unavailable",
-                        py.get_type::<PyRuntimeWarning>(),
-                    ),
-                )?;
-                return Ok(());
-            }
-            return Err(error);
-        }
-    };
-
     let sys = py.import("sys")?;
     let modules = sys.getattr("modules")?;
+
+    let common = match module_from_source(
+        py,
+        STRUCTS_COMMON_SOURCE,
+        STRUCTS_COMMON_FILENAME,
+        STRUCTS_COMMON_MODULE_NAME,
+    ) {
+        Ok(module) => module,
+        Err(error) => return handle_structs_import_error(py, error),
+    };
+    modules.set_item(STRUCTS_COMMON_MODULE_NAME, &common)?;
+
+    let body = match module_from_source(
+        py,
+        STRUCTS_BODY_SOURCE,
+        STRUCTS_BODY_FILENAME,
+        STRUCTS_BODY_MODULE_NAME,
+    ) {
+        Ok(module) => module,
+        Err(error) => return handle_structs_import_error(py, error),
+    };
+    modules.set_item(STRUCTS_BODY_MODULE_NAME, &body)?;
+
+    let events = match module_from_source(
+        py,
+        STRUCTS_EVENTS_SOURCE,
+        STRUCTS_EVENTS_FILENAME,
+        STRUCTS_EVENTS_MODULE_NAME,
+    ) {
+        Ok(module) => module,
+        Err(error) => return handle_structs_import_error(py, error),
+    };
+    modules.set_item(STRUCTS_EVENTS_MODULE_NAME, &events)?;
+
+    let structs =
+        match module_from_source(py, STRUCTS_SOURCE, STRUCTS_FILENAME, STRUCTS_MODULE_NAME) {
+            Ok(module) => module,
+            Err(error) => return handle_structs_import_error(py, error),
+        };
     modules.set_item(STRUCTS_MODULE_NAME, &structs)?;
 
     parent.add_submodule(&structs)?;
     parent.setattr("structs", &structs)?;
 
     Ok(())
+}
+
+#[expect(
+    deprecated,
+    reason = "PyO3 0.23 retains from_code_bound; new API requires CStr plumbing we avoid here"
+)]
+fn module_from_source<'py>(
+    py: Python<'py>,
+    source: &str,
+    filename: &str,
+    module_name: &str,
+) -> PyResult<Bound<'py, PyModule>> {
+    PyModule::from_code_bound(py, source, filename, module_name)
+}
+
+fn handle_structs_import_error(py: Python<'_>, error: pyo3::PyErr) -> PyResult<()> {
+    if error.is_instance_of::<PyModuleNotFoundError>(py) {
+        // msgspec missing; skip registering structs while leaving core bindings intact.
+        let warnings = py.import("warnings")?;
+        warnings.call_method1(
+            "warn",
+            (
+                "msgspec not installed; tei_rapporteur.structs unavailable",
+                py.get_type::<PyRuntimeWarning>(),
+            ),
+        )?;
+        Ok(())
+    } else {
+        Err(error)
+    }
 }

--- a/tei-py/src/structs.rs
+++ b/tei-py/src/structs.rs
@@ -90,16 +90,26 @@ fn module_from_source<'py>(
 
 fn handle_structs_import_error(py: Python<'_>, error: pyo3::PyErr) -> PyResult<()> {
     if error.is_instance_of::<PyModuleNotFoundError>(py) {
-        // msgspec missing; skip registering structs while leaving core bindings intact.
-        let warnings = py.import("warnings")?;
-        warnings.call_method1(
-            "warn",
-            (
-                "msgspec not installed; tei_rapporteur.structs unavailable",
-                py.get_type::<PyRuntimeWarning>(),
-            ),
-        )?;
-        Ok(())
+        let missing_module = error
+            .value(py)
+            .getattr("name")
+            .ok()
+            .and_then(|name| name.extract::<String>().ok());
+
+        if missing_module.as_deref() == Some("msgspec") {
+            // msgspec missing; skip registering structs while leaving core bindings intact.
+            let warnings = py.import("warnings")?;
+            warnings.call_method1(
+                "warn",
+                (
+                    "msgspec not installed; tei_rapporteur.structs unavailable",
+                    py.get_type::<PyRuntimeWarning>(),
+                ),
+            )?;
+            Ok(())
+        } else {
+            Err(error)
+        }
     } else {
         Err(error)
     }

--- a/tei-py/src/tests/div_structs.rs
+++ b/tei-py/src/tests/div_structs.rs
@@ -6,7 +6,7 @@ use pyo3::{
     Python,
     types::{PyAnyMethods, PyDict, PyModule},
 };
-use tei_core::{BodyBlock, Div, Item, Label, List, TeiBody, TeiDocument, TeiHeader, TeiText};
+use tei_core::{BodyBlock, Div, Head, Item, Label, List, TeiBody, TeiDocument, TeiHeader, TeiText};
 use tei_serde::msgpack::to_vec_named;
 use tei_xml::streaming::TeiEvent;
 
@@ -16,6 +16,9 @@ fn division_fixture() -> TeiDocument {
     );
     let mut div = Div::new("show-notes").expect("div type should validate");
     div.set_id("div1").expect("id should validate");
+    div.set_subtype("chapter-markers")
+        .expect("subtype should validate");
+    div.set_head(Head::from_text("Chapter markers").expect("head should validate"));
     div.push_paragraph(
         tei_core::P::from_text_segments(["Further reading"]).expect("paragraph should validate"),
     );
@@ -23,10 +26,34 @@ fn division_fixture() -> TeiDocument {
     let mut item = Item::from_text_segments(["Transcript"]).expect("item should validate");
     item.set_label(Label::from_text("1.").expect("label should validate"));
     let list = List::new([item]).expect("list should validate");
-    div.push_list(list);
+    let mut child = Div::new("segment").expect("child div type should validate");
+    child
+        .set_subtype("guest-bio")
+        .expect("child subtype should validate");
+    child.set_head(Head::from_text("Guest bios").expect("child head should validate"));
+    child.push_list(list);
+    div.push_div(child);
 
     let text = TeiText::new(TeiBody::new([BodyBlock::Div(div)]));
     TeiDocument::new(header, text)
+}
+
+fn text_value(any: &pyo3::Bound<'_, pyo3::PyAny>, attr: &str) -> String {
+    any.getattr(attr)
+        .unwrap_or_else(|error| panic!("{attr} should exist: {error}"))
+        .extract()
+        .unwrap_or_else(|error| panic!("{attr} should be a string: {error}"))
+}
+
+fn first_text_content(any: &pyo3::Bound<'_, pyo3::PyAny>) -> String {
+    any.getattr("content")
+        .expect("content should exist")
+        .get_item(0)
+        .expect("first content item should exist")
+        .getattr("value")
+        .expect("text inline should expose value")
+        .extract()
+        .expect("content value should be a string")
 }
 
 #[test]
@@ -74,31 +101,29 @@ fn episode_struct_decodes_div_blocks() {
             "first block should be a structs.DivBlock instance"
         );
 
-        let div_type: String = first
-            .getattr("div_type")
-            .expect("DivBlock should expose div_type")
-            .extract()
-            .expect("div_type should be a string");
-        assert_eq!(div_type, "show-notes");
+        assert_eq!(text_value(&first, "div_type"), "show-notes");
+        assert_eq!(text_value(&first, "subtype"), "chapter-markers");
+        let head = first.getattr("head").expect("DivBlock should expose head");
+        assert_eq!(first_text_content(&head), "Chapter markers");
         let content = first
             .getattr("content")
             .expect("DivBlock should expose content");
-        let list_block = content.get_item(1).expect("list block should exist");
+        let nested_div = content.get_item(1).expect("nested div should exist");
+        let nested_head = nested_div
+            .getattr("head")
+            .expect("nested DivBlock should expose head");
+        assert_eq!(first_text_content(&nested_head), "Guest bios");
+        let list_block = nested_div
+            .getattr("content")
+            .expect("nested content")
+            .get_item(0)
+            .expect("list block should exist");
         let items = list_block
             .getattr("items")
             .expect("ListBlock should expose items");
         let item = items.get_item(0).expect("item should exist");
         let label = item.getattr("label").expect("Item should expose label");
-        let label_text: String = label
-            .getattr("content")
-            .expect("Label should expose content")
-            .get_item(0)
-            .expect("label content item")
-            .getattr("value")
-            .expect("text inline should expose value")
-            .extract()
-            .expect("label content value should be a string");
-        assert_eq!(label_text, "1.");
+        assert_eq!(first_text_content(&label), "1.");
     });
 }
 
@@ -140,5 +165,11 @@ fn streaming_div_events_decode_into_python_union() {
             .extract()
             .expect("div_type should be a string");
         assert_eq!(div_type, "show-notes");
+        let subtype: String = decoded_event
+            .getattr("subtype")
+            .expect("DivEvent should expose subtype")
+            .extract()
+            .expect("subtype should be a string");
+        assert_eq!(subtype, "chapter-markers");
     });
 }

--- a/tei-py/src/tests/div_structs.rs
+++ b/tei-py/src/tests/div_structs.rs
@@ -171,5 +171,9 @@ fn streaming_div_events_decode_into_python_union() {
             .extract()
             .expect("subtype should be a string");
         assert_eq!(subtype, "chapter-markers");
+        let head = decoded_event
+            .getattr("head")
+            .expect("DivEvent should expose head");
+        assert_eq!(first_text_content(&head), "Chapter markers");
     });
 }

--- a/tei-py/src/tests/head_structs.rs
+++ b/tei-py/src/tests/head_structs.rs
@@ -1,0 +1,50 @@
+//! Unit tests covering `Head` validation in the `tei_rapporteur.structs`
+//! submodule.
+
+use super::*;
+use crate::test_support::ensure_msgspec_installed;
+use pyo3::{
+    Py, Python,
+    exceptions::PyValueError,
+    types::{PyAnyMethods, PyModule},
+};
+use rstest::fixture;
+
+#[fixture]
+fn registered_module() -> Option<Py<PyModule>> {
+    Python::with_gil(|py| {
+        if ensure_msgspec_installed(py).is_err() {
+            return None;
+        }
+        let module = PyModule::new(py, "tei_rapporteur").expect("module allocation");
+        tei_rapporteur(py, &module).expect("module registration");
+        Some(module.unbind())
+    })
+}
+
+#[rstest::rstest]
+fn head_rejects_empty_content(#[from(registered_module)] module: Option<Py<PyModule>>) {
+    let Some(registered_module) = module else {
+        return;
+    };
+
+    Python::with_gil(|py| {
+        let bound_module = registered_module.bind(py);
+        let structs = bound_module.getattr("structs").expect("structs module");
+        let head_type = structs.getattr("Head").expect("Head class");
+
+        let error = head_type
+            .call0()
+            .expect_err("Head should reject empty content");
+        assert!(
+            error.is_instance_of::<PyValueError>(py),
+            "empty Head should raise ValueError"
+        );
+        assert!(
+            error
+                .to_string()
+                .contains("Head must contain at least one Inline node"),
+            "error should explain the Head invariant"
+        );
+    });
+}

--- a/tei-py/src/tests/mod.rs
+++ b/tei-py/src/tests/mod.rs
@@ -12,6 +12,7 @@ use tei_serde::serde_json::json;
 mod bindings_tests;
 mod dict;
 mod div_structs;
+mod head_structs;
 mod projection_tests;
 mod streaming;
 mod structs_tests;

--- a/tei-py/src/tests/projection_tests.rs
+++ b/tei-py/src/tests/projection_tests.rs
@@ -9,8 +9,8 @@ use crate::{
 use pyo3::{Python, types::PyAnyMethods, types::PyModule};
 use pyo3_serde::to_pyobject;
 use tei_core::{
-    BodyBlock, CiteData, CiteStructure, EncodingDesc, Inline, P, PointerList, RefsDecl, Span,
-    SpanGroup, StandOff, TeiDocument, Utterance,
+    BodyBlock, CiteData, CiteStructure, Div, EncodingDesc, Head, Inline, P, PointerList, RefsDecl,
+    Span, SpanGroup, StandOff, TeiDocument, Utterance,
 };
 use tei_serde::{json::Value, serde_json::json};
 use tei_xml::streaming::TeiEvent;
@@ -257,6 +257,55 @@ fn round_trip_document_to_value_and_back_preserves_core_structure() {
         "citeData entries should survive projection"
     );
     assert_round_tripped_paragraph(&original, &round_tripped);
+}
+
+#[test]
+fn nested_division_projection_round_trips_head_and_subtype() {
+    let mut child = Div::new("segment").expect("child div should validate");
+    child
+        .set_subtype("guest-bio")
+        .expect("child subtype should validate");
+    child.set_head(Head::from_text("Guest bios").expect("head should validate"));
+    child.push_paragraph(P::from_text_segments(["Profile"]).expect("paragraph should validate"));
+
+    let mut parent = Div::new("show-notes").expect("div should validate");
+    parent
+        .set_subtype("chapter-markers")
+        .expect("subtype should validate");
+    parent.set_head(Head::from_text("Chapter markers").expect("head should validate"));
+    parent.push_div(child);
+
+    let header = tei_core::TeiHeader::new(
+        tei_core::FileDesc::from_title_str("Bridgewater").expect("title should validate"),
+    );
+    let body = tei_core::TeiBody::new([BodyBlock::Div(parent)]);
+    let document = TeiDocument::new(header, tei_core::TeiText::new(body));
+
+    let value = document_to_value(&document).expect("projection should serialise to JSON");
+    assert_eq!(
+        value.pointer("/text/body/blocks/0/subtype"),
+        Some(&json!("chapter-markers"))
+    );
+    assert_eq!(
+        value.pointer("/text/body/blocks/0/head/content/0/value"),
+        Some(&json!("Chapter markers"))
+    );
+    assert_eq!(
+        value.pointer("/text/body/blocks/0/content/0/subtype"),
+        Some(&json!("guest-bio"))
+    );
+
+    let round_tripped =
+        value_to_document(&value).expect("projection JSON should round-trip into TeiDocument");
+    let Some(BodyBlock::Div(div)) = round_tripped.text().body().blocks().first() else {
+        panic!("expected div body block after round-trip");
+    };
+    assert_eq!(div.subtype(), Some("chapter-markers"));
+    assert!(div.head().is_some());
+    assert!(matches!(
+        div.content().first(),
+        Some(tei_core::DivContent::Div(_))
+    ));
 }
 
 #[test]

--- a/tei-py/src/tests/structs_tests.rs
+++ b/tei-py/src/tests/structs_tests.rs
@@ -61,7 +61,7 @@ _orig_meta_path_structs_test = list(sys.meta_path)
 class _BlockMsgspecImport:
     def find_spec(self, fullname, path=None, target=None):
         if fullname == "msgspec" or fullname.startswith("msgspec."):
-            raise ModuleNotFoundError("msgspec is blocked for test")
+            raise ModuleNotFoundError("msgspec is blocked for test", name="msgspec")
         return None
 
 _blocker_structs_test = _BlockMsgspecImport()

--- a/tei-py/src/tests/structs_tests.rs
+++ b/tei-py/src/tests/structs_tests.rs
@@ -217,7 +217,7 @@ fn div_block_rejects_blank_type(#[from(registered_module)] module: Option<Py<PyM
         assert!(
             error
                 .to_string()
-                .contains("DivBlock.div_type must contain non-whitespace text"),
+                .contains("div_type must contain non-whitespace text"),
             "error should explain the DivBlock invariant"
         );
     });

--- a/tei-serde/src/schema.rs
+++ b/tei-serde/src/schema.rs
@@ -40,6 +40,7 @@ fn apply_profile_constraints(schema: &mut Map<String, Value>) {
     apply_citation_constraints(definitions);
     apply_stand_off_constraints(definitions);
     apply_div_type_constraints(definitions);
+    apply_div_subtype_constraints(definitions);
 }
 
 fn apply_refs_decl_constraints(definitions: &mut Map<String, Value>) {
@@ -138,15 +139,20 @@ fn apply_stand_off_constraints(definitions: &mut Map<String, Value>) {
 }
 
 fn apply_div_type_constraints(definitions: &mut Map<String, Value>) {
-    let Some(div_type) = definitions
-        .get_mut("DivType")
-        .and_then(Value::as_object_mut)
-    else {
+    apply_non_empty_string_definition(definitions, "DivType");
+}
+
+fn apply_div_subtype_constraints(definitions: &mut Map<String, Value>) {
+    apply_non_empty_string_definition(definitions, "DivSubtype");
+}
+
+fn apply_non_empty_string_definition(definitions: &mut Map<String, Value>, name: &str) {
+    let Some(schema) = definitions.get_mut(name).and_then(Value::as_object_mut) else {
         return;
     };
-    // Enforce non-empty, non-whitespace validation matching the Rust newtype
-    div_type.insert("minLength".to_owned(), Value::from(1));
-    div_type.insert("pattern".to_owned(), Value::String("\\S".to_owned()));
+    // Enforce non-empty, non-whitespace validation matching the Rust newtypes.
+    schema.insert("minLength".to_owned(), Value::from(1));
+    schema.insert("pattern".to_owned(), Value::String("\\S".to_owned()));
 }
 
 fn set_min_length(properties: &mut Map<String, Value>, name: &str, min_length: u64) {

--- a/tei-serde/src/schema.rs
+++ b/tei-serde/src/schema.rs
@@ -159,6 +159,9 @@ fn apply_head_constraints(definitions: &mut Map<String, Value>) {
     let Some(properties) = head.get_mut("properties").and_then(Value::as_object_mut) else {
         return;
     };
+    if let Some(value_schema) = properties.get_mut("$value").and_then(Value::as_object_mut) {
+        value_schema.remove("default");
+    }
     set_min_items(properties, "$value", 1);
 }
 

--- a/tei-serde/src/schema.rs
+++ b/tei-serde/src/schema.rs
@@ -41,6 +41,7 @@ fn apply_profile_constraints(schema: &mut Map<String, Value>) {
     apply_stand_off_constraints(definitions);
     apply_div_type_constraints(definitions);
     apply_div_subtype_constraints(definitions);
+    apply_head_constraints(definitions);
 }
 
 fn apply_refs_decl_constraints(definitions: &mut Map<String, Value>) {
@@ -144,6 +145,21 @@ fn apply_div_type_constraints(definitions: &mut Map<String, Value>) {
 
 fn apply_div_subtype_constraints(definitions: &mut Map<String, Value>) {
     apply_non_empty_string_definition(definitions, "DivSubtype");
+}
+
+fn apply_head_constraints(definitions: &mut Map<String, Value>) {
+    let Some(head) = definitions.get_mut("head").and_then(Value::as_object_mut) else {
+        return;
+    };
+    head.insert(
+        "required".to_owned(),
+        Value::Array(vec![Value::String("$value".to_owned())]),
+    );
+
+    let Some(properties) = head.get_mut("properties").and_then(Value::as_object_mut) else {
+        return;
+    };
+    set_min_items(properties, "$value", 1);
 }
 
 fn apply_non_empty_string_definition(definitions: &mut Map<String, Value>, name: &str) {

--- a/tei-serde/tests/arbitrary/text.rs
+++ b/tei-serde/tests/arbitrary/text.rs
@@ -19,7 +19,7 @@
 
 use proptest::prelude::*;
 use tei_core::{
-    BodyBlock, Div, DivContent, Inline, Item, Label, List, P, PointerList, TeiBody, TeiText,
+    BodyBlock, Div, DivContent, Head, Inline, Item, Label, List, P, PointerList, TeiBody, TeiText,
     Utterance,
 };
 
@@ -225,27 +225,60 @@ fn div_type_strategy() -> impl Strategy<Value = String> {
     ])
 }
 
-fn div_with_content_strategy<S>(content_strategy: S) -> impl Strategy<Value = Div>
+fn div_subtype_strategy() -> impl Strategy<Value = String> {
+    prop::sample::select(vec![
+        String::from("chapter-marker"),
+        String::from("guest-bio"),
+        String::from("sponsor-read"),
+        String::from("segment"),
+    ])
+}
+
+fn head_with_content_strategy<S>(content_strategy: S) -> impl Strategy<Value = Head>
+where
+    S: Strategy<Value = Vec<Inline>>,
+{
+    content_strategy.prop_map(|content| {
+        Head::new(content)
+            .unwrap_or_else(|error| panic!("generated head content should be valid: {error}"))
+    })
+}
+
+fn div_with_content_strategy<S, H>(
+    content_strategy: S,
+    head_strategy: H,
+) -> impl Strategy<Value = Div>
 where
     S: Strategy<Value = Vec<DivContent>>,
+    H: Strategy<Value = Head>,
 {
     (
         proptest::option::of(xml_id_strategy()),
         div_type_strategy(),
+        proptest::option::of(div_subtype_strategy()),
+        proptest::option::of(head_strategy),
         content_strategy,
     )
-        .prop_map(|(id, div_type, content)| {
+        .prop_map(|(id, div_type, subtype, head, content)| {
             let mut div = Div::new(div_type)
                 .unwrap_or_else(|error| panic!("generated div type should be valid: {error}"));
             if let Some(id_value) = id {
                 div.set_id(id_value)
                     .unwrap_or_else(|error| panic!("generated id should be valid: {error}"));
             }
+            if let Some(subtype_value) = subtype {
+                div.set_subtype(subtype_value)
+                    .unwrap_or_else(|error| panic!("generated subtype should be valid: {error}"));
+            }
+            if let Some(head_value) = head {
+                div.set_head(head_value);
+            }
             for child in content {
                 match child {
                     DivContent::Paragraph(paragraph_block) => div.push_paragraph(paragraph_block),
                     DivContent::Utterance(utterance_block) => div.push_utterance(utterance_block),
                     DivContent::List(list_block) => div.push_list(list_block),
+                    DivContent::Div(nested_div) => div.push_div(nested_div),
                 }
             }
             div
@@ -253,37 +286,64 @@ where
 }
 
 fn div_strategy() -> impl Strategy<Value = Div> {
-    let paragraph_content = paragraph_strategy().prop_map(DivContent::Paragraph);
-    let utterance_content = utterance_strategy().prop_map(DivContent::Utterance);
-    let list_content = list_with_item_strategy(item_with_content_strategy(
-        prop::collection::vec(inline_strategy(), 1..=5)
-            .prop_filter("item must have visible content", |v| has_visible_content(v)),
+    let head_strategy = head_with_content_strategy(
         prop::collection::vec(inline_strategy(), 1..=3)
-            .prop_filter("label must have visible content", |v| {
-                has_visible_content(v)
-            }),
-    ))
-    .prop_map(DivContent::List);
+            .prop_filter("head must have visible content", |v| has_visible_content(v)),
+    );
+    let leaf_content = prop_oneof![
+        paragraph_strategy().prop_map(DivContent::Paragraph),
+        utterance_strategy().prop_map(DivContent::Utterance),
+        list_with_item_strategy(item_with_content_strategy(
+            prop::collection::vec(inline_strategy(), 1..=5)
+                .prop_filter("item must have visible content", |v| has_visible_content(v)),
+            prop::collection::vec(inline_strategy(), 1..=3)
+                .prop_filter("label must have visible content", |v| has_visible_content(
+                    v
+                )),
+        ))
+        .prop_map(DivContent::List),
+    ];
+    let recursive_content = leaf_content.prop_recursive(3, 32, 4, |inner| {
+        div_with_content_strategy(
+            prop::collection::vec(inner, 0..=3),
+            head_with_content_strategy(
+                prop::collection::vec(inline_strategy(), 1..=3)
+                    .prop_filter("head must have visible content", |v| has_visible_content(v)),
+            ),
+        )
+        .prop_map(DivContent::Div)
+    });
 
-    div_with_content_strategy(prop::collection::vec(
-        prop_oneof![paragraph_content, utterance_content, list_content],
-        0..=4,
-    ))
+    div_with_content_strategy(
+        prop::collection::vec(recursive_content, 0..=4),
+        head_strategy,
+    )
 }
 
 fn text_only_div_strategy() -> impl Strategy<Value = Div> {
-    let paragraph_content = text_only_paragraph_strategy().prop_map(DivContent::Paragraph);
-    let utterance_content = text_only_utterance_strategy().prop_map(DivContent::Utterance);
-    let list_content = list_with_item_strategy(item_with_content_strategy(
-        text_only_inline_strategy().prop_map(|inline| vec![inline]),
-        text_only_inline_strategy().prop_map(|inline| vec![inline]),
-    ))
-    .prop_map(DivContent::List);
+    let head_strategy =
+        head_with_content_strategy(text_only_inline_strategy().prop_map(|inline| vec![inline]));
+    let leaf_content = prop_oneof![
+        text_only_paragraph_strategy().prop_map(DivContent::Paragraph),
+        text_only_utterance_strategy().prop_map(DivContent::Utterance),
+        list_with_item_strategy(item_with_content_strategy(
+            text_only_inline_strategy().prop_map(|inline| vec![inline]),
+            text_only_inline_strategy().prop_map(|inline| vec![inline]),
+        ))
+        .prop_map(DivContent::List),
+    ];
+    let recursive_content = leaf_content.prop_recursive(2, 24, 4, |inner| {
+        div_with_content_strategy(
+            prop::collection::vec(inner, 0..=3),
+            head_with_content_strategy(text_only_inline_strategy().prop_map(|inline| vec![inline])),
+        )
+        .prop_map(DivContent::Div)
+    });
 
-    div_with_content_strategy(prop::collection::vec(
-        prop_oneof![paragraph_content, utterance_content, list_content],
-        0..=4,
-    ))
+    div_with_content_strategy(
+        prop::collection::vec(recursive_content, 0..=4),
+        head_strategy,
+    )
 }
 
 #[cfg(test)]
@@ -293,6 +353,10 @@ mod tests {
 
     fn label_is_valid(label: &Label) -> bool {
         has_visible_content_slice(label.content())
+    }
+
+    fn head_is_valid(head: &Head) -> bool {
+        has_visible_content_slice(head.content())
     }
 
     fn item_is_valid(item: &Item) -> bool {
@@ -305,10 +369,15 @@ mod tests {
 
     fn div_is_valid(div: &Div) -> bool {
         !div.div_type().trim().is_empty()
+            && div
+                .subtype()
+                .is_none_or(|subtype| !subtype.trim().is_empty())
+            && div.head().is_none_or(head_is_valid)
             && div.content().iter().all(|content| match content {
                 DivContent::Paragraph(paragraph) => has_visible_content_slice(paragraph.content()),
                 DivContent::Utterance(utterance) => has_visible_content_slice(utterance.content()),
                 DivContent::List(list) => list_is_valid(list),
+                DivContent::Div(nested_div) => div_is_valid(nested_div),
             })
     }
 

--- a/tei-serde/tests/json_schema_behaviour.rs
+++ b/tei-serde/tests/json_schema_behaviour.rs
@@ -542,8 +542,8 @@ fn assert_instance_shape(instance: &serde_json::Value) -> Result<()> {
     ensure!(
         instance
             .pointer("/text/body/$value/0/div/@subtype")
-            .is_some_and(|subtype| !subtype.is_null()),
-        "serialized document should include the division subtype"
+            .is_some_and(|subtype| subtype == "chapter-markers"),
+        "serialized document should include the expected division subtype"
     );
     ensure!(
         instance
@@ -554,8 +554,8 @@ fn assert_instance_shape(instance: &serde_json::Value) -> Result<()> {
     ensure!(
         instance
             .pointer("/text/body/$value/0/div/$value/1/div/@subtype")
-            .is_some_and(|subtype| !subtype.is_null()),
-        "serialized document should include the nested division subtype"
+            .is_some_and(|subtype| subtype == "guest-bio"),
+        "serialized document should include the expected nested division subtype"
     );
     ensure!(
         instance

--- a/tei-serde/tests/json_schema_behaviour.rs
+++ b/tei-serde/tests/json_schema_behaviour.rs
@@ -541,9 +541,21 @@ fn assert_instance_shape(instance: &serde_json::Value) -> Result<()> {
     );
     ensure!(
         instance
+            .pointer("/text/body/$value/0/div/@subtype")
+            .is_some_and(|subtype| !subtype.is_null()),
+        "serialized document should include the division subtype"
+    );
+    ensure!(
+        instance
             .pointer("/text/body/$value/0/div/$value/1/div/head")
             .is_some_and(|head| !head.is_null()),
         "serialized document should include the nested division head"
+    );
+    ensure!(
+        instance
+            .pointer("/text/body/$value/0/div/$value/1/div/@subtype")
+            .is_some_and(|subtype| !subtype.is_null()),
+        "serialized document should include the nested division subtype"
     );
     ensure!(
         instance

--- a/tei-serde/tests/json_schema_behaviour.rs
+++ b/tei-serde/tests/json_schema_behaviour.rs
@@ -5,8 +5,8 @@ use rstest::fixture;
 use rstest_bdd_macros::{given, scenario, then, when};
 use std::cell::RefCell;
 use tei_core::{
-    BodyBlock, Div, DivContent, Hi, Inline, Item, Label, List, P, TeiBody, TeiDocument, TeiHeader,
-    TeiText,
+    BodyBlock, Div, DivContent, Head, Hi, Inline, Item, Label, List, P, TeiBody, TeiDocument,
+    TeiHeader, TeiText, Utterance,
 };
 use tei_test_helpers::expect_validated_state;
 
@@ -345,13 +345,34 @@ fn structural_document() -> TeiDocument {
         Label::from_text("1.").unwrap_or_else(|error| panic!("label should validate: {error}")),
     );
     let list = List::new([item]).unwrap_or_else(|error| panic!("list should validate: {error}"));
+    let mut child =
+        Div::new("segment").unwrap_or_else(|error| panic!("child div should validate: {error}"));
+    child
+        .set_subtype("guest-bio")
+        .unwrap_or_else(|error| panic!("child subtype should validate: {error}"));
+    child.set_head(
+        Head::from_text("Guest bios")
+            .unwrap_or_else(|error| panic!("head should validate: {error}")),
+    );
+    child.push_utterance(
+        Utterance::from_text_segments(Some("host"), ["Meet our guest"])
+            .unwrap_or_else(|error| panic!("utterance should validate: {error}")),
+    );
+    child.push_list(list);
+
     let mut div =
         Div::new("show-notes").unwrap_or_else(|error| panic!("div should validate: {error}"));
+    div.set_subtype("chapter-markers")
+        .unwrap_or_else(|error| panic!("subtype should validate: {error}"));
+    div.set_head(
+        Head::from_text("Chapter markers")
+            .unwrap_or_else(|error| panic!("head should validate: {error}")),
+    );
     div.push_paragraph(
         P::from_text_segments(["Intro"])
             .unwrap_or_else(|error| panic!("paragraph should validate: {error}")),
     );
-    div.push_list(list);
+    div.push_div(child);
 
     TeiDocument::new(
         TeiHeader::new(
@@ -381,8 +402,41 @@ fn schema_has_variant(
         })
 }
 
+fn schema_property_references(
+    schema: &serde_json::Value,
+    property_path: &str,
+    expected_ref_suffix: &str,
+) -> bool {
+    let Some(property) = schema.pointer(property_path) else {
+        return false;
+    };
+
+    property
+        .get("$ref")
+        .and_then(serde_json::Value::as_str)
+        .is_some_and(|reference| reference.ends_with(expected_ref_suffix))
+        || property
+            .get("anyOf")
+            .and_then(serde_json::Value::as_array)
+            .is_some_and(|variants| {
+                variants.iter().any(|variant| {
+                    variant
+                        .get("$ref")
+                        .and_then(serde_json::Value::as_str)
+                        .is_some_and(|reference| reference.ends_with(expected_ref_suffix))
+                })
+            })
+}
+
 fn assert_schema_definitions(schema: &serde_json::Value) -> Result<()> {
-    for definition in ["/$defs/div", "/$defs/list", "/$defs/item", "/$defs/label"] {
+    for definition in [
+        "/$defs/div",
+        "/$defs/list",
+        "/$defs/item",
+        "/$defs/label",
+        "/$defs/head",
+        "/$defs/DivSubtype",
+    ] {
         ensure!(
             schema.pointer(definition).is_some(),
             "schema should define {definition}"
@@ -428,6 +482,27 @@ fn assert_schema_variants(schema: &serde_json::Value) -> Result<()> {
         ),
         "DivContent schema should include the `list` variant"
     );
+    ensure!(
+        schema_has_variant(
+            schema,
+            "/$defs/DivContent/oneOf",
+            "/properties/div/$ref",
+            "#/$defs/div",
+        ),
+        "DivContent schema should include the nested `div` variant"
+    );
+    ensure!(
+        schema_property_references(
+            schema,
+            "/$defs/div/properties/@subtype",
+            "#/$defs/DivSubtype"
+        ),
+        "div schema should reference DivSubtype for @subtype"
+    );
+    ensure!(
+        schema_property_references(schema, "/$defs/div/properties/head", "#/$defs/head"),
+        "div schema should reference head"
+    );
     Ok(())
 }
 
@@ -450,9 +525,9 @@ fn assert_document_shape(document: &TeiDocument) -> Result<()> {
                     BodyBlock::Div(division) => division.content().get(1),
                     _ => None,
                 }),
-            Some(DivContent::List(_))
+            Some(DivContent::Div(_))
         ),
-        "fixture division should contain a list"
+        "fixture division should contain a nested div"
     );
     Ok(())
 }
@@ -460,7 +535,19 @@ fn assert_document_shape(document: &TeiDocument) -> Result<()> {
 fn assert_instance_shape(instance: &serde_json::Value) -> Result<()> {
     ensure!(
         instance
-            .pointer("/text/body/$value/0/div/$value/1/list/$value/0/label")
+            .pointer("/text/body/$value/0/div/head")
+            .is_some_and(|head| !head.is_null()),
+        "serialized document should include the division head"
+    );
+    ensure!(
+        instance
+            .pointer("/text/body/$value/0/div/$value/1/div/head")
+            .is_some_and(|head| !head.is_null()),
+        "serialized document should include the nested division head"
+    );
+    ensure!(
+        instance
+            .pointer("/text/body/$value/0/div/$value/1/div/$value/1/list/$value/0/label")
             .is_some_and(|label| !label.is_null()),
         "serialized document should include the list item label"
     );

--- a/tei-xml/Cargo.toml
+++ b/tei-xml/Cargo.toml
@@ -16,6 +16,10 @@ streaming = []
 name = "generate-fixtures"
 path = "src/bin/generate-fixtures.rs"
 
+[[example]]
+name = "bench_memory"
+required-features = ["streaming"]
+
 [dependencies]
 tei-core = { path = "../tei-core" }
 quick-xml = { workspace = true }

--- a/tei-xml/resources/tei-episodic-profile.rng
+++ b/tei-xml/resources/tei-episodic-profile.rng
@@ -308,11 +308,20 @@
       <attribute name="type">
         <text/>
       </attribute>
+      <optional>
+        <attribute name="subtype">
+          <text/>
+        </attribute>
+      </optional>
+      <optional>
+        <ref name="head"/>
+      </optional>
       <zeroOrMore>
         <choice>
           <ref name="p"/>
           <ref name="u"/>
           <ref name="list"/>
+          <ref name="div"/>
         </choice>
       </zeroOrMore>
     </element>

--- a/tei-xml/resources/tei-episodic-profile.rng
+++ b/tei-xml/resources/tei-episodic-profile.rng
@@ -370,6 +370,12 @@
     </element>
   </define>
 
+  <define name="head">
+    <element name="head" ns="http://www.tei-c.org/ns/1.0">
+      <ref name="inlineContent"/>
+    </element>
+  </define>
+
   <define name="p">
     <element name="p" ns="http://www.tei-c.org/ns/1.0">
       <optional>

--- a/tei-xml/src/emitter.rs
+++ b/tei-xml/src/emitter.rs
@@ -151,7 +151,8 @@ fn emit_div(output: &mut String, div: &Div) {
     emit_attr(output, "type", div.div_type());
     emit_optional_attr(output, "subtype", div.subtype());
     emit_optional_xml_id(output, div.id());
-    emit_element_body(output, "div", div.is_empty(), |out| {
+    let is_empty = div.head().is_none() && div.content().is_empty();
+    emit_element_body(output, "div", is_empty, |out| {
         if let Some(head) = div.head() {
             emit_head(out, head);
         }

--- a/tei-xml/src/emitter.rs
+++ b/tei-xml/src/emitter.rs
@@ -11,8 +11,8 @@
 //! hand-writing the body portion using direct string construction.
 
 use tei_core::{
-    BodyBlock, Div, DivContent, Hi, Inline, Item, Label, List, P, Pause, TeiDocument, TeiError,
-    Utterance,
+    BodyBlock, Div, DivContent, Head, Hi, Inline, Item, Label, List, P, Pause, TeiDocument,
+    TeiError, Utterance,
 };
 
 use crate::escape_xml_text;
@@ -149,8 +149,12 @@ fn emit_utterance(output: &mut String, utterance: &Utterance) {
 fn emit_div(output: &mut String, div: &Div) {
     output.push_str("<div");
     emit_attr(output, "type", div.div_type());
+    emit_optional_attr(output, "subtype", div.subtype());
     emit_optional_xml_id(output, div.id());
     emit_element_body(output, "div", div.is_empty(), |out| {
+        if let Some(head) = div.head() {
+            emit_head(out, head);
+        }
         for child in div.content() {
             emit_div_content(out, child);
         }
@@ -163,6 +167,7 @@ fn emit_div_content(output: &mut String, content: &DivContent) {
         DivContent::Paragraph(p) => emit_paragraph(output, p),
         DivContent::Utterance(u) => emit_utterance(output, u),
         DivContent::List(list) => emit_list(output, list),
+        DivContent::Div(div) => emit_div(output, div),
     }
 }
 
@@ -196,6 +201,13 @@ fn emit_label(output: &mut String, label: &Label) {
     output.push_str("<label>");
     emit_inline_sequence(output, label.content());
     output.push_str("</label>");
+}
+
+/// Writes `<head>inline content</head>`.
+fn emit_head(output: &mut String, head: &Head) {
+    output.push_str("<head>");
+    emit_inline_sequence(output, head.content());
+    output.push_str("</head>");
 }
 
 /// Writes a sequence of inline nodes (text, hi, pause).

--- a/tei-xml/src/fixtures/bench.rs
+++ b/tei-xml/src/fixtures/bench.rs
@@ -122,10 +122,9 @@ pub fn generate_benchmark_document(config: &BenchFixtureConfig) -> Result<TeiDoc
 ///
 /// ```
 /// use tei_xml::fixtures::{BenchFixtureConfig, generate_benchmark_xml};
-/// use tei_xml::namespace::TEI_NAMESPACE;
 ///
 /// let xml = generate_benchmark_xml(&BenchFixtureConfig::SMALL)?;
-/// let expected = format!(r#"<TEI xmlns="{TEI_NAMESPACE}">"#);
+/// let expected = r#"<TEI xmlns="http://www.tei-c.org/ns/1.0">"#;
 /// assert!(xml.contains(&expected));
 /// # Ok::<(), tei_core::TeiError>(())
 /// ```

--- a/tei-xml/src/fixtures/mod.rs
+++ b/tei-xml/src/fixtures/mod.rs
@@ -19,9 +19,9 @@ mod bench;
 pub use bench::{BenchFixtureConfig, generate_benchmark_document, generate_benchmark_xml};
 
 use tei_core::{
-    AnnotationSystem, BodyBlock, CiteData, CiteStructure, Div, EncodingDesc, FileDesc, Item, Label,
-    List, P, PointerList, ProfileDesc, RefsDecl, RevisionChange, RevisionDesc, Span, SpanGroup,
-    StandOff, TeiBody, TeiDocument, TeiError, TeiHeader, TeiText, Utterance,
+    AnnotationSystem, BodyBlock, CiteData, CiteStructure, Div, EncodingDesc, FileDesc, Head, Item,
+    Label, List, P, PointerList, ProfileDesc, RefsDecl, RevisionChange, RevisionDesc, Span,
+    SpanGroup, StandOff, TeiBody, TeiDocument, TeiError, TeiHeader, TeiText, Utterance,
 };
 
 /// A function that builds a TEI document fixture.
@@ -207,6 +207,36 @@ pub fn document_with_div_and_list() -> Result<TeiDocument, TeiError> {
     Ok(TeiDocument::new(header, text))
 }
 
+/// Returns a document with nested divisions, headings, and subtypes.
+///
+/// # Errors
+///
+/// Returns [`TeiError`] when any component of the document cannot be
+/// constructed.
+pub fn document_with_nested_divs() -> Result<TeiDocument, TeiError> {
+    let file_desc = FileDesc::from_title_str("Nested Division Fixture")?;
+    let header = TeiHeader::new(file_desc);
+
+    let mut child = Div::new("segment")?;
+    child.set_id("ch1")?;
+    child.set_subtype("chapter-marker")?;
+    child.set_head(Head::from_text("Cold open")?);
+    child.push_utterance(Utterance::from_text_segments(
+        Some("host"),
+        ["Welcome back."],
+    )?);
+
+    let mut parent = Div::new("segment")?;
+    parent.set_id("seg1")?;
+    parent.set_subtype("chapter-markers")?;
+    parent.set_head(Head::from_text("Chapter markers")?);
+    parent.push_div(child);
+
+    let body = TeiBody::new([BodyBlock::Div(parent)]);
+    let text = TeiText::new(body);
+    Ok(TeiDocument::new(header, text))
+}
+
 /// Returns an iterator over all fixture builders with their names.
 ///
 /// This is used by the `generate-fixtures` binary to produce XML files.
@@ -218,6 +248,7 @@ pub fn fixture_builders() -> Vec<NamedFixture> {
         ("utterances", document_with_utterances),
         ("comprehensive", comprehensive_document),
         ("div-list", document_with_div_and_list),
+        ("nested-div", document_with_nested_divs),
     ]
 }
 
@@ -257,6 +288,12 @@ mod tests {
     #[test]
     fn document_with_div_and_list_builds_successfully() {
         let doc = document_with_div_and_list().expect("division fixture should build");
+        assert_eq!(doc.text().body().blocks().len(), 1);
+    }
+
+    #[test]
+    fn document_with_nested_divs_builds_successfully() {
+        let doc = document_with_nested_divs().expect("nested division fixture should build");
         assert_eq!(doc.text().body().blocks().len(), 1);
     }
 

--- a/tei-xml/src/streaming/content_handlers.rs
+++ b/tei-xml/src/streaming/content_handlers.rs
@@ -1,0 +1,146 @@
+//! Text, entity, CDATA, and empty-element handlers for the TEI pull parser.
+
+use std::io::BufRead;
+
+use quick_xml::events::{BytesRef, BytesStart, BytesText};
+
+use tei_core::{Inline, TeiError};
+
+use super::event::TeiEvent;
+use super::helpers::{append_empty_element, build_pause, extract_attribute, resolve_entity_ref};
+use super::parser::TeiPullParser;
+use super::state::ParserState;
+
+/// Content handlers (text, empty elements, CDATA, EOF).
+impl<R: BufRead> TeiPullParser<R> {
+    /// Handles a text event.
+    pub(super) fn handle_text(
+        &mut self,
+        text: &BytesText<'_>,
+    ) -> Result<Option<TeiEvent>, TeiError> {
+        match &mut self.state {
+            ParserState::InHeader { buffer, .. } => {
+                buffer.extend_from_slice(text.as_ref());
+                Ok(None)
+            }
+            ParserState::InParagraph { content, .. }
+            | ParserState::InUtterance { content, .. }
+            | ParserState::InEmphasis { content, .. }
+            | ParserState::InItem { content, .. }
+            | ParserState::InHead { content, .. }
+            | ParserState::InLabel { content, .. } => {
+                let unescaped = text.decode().map_err(|e| TeiError::xml(e.to_string()))?;
+                if !unescaped.is_empty() {
+                    content.push(Inline::Text(unescaped.into_owned()));
+                }
+                Ok(None)
+            }
+            _ => Ok(None),
+        }
+    }
+
+    /// Handles a general entity reference (`&name;` or `&#...;`).
+    pub(super) fn handle_general_ref(
+        &mut self,
+        reference: &BytesRef<'_>,
+    ) -> Result<Option<TeiEvent>, TeiError> {
+        match &mut self.state {
+            ParserState::InHeader { buffer, .. } => {
+                buffer.push(b'&');
+                buffer.extend_from_slice(reference.as_ref());
+                buffer.push(b';');
+                Ok(None)
+            }
+            ParserState::InParagraph { content, .. }
+            | ParserState::InUtterance { content, .. }
+            | ParserState::InEmphasis { content, .. }
+            | ParserState::InItem { content, .. }
+            | ParserState::InHead { content, .. }
+            | ParserState::InLabel { content, .. } => {
+                let resolved = resolve_entity_ref(reference)?;
+                content.push(Inline::Text(resolved));
+                Ok(None)
+            }
+            _ => Ok(None),
+        }
+    }
+
+    /// Handles an empty element event (self-closing tag).
+    pub(super) fn handle_empty_element(
+        &mut self,
+        element: &BytesStart<'_>,
+    ) -> Result<Option<TeiEvent>, TeiError> {
+        let name = element.local_name();
+        let name_bytes = name.as_ref();
+
+        match &mut self.state {
+            ParserState::InHeader { buffer, .. } => {
+                append_empty_element(buffer, element)?;
+                Ok(None)
+            }
+            ParserState::InParagraph { content, .. }
+            | ParserState::InUtterance { content, .. }
+            | ParserState::InEmphasis { content, .. }
+            | ParserState::InItem { content, .. }
+            | ParserState::InHead { content, .. }
+            | ParserState::InLabel { content, .. }
+                if name_bytes == b"pause" =>
+            {
+                let dur = extract_attribute(element, b"dur")?;
+                let pause_type = extract_attribute(element, b"type")?;
+                let pause = build_pause(dur, pause_type);
+                content.push(Inline::Pause(pause));
+                Ok(None)
+            }
+            ParserState::AwaitingBody if name_bytes == b"body" => {
+                self.state = ParserState::DocumentComplete;
+                Ok(Some(TeiEvent::DocumentEnd))
+            }
+            _ => Ok(None),
+        }
+    }
+
+    /// Handles CDATA sections.
+    pub(super) fn handle_cdata(
+        &mut self,
+        cdata: &quick_xml::events::BytesCData<'_>,
+    ) -> Result<Option<TeiEvent>, TeiError> {
+        match &mut self.state {
+            ParserState::InHeader { buffer, .. } => {
+                buffer.extend_from_slice(b"<![CDATA[");
+                buffer.extend_from_slice(cdata.as_ref());
+                buffer.extend_from_slice(b"]]>");
+                Ok(None)
+            }
+            ParserState::InParagraph { content, .. }
+            | ParserState::InUtterance { content, .. }
+            | ParserState::InEmphasis { content, .. }
+            | ParserState::InItem { content, .. }
+            | ParserState::InHead { content, .. }
+            | ParserState::InLabel { content, .. } => {
+                let text = std::str::from_utf8(cdata.as_ref())
+                    .map_err(|e| TeiError::xml(format!("invalid UTF-8 in CDATA: {e}")))?;
+                if !text.is_empty() {
+                    content.push(Inline::Text(text.to_owned()));
+                }
+                Ok(None)
+            }
+            _ => Ok(None),
+        }
+    }
+
+    /// Handles end-of-file.
+    pub(super) fn handle_eof(&mut self) -> Result<Option<TeiEvent>, TeiError> {
+        match &self.state {
+            ParserState::DocumentComplete => Ok(None),
+            ParserState::InBody | ParserState::AfterBody => {
+                self.state = ParserState::DocumentComplete;
+                Ok(Some(TeiEvent::DocumentEnd))
+            }
+            _ => {
+                self.state = ParserState::Error;
+                Err(TeiError::xml("unexpected end of document"))
+            }
+        }
+    }
+}

--- a/tei-xml/src/streaming/content_handlers.rs
+++ b/tei-xml/src/streaming/content_handlers.rs
@@ -95,9 +95,26 @@ impl<R: BufRead> TeiPullParser<R> {
                 content.push(Inline::Pause(pause));
                 Ok(None)
             }
+            ParserState::InParagraph { .. } => {
+                Err(unexpected_empty_element_error(name_bytes, "InParagraph"))
+            }
+            ParserState::InUtterance { .. } => {
+                Err(unexpected_empty_element_error(name_bytes, "InUtterance"))
+            }
+            ParserState::InEmphasis { .. } => {
+                Err(unexpected_empty_element_error(name_bytes, "InEmphasis"))
+            }
+            ParserState::InItem { .. } => Err(unexpected_empty_element_error(name_bytes, "InItem")),
+            ParserState::InHead { .. } => Err(unexpected_empty_element_error(name_bytes, "InHead")),
+            ParserState::InLabel { .. } => {
+                Err(unexpected_empty_element_error(name_bytes, "InLabel"))
+            }
             ParserState::AwaitingBody if name_bytes == b"body" => {
                 self.state = ParserState::DocumentComplete;
                 Ok(Some(TeiEvent::DocumentEnd))
+            }
+            ParserState::AwaitingBody => {
+                Err(unexpected_empty_element_error(name_bytes, "AwaitingBody"))
             }
             ParserState::InBody if name_bytes == b"div" => {
                 let div = Self::build_empty_div(element)?;
@@ -108,6 +125,8 @@ impl<R: BufRead> TeiPullParser<R> {
                 content.push(DivContent::Div(div));
                 Ok(None)
             }
+            ParserState::InBody => Err(unexpected_empty_element_error(name_bytes, "InBody")),
+            ParserState::InDiv { .. } => Err(unexpected_empty_element_error(name_bytes, "InDiv")),
             _ => Ok(None),
         }
     }
@@ -172,4 +191,11 @@ impl<R: BufRead> TeiPullParser<R> {
             Vec::new(),
         )
     }
+}
+
+fn unexpected_empty_element_error(name_bytes: &[u8], state_name: &str) -> TeiError {
+    let name = String::from_utf8_lossy(name_bytes);
+    TeiError::xml(format!(
+        "unexpected empty element <{name}/> while parsing state {state_name}"
+    ))
 }

--- a/tei-xml/src/streaming/content_handlers.rs
+++ b/tei-xml/src/streaming/content_handlers.rs
@@ -2,7 +2,7 @@
 
 use std::io::BufRead;
 
-use quick_xml::events::{BytesRef, BytesStart, BytesText};
+use quick_xml::events::{BytesCData, BytesRef, BytesStart, BytesText};
 
 use tei_core::{BodyBlock, DivContent, Inline, TeiError};
 
@@ -17,9 +17,10 @@ use super::state::ParserState;
 /// Content handlers (text, empty elements, CDATA, EOF).
 impl<R: BufRead> TeiPullParser<R> {
     /// Appends an `Inline::Text` node to whichever content buffer the current
-    /// parser state owns, if any.  Returns `Ok(None)` regardless of state so
-    /// callers can propagate it directly.  The `produce` closure is only
-    /// invoked when the state carries an inline-content buffer.
+    /// parser state owns, if any. Successful execution returns `Ok(None)`,
+    /// while any `Err` produced by the `produce` closure is propagated. The
+    /// `produce` closure is only invoked when the state carries an
+    /// inline-content buffer.
     fn push_text_inline(
         &mut self,
         produce: impl FnOnce() -> Result<String, TeiError>,
@@ -135,7 +136,7 @@ impl<R: BufRead> TeiPullParser<R> {
     /// Handles CDATA sections.
     pub(super) fn handle_cdata(
         &mut self,
-        cdata: &quick_xml::events::BytesCData<'_>,
+        cdata: &BytesCData<'_>,
     ) -> Result<Option<TeiEvent>, TeiError> {
         if let ParserState::InHeader { buffer, .. } = &mut self.state {
             buffer.extend_from_slice(b"<![CDATA[");

--- a/tei-xml/src/streaming/content_handlers.rs
+++ b/tei-xml/src/streaming/content_handlers.rs
@@ -16,30 +16,46 @@ use super::state::ParserState;
 
 /// Content handlers (text, empty elements, CDATA, EOF).
 impl<R: BufRead> TeiPullParser<R> {
-    /// Handles a text event.
-    pub(super) fn handle_text(
+    /// Appends an `Inline::Text` node to whichever content buffer the current
+    /// parser state owns, if any.  Returns `Ok(None)` regardless of state so
+    /// callers can propagate it directly.  The `produce` closure is only
+    /// invoked when the state carries an inline-content buffer.
+    fn push_text_inline(
         &mut self,
-        text: &BytesText<'_>,
+        produce: impl FnOnce() -> Result<String, TeiError>,
     ) -> Result<Option<TeiEvent>, TeiError> {
-        match &mut self.state {
-            ParserState::InHeader { buffer, .. } => {
-                buffer.extend_from_slice(text.as_ref());
-                Ok(None)
-            }
+        let maybe_content = match &mut self.state {
             ParserState::InParagraph { content, .. }
             | ParserState::InUtterance { content, .. }
             | ParserState::InEmphasis { content, .. }
             | ParserState::InItem { content, .. }
             | ParserState::InHead { content, .. }
-            | ParserState::InLabel { content, .. } => {
-                let unescaped = text.decode().map_err(|e| TeiError::xml(e.to_string()))?;
-                if !unescaped.is_empty() {
-                    content.push(Inline::Text(unescaped.into_owned()));
-                }
-                Ok(None)
+            | ParserState::InLabel { content, .. } => Some(content),
+            _ => None,
+        };
+        if let Some(content) = maybe_content {
+            let text = produce()?;
+            if !text.is_empty() {
+                content.push(Inline::Text(text));
             }
-            _ => Ok(None),
         }
+        Ok(None)
+    }
+
+    /// Handles a text event.
+    pub(super) fn handle_text(
+        &mut self,
+        text: &BytesText<'_>,
+    ) -> Result<Option<TeiEvent>, TeiError> {
+        if let ParserState::InHeader { buffer, .. } = &mut self.state {
+            buffer.extend_from_slice(text.as_ref());
+            return Ok(None);
+        }
+        self.push_text_inline(|| {
+            text.decode()
+                .map(std::borrow::Cow::into_owned)
+                .map_err(|e| TeiError::xml(e.to_string()))
+        })
     }
 
     /// Handles a general entity reference (`&name;` or `&#...;`).
@@ -47,25 +63,13 @@ impl<R: BufRead> TeiPullParser<R> {
         &mut self,
         reference: &BytesRef<'_>,
     ) -> Result<Option<TeiEvent>, TeiError> {
-        match &mut self.state {
-            ParserState::InHeader { buffer, .. } => {
-                buffer.push(b'&');
-                buffer.extend_from_slice(reference.as_ref());
-                buffer.push(b';');
-                Ok(None)
-            }
-            ParserState::InParagraph { content, .. }
-            | ParserState::InUtterance { content, .. }
-            | ParserState::InEmphasis { content, .. }
-            | ParserState::InItem { content, .. }
-            | ParserState::InHead { content, .. }
-            | ParserState::InLabel { content, .. } => {
-                let resolved = resolve_entity_ref(reference)?;
-                content.push(Inline::Text(resolved));
-                Ok(None)
-            }
-            _ => Ok(None),
+        if let ParserState::InHeader { buffer, .. } = &mut self.state {
+            buffer.push(b'&');
+            buffer.extend_from_slice(reference.as_ref());
+            buffer.push(b';');
+            return Ok(None);
         }
+        self.push_text_inline(|| resolve_entity_ref(reference))
     }
 
     /// Handles an empty element event (self-closing tag).
@@ -136,28 +140,17 @@ impl<R: BufRead> TeiPullParser<R> {
         &mut self,
         cdata: &quick_xml::events::BytesCData<'_>,
     ) -> Result<Option<TeiEvent>, TeiError> {
-        match &mut self.state {
-            ParserState::InHeader { buffer, .. } => {
-                buffer.extend_from_slice(b"<![CDATA[");
-                buffer.extend_from_slice(cdata.as_ref());
-                buffer.extend_from_slice(b"]]>");
-                Ok(None)
-            }
-            ParserState::InParagraph { content, .. }
-            | ParserState::InUtterance { content, .. }
-            | ParserState::InEmphasis { content, .. }
-            | ParserState::InItem { content, .. }
-            | ParserState::InHead { content, .. }
-            | ParserState::InLabel { content, .. } => {
-                let text = std::str::from_utf8(cdata.as_ref())
-                    .map_err(|e| TeiError::xml(format!("invalid UTF-8 in CDATA: {e}")))?;
-                if !text.is_empty() {
-                    content.push(Inline::Text(text.to_owned()));
-                }
-                Ok(None)
-            }
-            _ => Ok(None),
+        if let ParserState::InHeader { buffer, .. } = &mut self.state {
+            buffer.extend_from_slice(b"<![CDATA[");
+            buffer.extend_from_slice(cdata.as_ref());
+            buffer.extend_from_slice(b"]]>");
+            return Ok(None);
         }
+        self.push_text_inline(|| {
+            std::str::from_utf8(cdata.as_ref())
+                .map(std::borrow::ToOwned::to_owned)
+                .map_err(|e| TeiError::xml(format!("invalid UTF-8 in CDATA: {e}")))
+        })
     }
 
     /// Handles end-of-file.

--- a/tei-xml/src/streaming/content_handlers.rs
+++ b/tei-xml/src/streaming/content_handlers.rs
@@ -124,6 +124,10 @@ impl<R: BufRead> TeiPullParser<R> {
                 let div = Self::build_empty_div(element)?;
                 Ok(Some(TeiEvent::BodyBlock(BodyBlock::Div(div))))
             }
+            ParserState::InList { .. } if name_bytes == b"item" => {
+                Err(unexpected_empty_element_error(name_bytes, "InList"))
+            }
+            ParserState::InList { .. } => Err(unexpected_empty_element_error(name_bytes, "InList")),
             ParserState::InDiv { content, .. } if name_bytes == b"div" => {
                 let div = Self::build_empty_div(element)?;
                 content.push(DivContent::Div(div));
@@ -131,7 +135,13 @@ impl<R: BufRead> TeiPullParser<R> {
             }
             ParserState::InBody => Err(unexpected_empty_element_error(name_bytes, "InBody")),
             ParserState::InDiv { .. } => Err(unexpected_empty_element_error(name_bytes, "InDiv")),
-            _ => Ok(None),
+            ParserState::Initial
+            | ParserState::AwaitingRoot
+            | ParserState::AwaitingHeader
+            | ParserState::AwaitingText
+            | ParserState::AfterBody
+            | ParserState::DocumentComplete
+            | ParserState::Error => Ok(None),
         }
     }
 

--- a/tei-xml/src/streaming/content_handlers.rs
+++ b/tei-xml/src/streaming/content_handlers.rs
@@ -4,10 +4,13 @@ use std::io::BufRead;
 
 use quick_xml::events::{BytesRef, BytesStart, BytesText};
 
-use tei_core::{Inline, TeiError};
+use tei_core::{BodyBlock, DivContent, Inline, TeiError};
 
 use super::event::TeiEvent;
-use super::helpers::{append_empty_element, build_pause, extract_attribute, resolve_entity_ref};
+use super::helpers::{
+    RawDivAttrs, append_empty_element, build_div, build_pause, extract_attribute, extract_xml_id,
+    resolve_entity_ref,
+};
 use super::parser::TeiPullParser;
 use super::state::ParserState;
 
@@ -96,6 +99,15 @@ impl<R: BufRead> TeiPullParser<R> {
                 self.state = ParserState::DocumentComplete;
                 Ok(Some(TeiEvent::DocumentEnd))
             }
+            ParserState::InBody if name_bytes == b"div" => {
+                let div = Self::build_empty_div(element)?;
+                Ok(Some(TeiEvent::BodyBlock(BodyBlock::Div(div))))
+            }
+            ParserState::InDiv { content, .. } if name_bytes == b"div" => {
+                let div = Self::build_empty_div(element)?;
+                content.push(DivContent::Div(div));
+                Ok(None)
+            }
             _ => Ok(None),
         }
     }
@@ -142,5 +154,22 @@ impl<R: BufRead> TeiPullParser<R> {
                 Err(TeiError::xml("unexpected end of document"))
             }
         }
+    }
+
+    fn build_empty_div(element: &BytesStart<'_>) -> Result<tei_core::Div, TeiError> {
+        let div_type = extract_attribute(element, b"type")?
+            .ok_or_else(|| TeiError::xml("div element missing required @type attribute"))?;
+        let subtype = extract_attribute(element, b"subtype")?;
+        let id = extract_xml_id(element)?;
+
+        build_div(
+            RawDivAttrs {
+                div_type,
+                subtype,
+                id,
+                head: None,
+            },
+            Vec::new(),
+        )
     }
 }

--- a/tei-xml/src/streaming/content_handlers.rs
+++ b/tei-xml/src/streaming/content_handlers.rs
@@ -85,33 +85,23 @@ impl<R: BufRead> TeiPullParser<R> {
                 append_empty_element(buffer, element)?;
                 Ok(None)
             }
-            ParserState::InParagraph { content, .. }
-            | ParserState::InUtterance { content, .. }
-            | ParserState::InEmphasis { content, .. }
-            | ParserState::InItem { content, .. }
-            | ParserState::InHead { content, .. }
-            | ParserState::InLabel { content, .. }
-                if name_bytes == b"pause" =>
-            {
-                let dur = extract_attribute(element, b"dur")?;
-                let pause_type = extract_attribute(element, b"type")?;
-                let pause = build_pause(dur, pause_type);
-                content.push(Inline::Pause(pause));
-                Ok(None)
+            ParserState::InParagraph { content, .. } => {
+                handle_inline_empty_element(content, name_bytes, element, "InParagraph")
             }
-            ParserState::InParagraph { .. } => {
-                Err(unexpected_empty_element_error(name_bytes, "InParagraph"))
+            ParserState::InUtterance { content, .. } => {
+                handle_inline_empty_element(content, name_bytes, element, "InUtterance")
             }
-            ParserState::InUtterance { .. } => {
-                Err(unexpected_empty_element_error(name_bytes, "InUtterance"))
+            ParserState::InEmphasis { content, .. } => {
+                handle_inline_empty_element(content, name_bytes, element, "InEmphasis")
             }
-            ParserState::InEmphasis { .. } => {
-                Err(unexpected_empty_element_error(name_bytes, "InEmphasis"))
+            ParserState::InItem { content, .. } => {
+                handle_inline_empty_element(content, name_bytes, element, "InItem")
             }
-            ParserState::InItem { .. } => Err(unexpected_empty_element_error(name_bytes, "InItem")),
-            ParserState::InHead { .. } => Err(unexpected_empty_element_error(name_bytes, "InHead")),
-            ParserState::InLabel { .. } => {
-                Err(unexpected_empty_element_error(name_bytes, "InLabel"))
+            ParserState::InHead { content, .. } => {
+                handle_inline_empty_element(content, name_bytes, element, "InHead")
+            }
+            ParserState::InLabel { content, .. } => {
+                handle_inline_empty_element(content, name_bytes, element, "InLabel")
             }
             ParserState::AwaitingBody if name_bytes == b"body" => {
                 self.state = ParserState::DocumentComplete;
@@ -193,6 +183,22 @@ impl<R: BufRead> TeiPullParser<R> {
             },
             Vec::new(),
         )
+    }
+}
+
+fn handle_inline_empty_element(
+    content: &mut Vec<Inline>,
+    name_bytes: &[u8],
+    element: &BytesStart<'_>,
+    state_name: &str,
+) -> Result<Option<TeiEvent>, TeiError> {
+    if name_bytes == b"pause" {
+        let dur = extract_attribute(element, b"dur")?;
+        let pause_type = extract_attribute(element, b"type")?;
+        content.push(Inline::Pause(build_pause(dur, pause_type)));
+        Ok(None)
+    } else {
+        Err(unexpected_empty_element_error(name_bytes, state_name))
     }
 }
 

--- a/tei-xml/src/streaming/content_handlers.rs
+++ b/tei-xml/src/streaming/content_handlers.rs
@@ -114,9 +114,6 @@ impl<R: BufRead> TeiPullParser<R> {
                 let div = Self::build_empty_div(element)?;
                 Ok(Some(TeiEvent::BodyBlock(BodyBlock::Div(div))))
             }
-            ParserState::InList { .. } if name_bytes == b"item" => {
-                Err(unexpected_empty_element_error(name_bytes, "InList"))
-            }
             ParserState::InList { .. } => Err(unexpected_empty_element_error(name_bytes, "InList")),
             ParserState::InDiv { content, .. } if name_bytes == b"div" => {
                 let div = Self::build_empty_div(element)?;

--- a/tei-xml/src/streaming/finish_handlers.rs
+++ b/tei-xml/src/streaming/finish_handlers.rs
@@ -77,13 +77,13 @@ impl<R: BufRead> TeiPullParser<R> {
     fn finish_with_parent_restore<V>(
         &mut self,
         extract: impl FnOnce(&mut ParserState) -> Result<Option<(V, Box<ParserState>)>, TeiError>,
-        apply: impl FnOnce(V, &mut ParserState),
+        apply: impl FnOnce(V, &mut ParserState) -> Result<(), TeiError>,
     ) -> Result<Option<TeiEvent>, TeiError> {
         let Some((value, mut parent_state)) = extract(&mut self.state)? else {
             return Ok(None);
         };
 
-        apply(value, parent_state.as_mut());
+        apply(value, parent_state.as_mut())?;
         self.state = *parent_state;
         Ok(None)
     }
@@ -161,7 +161,11 @@ impl<R: BufRead> TeiPullParser<R> {
                 } = parent_state
                 {
                     *item_label = Some(label);
+                    return Ok(());
                 }
+                Err(TeiError::xml(
+                    "internal error: InLabel parent was not InItem",
+                ))
             },
         )
     }
@@ -187,7 +191,9 @@ impl<R: BufRead> TeiPullParser<R> {
             |head, parent_state| {
                 if let ParserState::InDiv { head: div_head, .. } = parent_state {
                     *div_head = Some(head);
+                    return Ok(());
                 }
+                Err(TeiError::xml("internal error: InHead parent was not InDiv"))
             },
         )
     }
@@ -225,7 +231,11 @@ impl<R: BufRead> TeiPullParser<R> {
             |item, parent_state| {
                 if let ParserState::InList { items, .. } = parent_state {
                     items.push(item);
+                    return Ok(());
                 }
+                Err(TeiError::xml(
+                    "internal error: InItem parent was not InList",
+                ))
             },
         )
     }
@@ -252,7 +262,9 @@ impl<R: BufRead> TeiPullParser<R> {
             |list, parent_state| {
                 if let ParserState::InDiv { content, .. } = parent_state {
                     content.push(DivContent::List(list));
+                    return Ok(());
                 }
+                Err(TeiError::xml("internal error: InList parent was not InDiv"))
             },
         )
     }

--- a/tei-xml/src/streaming/finish_handlers.rs
+++ b/tei-xml/src/streaming/finish_handlers.rs
@@ -18,9 +18,9 @@ fn combine_result_with_parent<V>(
     built: Result<V, TeiError>,
     parent: Option<Box<ParserState>>,
     context: &'static str,
-) -> Option<Result<(V, Box<ParserState>), TeiError>> {
+) -> Result<(V, Box<ParserState>), TeiError> {
     let parent_result = parent.ok_or_else(|| TeiError::xml(context));
-    Some(built.and_then(|v| parent_result.map(|p| (v, p))))
+    built.and_then(|v| parent_result.map(|p| (v, p)))
 }
 
 /// End element handlers.
@@ -150,11 +150,11 @@ impl<R: BufRead> TeiPullParser<R> {
                 else {
                     return None;
                 };
-                combine_result_with_parent(
+                Some(combine_result_with_parent(
                     build_label(std::mem::take(content)),
                     parent_item.take(),
                     "internal error: InLabel parent was None",
-                )
+                ))
             },
             |label, parent_state| {
                 if let ParserState::InItem {
@@ -178,11 +178,11 @@ impl<R: BufRead> TeiPullParser<R> {
                 else {
                     return None;
                 };
-                combine_result_with_parent(
+                Some(combine_result_with_parent(
                     build_head(std::mem::take(content)),
                     parent_div.take(),
                     "internal error: InHead parent was None",
-                )
+                ))
             },
             |head, parent_state| {
                 if let ParserState::InDiv { head: div_head, .. } = parent_state {
@@ -207,7 +207,7 @@ impl<R: BufRead> TeiPullParser<R> {
                 else {
                     return None;
                 };
-                combine_result_with_parent(
+                Some(combine_result_with_parent(
                     build_item(
                         RawItemAttrs {
                             id: item_id.take(),
@@ -219,7 +219,7 @@ impl<R: BufRead> TeiPullParser<R> {
                     ),
                     parent_list.take(),
                     "internal error: InItem parent was None",
-                )
+                ))
             },
             |item, parent_state| {
                 if let ParserState::InList { items, .. } = parent_state {
@@ -241,11 +241,11 @@ impl<R: BufRead> TeiPullParser<R> {
                 else {
                     return None;
                 };
-                combine_result_with_parent(
+                Some(combine_result_with_parent(
                     build_list(list_id.take(), std::mem::take(items)),
                     parent_div.take(),
                     "internal error: InList parent was None",
-                )
+                ))
             },
             |list, parent_state| {
                 if let ParserState::InDiv { content, .. } = parent_state {

--- a/tei-xml/src/streaming/finish_handlers.rs
+++ b/tei-xml/src/streaming/finish_handlers.rs
@@ -56,30 +56,60 @@ impl<R: BufRead> TeiPullParser<R> {
         Some(TeiEvent::BodyBlock(wrap_body(value)))
     }
 
-    /// Finishes parsing a paragraph and emits a `BodyBlock` event or pushes to div.
-    pub(super) fn finish_paragraph(&mut self) -> Result<Option<TeiEvent>, TeiError> {
-        if let ParserState::InParagraph { id, content } = &mut self.state {
-            let paragraph = build_paragraph(id.take(), std::mem::take(content))?;
-            return Ok(self.push_to_div_or_emit(
-                paragraph,
-                DivContent::Paragraph,
-                BodyBlock::Paragraph,
-            ));
+    fn finish_div_or_body_block<V>(
+        &mut self,
+        extract: impl FnOnce(&mut ParserState) -> Option<Result<V, TeiError>>,
+        wrap_div: fn(V) -> DivContent,
+        wrap_body: fn(V) -> BodyBlock,
+    ) -> Result<Option<TeiEvent>, TeiError> {
+        if let Some(result) = extract(&mut self.state) {
+            return Ok(self.push_to_div_or_emit(result?, wrap_div, wrap_body));
         }
         Ok(None)
     }
 
-    /// Finishes parsing an utterance and emits a `BodyBlock` event or pushes to div.
-    pub(super) fn finish_utterance(&mut self) -> Result<Option<TeiEvent>, TeiError> {
-        if let ParserState::InUtterance { attrs, content } = &mut self.state {
-            let utterance = build_utterance(std::mem::take(attrs), std::mem::take(content))?;
-            return Ok(self.push_to_div_or_emit(
-                utterance,
-                DivContent::Utterance,
-                BodyBlock::Utterance,
-            ));
+    fn finish_with_parent_restore<V>(
+        &mut self,
+        extract: impl FnOnce(&mut ParserState) -> Option<Result<(V, Box<ParserState>), TeiError>>,
+        apply: impl FnOnce(V, &mut ParserState),
+    ) -> Result<Option<TeiEvent>, TeiError> {
+        if let Some(result) = extract(&mut self.state) {
+            let (value, mut parent_state) = result?;
+            apply(value, parent_state.as_mut());
+            self.state = *parent_state;
         }
         Ok(None)
+    }
+
+    /// Finishes parsing a paragraph and emits a `BodyBlock` event or pushes to div.
+    pub(super) fn finish_paragraph(&mut self) -> Result<Option<TeiEvent>, TeiError> {
+        self.finish_div_or_body_block(
+            |state| {
+                let ParserState::InParagraph { id, content } = state else {
+                    return None;
+                };
+                Some(build_paragraph(id.take(), std::mem::take(content)))
+            },
+            DivContent::Paragraph,
+            BodyBlock::Paragraph,
+        )
+    }
+
+    /// Finishes parsing an utterance and emits a `BodyBlock` event or pushes to div.
+    pub(super) fn finish_utterance(&mut self) -> Result<Option<TeiEvent>, TeiError> {
+        self.finish_div_or_body_block(
+            |state| {
+                let ParserState::InUtterance { attrs, content } = state else {
+                    return None;
+                };
+                Some(build_utterance(
+                    std::mem::take(attrs),
+                    std::mem::take(content),
+                ))
+            },
+            DivContent::Utterance,
+            BodyBlock::Utterance,
+        )
     }
 
     /// Finishes parsing emphasis and pushes it to the parent state.
@@ -102,94 +132,130 @@ impl<R: BufRead> TeiPullParser<R> {
 
     /// Finishes parsing a label and stores it in the parent item.
     pub(super) fn finish_label(&mut self) -> Result<Option<TeiEvent>, TeiError> {
-        if let ParserState::InLabel {
-            parent_item,
-            content,
-        } = &mut self.state
-        {
-            let label = build_label(std::mem::take(content))?;
-            let Some(mut parent_state) = parent_item.take() else {
-                return Err(TeiError::xml("internal error: InLabel parent was None"));
-            };
-            if let ParserState::InItem {
-                label: item_label, ..
-            } = parent_state.as_mut()
-            {
-                *item_label = Some(label);
-            }
-            self.state = *parent_state;
-        }
-        Ok(None)
+        self.finish_with_parent_restore(
+            |state| {
+                let ParserState::InLabel {
+                    parent_item,
+                    content,
+                } = state
+                else {
+                    return None;
+                };
+                let built_label = build_label(std::mem::take(content));
+                let parent_state = parent_item
+                    .take()
+                    .ok_or_else(|| TeiError::xml("internal error: InLabel parent was None"));
+                Some(
+                    built_label
+                        .and_then(|label_value| parent_state.map(|parent| (label_value, parent))),
+                )
+            },
+            |label, parent_state| {
+                if let ParserState::InItem {
+                    label: item_label, ..
+                } = parent_state
+                {
+                    *item_label = Some(label);
+                }
+            },
+        )
     }
 
     /// Finishes parsing a head and stores it in the parent div.
     pub(super) fn finish_head(&mut self) -> Result<Option<TeiEvent>, TeiError> {
-        if let ParserState::InHead {
-            parent_div,
-            content,
-        } = &mut self.state
-        {
-            let head = build_head(std::mem::take(content))?;
-            let Some(mut parent_state) = parent_div.take() else {
-                return Err(TeiError::xml("internal error: InHead parent was None"));
-            };
-            if let ParserState::InDiv { head: div_head, .. } = parent_state.as_mut() {
-                *div_head = Some(head);
-            }
-            self.state = *parent_state;
-        }
-        Ok(None)
+        self.finish_with_parent_restore(
+            |state| {
+                let ParserState::InHead {
+                    parent_div,
+                    content,
+                } = state
+                else {
+                    return None;
+                };
+                let built_head = build_head(std::mem::take(content));
+                let parent_state = parent_div
+                    .take()
+                    .ok_or_else(|| TeiError::xml("internal error: InHead parent was None"));
+                Some(
+                    built_head
+                        .and_then(|head_value| parent_state.map(|parent| (head_value, parent))),
+                )
+            },
+            |head, parent_state| {
+                if let ParserState::InDiv { head: div_head, .. } = parent_state {
+                    *div_head = Some(head);
+                }
+            },
+        )
     }
 
     /// Finishes parsing an item and pushes it to the parent list.
     pub(super) fn finish_item(&mut self) -> Result<Option<TeiEvent>, TeiError> {
-        if let ParserState::InItem {
-            parent_list,
-            item_id,
-            item_n,
-            item_corresp,
-            label,
-            content,
-        } = &mut self.state
-        {
-            let item = build_item(
-                RawItemAttrs {
-                    id: item_id.take(),
-                    n: item_n.take(),
-                    corresp: item_corresp.take(),
-                    label: label.take(),
-                },
-                std::mem::take(content),
-            )?;
-            let Some(mut parent_state) = parent_list.take() else {
-                return Err(TeiError::xml("internal error: InItem parent was None"));
-            };
-            if let ParserState::InList { items, .. } = parent_state.as_mut() {
-                items.push(item);
-            }
-            self.state = *parent_state;
-        }
-        Ok(None)
+        self.finish_with_parent_restore(
+            |state| {
+                let ParserState::InItem {
+                    parent_list,
+                    item_id,
+                    item_n,
+                    item_corresp,
+                    label,
+                    content,
+                } = state
+                else {
+                    return None;
+                };
+                let built_item = build_item(
+                    RawItemAttrs {
+                        id: item_id.take(),
+                        n: item_n.take(),
+                        corresp: item_corresp.take(),
+                        label: label.take(),
+                    },
+                    std::mem::take(content),
+                );
+                let parent_state = parent_list
+                    .take()
+                    .ok_or_else(|| TeiError::xml("internal error: InItem parent was None"));
+                Some(
+                    built_item
+                        .and_then(|item_value| parent_state.map(|parent| (item_value, parent))),
+                )
+            },
+            |item, parent_state| {
+                if let ParserState::InList { items, .. } = parent_state {
+                    items.push(item);
+                }
+            },
+        )
     }
 
     /// Finishes parsing a list and pushes it to the parent div.
     pub(super) fn finish_list(&mut self) -> Result<Option<TeiEvent>, TeiError> {
-        if let ParserState::InList {
-            parent_div,
-            list_id,
-            items,
-        } = &mut self.state
-        {
-            let list = build_list(list_id.take(), std::mem::take(items))?;
-            let Some(mut parent_state) = parent_div.take() else {
-                return Err(TeiError::xml("internal error: InList parent was None"));
-            };
-            if let ParserState::InDiv { content, .. } = parent_state.as_mut() {
-                content.push(DivContent::List(list));
-            }
-            self.state = *parent_state;
-        }
-        Ok(None)
+        self.finish_with_parent_restore(
+            |state| {
+                let ParserState::InList {
+                    parent_div,
+                    list_id,
+                    items,
+                } = state
+                else {
+                    return None;
+                };
+                let built_list = build_list(list_id.take(), std::mem::take(items));
+                let parent_state = parent_div
+                    .take()
+                    .ok_or_else(|| TeiError::xml("internal error: InList parent was None"));
+                Some(
+                    built_list
+                        .and_then(|list_value| parent_state.map(|parent| (list_value, parent))),
+                )
+            },
+            |list, parent_state| {
+                if let ParserState::InDiv { content, .. } = parent_state {
+                    content.push(DivContent::List(list));
+                }
+            },
+        )
     }
 
     /// Finishes parsing a div and emits a `BodyBlock` event.
@@ -255,7 +321,9 @@ fn push_nested_div(
         ..
     } = state.as_mut()
     else {
-        return Err(TeiError::xml("internal error: nested div parent was not InDiv"));
+        return Err(TeiError::xml(
+            "internal error: nested div parent was not InDiv",
+        ));
     };
     parent_content.push(DivContent::Div(div));
     Ok(*state)

--- a/tei-xml/src/streaming/finish_handlers.rs
+++ b/tei-xml/src/streaming/finish_handlers.rs
@@ -14,15 +14,6 @@ use super::helpers::{
 use super::parser::TeiPullParser;
 use super::state::ParserState;
 
-fn combine_result_with_parent<V>(
-    built: Result<V, TeiError>,
-    parent: Option<Box<ParserState>>,
-    context: &'static str,
-) -> Result<(V, Box<ParserState>), TeiError> {
-    let parent_result = parent.ok_or_else(|| TeiError::xml(context));
-    built.and_then(|v| parent_result.map(|p| (v, p)))
-}
-
 /// End element handlers.
 impl<R: BufRead> TeiPullParser<R> {
     /// Handles closing of header elements and emits Header event when complete.
@@ -50,19 +41,25 @@ impl<R: BufRead> TeiPullParser<R> {
         value: V,
         wrap_div: fn(V) -> DivContent,
         wrap_body: fn(V) -> BodyBlock,
-    ) -> Option<TeiEvent> {
-        if let Some(mut parent_div) = self.pending_div_state.take()
-            && let ParserState::InDiv {
-                content: div_children,
-                ..
-            } = parent_div.as_mut()
-        {
-            div_children.push(wrap_div(value));
-            self.state = *parent_div;
-            return None;
+    ) -> Result<Option<TeiEvent>, TeiError> {
+        if let Some(mut parent_div) = self.pending_div_state.take() {
+            match parent_div.as_mut() {
+                ParserState::InDiv {
+                    content: div_children,
+                    ..
+                } => {
+                    div_children.push(wrap_div(value));
+                    self.state = *parent_div;
+                    Ok(None)
+                }
+                _ => Err(TeiError::xml(
+                    "internal error: pending div parent was not InDiv",
+                )),
+            }
+        } else {
+            self.state = ParserState::InBody;
+            Ok(Some(TeiEvent::BodyBlock(wrap_body(value))))
         }
-        self.state = ParserState::InBody;
-        Some(TeiEvent::BodyBlock(wrap_body(value)))
     }
 
     fn finish_div_or_body_block<V>(
@@ -72,21 +69,22 @@ impl<R: BufRead> TeiPullParser<R> {
         wrap_body: fn(V) -> BodyBlock,
     ) -> Result<Option<TeiEvent>, TeiError> {
         if let Some(result) = extract(&mut self.state) {
-            return Ok(self.push_to_div_or_emit(result?, wrap_div, wrap_body));
+            return self.push_to_div_or_emit(result?, wrap_div, wrap_body);
         }
         Ok(None)
     }
 
     fn finish_with_parent_restore<V>(
         &mut self,
-        extract: impl FnOnce(&mut ParserState) -> Option<Result<(V, Box<ParserState>), TeiError>>,
+        extract: impl FnOnce(&mut ParserState) -> Result<Option<(V, Box<ParserState>)>, TeiError>,
         apply: impl FnOnce(V, &mut ParserState),
     ) -> Result<Option<TeiEvent>, TeiError> {
-        if let Some(result) = extract(&mut self.state) {
-            let (value, mut parent_state) = result?;
-            apply(value, parent_state.as_mut());
-            self.state = *parent_state;
-        }
+        let Some((value, mut parent_state)) = extract(&mut self.state)? else {
+            return Ok(None);
+        };
+
+        apply(value, parent_state.as_mut());
+        self.state = *parent_state;
         Ok(None)
     }
 
@@ -148,13 +146,14 @@ impl<R: BufRead> TeiPullParser<R> {
                     content,
                 } = state
                 else {
-                    return None;
+                    return Ok(None);
                 };
-                Some(combine_result_with_parent(
-                    build_label(std::mem::take(content)),
-                    parent_item.take(),
-                    "internal error: InLabel parent was None",
-                ))
+                let label = build_label(std::mem::take(content))?;
+                let parent = parent_item
+                    .take()
+                    .ok_or_else(|| TeiError::xml("internal error: InLabel parent was None"))?;
+
+                Ok(Some((label, parent)))
             },
             |label, parent_state| {
                 if let ParserState::InItem {
@@ -176,13 +175,14 @@ impl<R: BufRead> TeiPullParser<R> {
                     content,
                 } = state
                 else {
-                    return None;
+                    return Ok(None);
                 };
-                Some(combine_result_with_parent(
-                    build_head(std::mem::take(content)),
-                    parent_div.take(),
-                    "internal error: InHead parent was None",
-                ))
+                let head = build_head(std::mem::take(content))?;
+                let parent = parent_div
+                    .take()
+                    .ok_or_else(|| TeiError::xml("internal error: InHead parent was None"))?;
+
+                Ok(Some((head, parent)))
             },
             |head, parent_state| {
                 if let ParserState::InDiv { head: div_head, .. } = parent_state {
@@ -205,21 +205,22 @@ impl<R: BufRead> TeiPullParser<R> {
                     content,
                 } = state
                 else {
-                    return None;
+                    return Ok(None);
                 };
-                Some(combine_result_with_parent(
-                    build_item(
-                        RawItemAttrs {
-                            id: item_id.take(),
-                            n: item_n.take(),
-                            corresp: item_corresp.take(),
-                            label: label.take(),
-                        },
-                        std::mem::take(content),
-                    ),
-                    parent_list.take(),
-                    "internal error: InItem parent was None",
-                ))
+                let item = build_item(
+                    RawItemAttrs {
+                        id: item_id.take(),
+                        n: item_n.take(),
+                        corresp: item_corresp.take(),
+                        label: label.take(),
+                    },
+                    std::mem::take(content),
+                )?;
+                let parent = parent_list
+                    .take()
+                    .ok_or_else(|| TeiError::xml("internal error: InItem parent was None"))?;
+
+                Ok(Some((item, parent)))
             },
             |item, parent_state| {
                 if let ParserState::InList { items, .. } = parent_state {
@@ -239,13 +240,14 @@ impl<R: BufRead> TeiPullParser<R> {
                     items,
                 } = state
                 else {
-                    return None;
+                    return Ok(None);
                 };
-                Some(combine_result_with_parent(
-                    build_list(list_id.take(), std::mem::take(items)),
-                    parent_div.take(),
-                    "internal error: InList parent was None",
-                ))
+                let list = build_list(list_id.take(), std::mem::take(items))?;
+                let parent = parent_div
+                    .take()
+                    .ok_or_else(|| TeiError::xml("internal error: InList parent was None"))?;
+
+                Ok(Some((list, parent)))
             },
             |list, parent_state| {
                 if let ParserState::InDiv { content, .. } = parent_state {

--- a/tei-xml/src/streaming/finish_handlers.rs
+++ b/tei-xml/src/streaming/finish_handlers.rs
@@ -1,0 +1,262 @@
+//! End-element and completion handlers for the TEI pull parser.
+
+use std::io::BufRead;
+
+use quick_xml::events::BytesEnd;
+
+use tei_core::{BodyBlock, DivContent, Inline, TeiError};
+
+use super::event::TeiEvent;
+use super::helpers::{
+    RawDivAttrs, RawItemAttrs, build_div, build_head, build_hi, build_item, build_label,
+    build_list, build_paragraph, build_utterance,
+};
+use super::parser::TeiPullParser;
+use super::state::ParserState;
+
+/// End element handlers.
+impl<R: BufRead> TeiPullParser<R> {
+    /// Handles closing of header elements and emits Header event when complete.
+    pub(super) fn handle_header_end(
+        &mut self,
+        element: &BytesEnd<'_>,
+    ) -> Result<Option<TeiEvent>, TeiError> {
+        if let ParserState::InHeader { depth, buffer } = &mut self.state {
+            super::helpers::append_end_element(buffer, element);
+            *depth -= 1;
+            if *depth == 0 {
+                let header = self.parse_accumulated_header()?;
+                self.header = Some(header.clone());
+                self.state = ParserState::AwaitingText;
+                return Ok(Some(TeiEvent::Header(header)));
+            }
+        }
+        Ok(None)
+    }
+
+    /// Routes a completed body-content value to either the enclosing `<div>`
+    /// (if one is pending) or emits it as a top-level `BodyBlock` event.
+    fn push_to_div_or_emit<V>(
+        &mut self,
+        value: V,
+        wrap_div: fn(V) -> DivContent,
+        wrap_body: fn(V) -> BodyBlock,
+    ) -> Option<TeiEvent> {
+        if let Some(mut parent_div) = self.pending_div_state.take()
+            && let ParserState::InDiv {
+                content: div_children,
+                ..
+            } = parent_div.as_mut()
+        {
+            div_children.push(wrap_div(value));
+            self.state = *parent_div;
+            return None;
+        }
+        self.state = ParserState::InBody;
+        Some(TeiEvent::BodyBlock(wrap_body(value)))
+    }
+
+    /// Finishes parsing a paragraph and emits a `BodyBlock` event or pushes to div.
+    pub(super) fn finish_paragraph(&mut self) -> Result<Option<TeiEvent>, TeiError> {
+        if let ParserState::InParagraph { id, content } = &mut self.state {
+            let paragraph = build_paragraph(id.take(), std::mem::take(content))?;
+            return Ok(self.push_to_div_or_emit(
+                paragraph,
+                DivContent::Paragraph,
+                BodyBlock::Paragraph,
+            ));
+        }
+        Ok(None)
+    }
+
+    /// Finishes parsing an utterance and emits a `BodyBlock` event or pushes to div.
+    pub(super) fn finish_utterance(&mut self) -> Result<Option<TeiEvent>, TeiError> {
+        if let ParserState::InUtterance { attrs, content } = &mut self.state {
+            let utterance = build_utterance(std::mem::take(attrs), std::mem::take(content))?;
+            return Ok(self.push_to_div_or_emit(
+                utterance,
+                DivContent::Utterance,
+                BodyBlock::Utterance,
+            ));
+        }
+        Ok(None)
+    }
+
+    /// Finishes parsing emphasis and pushes it to the parent state.
+    pub(super) fn finish_emphasis(&mut self) -> Result<Option<TeiEvent>, TeiError> {
+        if let ParserState::InEmphasis {
+            parent,
+            rend,
+            content,
+        } = &mut self.state
+        {
+            let hi = build_hi(rend.take(), std::mem::take(content))?;
+            let Some(parent_state) = parent.take() else {
+                return Err(TeiError::xml("internal error: InEmphasis parent was None"));
+            };
+            self.state = *parent_state;
+            self.state.push_inline(Inline::Hi(hi));
+        }
+        Ok(None)
+    }
+
+    /// Finishes parsing a label and stores it in the parent item.
+    pub(super) fn finish_label(&mut self) -> Result<Option<TeiEvent>, TeiError> {
+        if let ParserState::InLabel {
+            parent_item,
+            content,
+        } = &mut self.state
+        {
+            let label = build_label(std::mem::take(content))?;
+            let Some(mut parent_state) = parent_item.take() else {
+                return Err(TeiError::xml("internal error: InLabel parent was None"));
+            };
+            if let ParserState::InItem {
+                label: item_label, ..
+            } = parent_state.as_mut()
+            {
+                *item_label = Some(label);
+            }
+            self.state = *parent_state;
+        }
+        Ok(None)
+    }
+
+    /// Finishes parsing a head and stores it in the parent div.
+    pub(super) fn finish_head(&mut self) -> Result<Option<TeiEvent>, TeiError> {
+        if let ParserState::InHead {
+            parent_div,
+            content,
+        } = &mut self.state
+        {
+            let head = build_head(std::mem::take(content))?;
+            let Some(mut parent_state) = parent_div.take() else {
+                return Err(TeiError::xml("internal error: InHead parent was None"));
+            };
+            if let ParserState::InDiv { head: div_head, .. } = parent_state.as_mut() {
+                *div_head = Some(head);
+            }
+            self.state = *parent_state;
+        }
+        Ok(None)
+    }
+
+    /// Finishes parsing an item and pushes it to the parent list.
+    pub(super) fn finish_item(&mut self) -> Result<Option<TeiEvent>, TeiError> {
+        if let ParserState::InItem {
+            parent_list,
+            item_id,
+            item_n,
+            item_corresp,
+            label,
+            content,
+        } = &mut self.state
+        {
+            let item = build_item(
+                RawItemAttrs {
+                    id: item_id.take(),
+                    n: item_n.take(),
+                    corresp: item_corresp.take(),
+                    label: label.take(),
+                },
+                std::mem::take(content),
+            )?;
+            let Some(mut parent_state) = parent_list.take() else {
+                return Err(TeiError::xml("internal error: InItem parent was None"));
+            };
+            if let ParserState::InList { items, .. } = parent_state.as_mut() {
+                items.push(item);
+            }
+            self.state = *parent_state;
+        }
+        Ok(None)
+    }
+
+    /// Finishes parsing a list and pushes it to the parent div.
+    pub(super) fn finish_list(&mut self) -> Result<Option<TeiEvent>, TeiError> {
+        if let ParserState::InList {
+            parent_div,
+            list_id,
+            items,
+        } = &mut self.state
+        {
+            let list = build_list(list_id.take(), std::mem::take(items))?;
+            let Some(mut parent_state) = parent_div.take() else {
+                return Err(TeiError::xml("internal error: InList parent was None"));
+            };
+            if let ParserState::InDiv { content, .. } = parent_state.as_mut() {
+                content.push(DivContent::List(list));
+            }
+            self.state = *parent_state;
+        }
+        Ok(None)
+    }
+
+    /// Finishes parsing a div and emits a `BodyBlock` event.
+    pub(super) fn finish_div(&mut self) -> Result<Option<TeiEvent>, TeiError> {
+        if let ParserState::InDiv {
+            div_type,
+            subtype,
+            id,
+            head,
+            parent_div,
+            content,
+        } = &mut self.state
+        {
+            let div = build_div(
+                RawDivAttrs {
+                    div_type: std::mem::take(div_type),
+                    subtype: subtype.take(),
+                    id: id.take(),
+                    head: head.take(),
+                },
+                std::mem::take(content),
+            )?;
+            if let Some(parent_state) = parent_div.take() {
+                self.state = push_nested_div(parent_state, div)?;
+                return Ok(None);
+            }
+            self.state = ParserState::InBody;
+            return Ok(Some(TeiEvent::BodyBlock(BodyBlock::Div(div))));
+        }
+        Ok(None)
+    }
+
+    /// Handles body end elements.
+    pub(super) fn handle_body_end(&mut self, name_bytes: &[u8]) -> Option<TeiEvent> {
+        match name_bytes {
+            b"body" => {
+                self.state = ParserState::AfterBody;
+                None
+            }
+            _ => None,
+        }
+    }
+
+    /// Handles end elements after the body has closed.
+    pub(super) fn handle_after_body_end(&mut self, name_bytes: &[u8]) -> Option<TeiEvent> {
+        match name_bytes {
+            b"text" | b"TEI" => {
+                self.state = ParserState::DocumentComplete;
+                Some(TeiEvent::DocumentEnd)
+            }
+            _ => None,
+        }
+    }
+}
+
+fn push_nested_div(
+    parent_state: Box<ParserState>,
+    div: tei_core::Div,
+) -> Result<ParserState, TeiError> {
+    let mut state = parent_state;
+    let ParserState::InDiv {
+        content: parent_content,
+        ..
+    } = state.as_mut()
+    else {
+        return Err(TeiError::xml("internal error: nested div parent was not InDiv"));
+    };
+    parent_content.push(DivContent::Div(div));
+    Ok(*state)
+}

--- a/tei-xml/src/streaming/finish_handlers.rs
+++ b/tei-xml/src/streaming/finish_handlers.rs
@@ -14,6 +14,15 @@ use super::helpers::{
 use super::parser::TeiPullParser;
 use super::state::ParserState;
 
+fn combine_result_with_parent<V>(
+    built: Result<V, TeiError>,
+    parent: Option<Box<ParserState>>,
+    context: &'static str,
+) -> Option<Result<(V, Box<ParserState>), TeiError>> {
+    let parent_result = parent.ok_or_else(|| TeiError::xml(context));
+    Some(built.and_then(|v| parent_result.map(|p| (v, p))))
+}
+
 /// End element handlers.
 impl<R: BufRead> TeiPullParser<R> {
     /// Handles closing of header elements and emits Header event when complete.
@@ -141,13 +150,10 @@ impl<R: BufRead> TeiPullParser<R> {
                 else {
                     return None;
                 };
-                let built_label = build_label(std::mem::take(content));
-                let parent_state = parent_item
-                    .take()
-                    .ok_or_else(|| TeiError::xml("internal error: InLabel parent was None"));
-                Some(
-                    built_label
-                        .and_then(|label_value| parent_state.map(|parent| (label_value, parent))),
+                combine_result_with_parent(
+                    build_label(std::mem::take(content)),
+                    parent_item.take(),
+                    "internal error: InLabel parent was None",
                 )
             },
             |label, parent_state| {
@@ -172,13 +178,10 @@ impl<R: BufRead> TeiPullParser<R> {
                 else {
                     return None;
                 };
-                let built_head = build_head(std::mem::take(content));
-                let parent_state = parent_div
-                    .take()
-                    .ok_or_else(|| TeiError::xml("internal error: InHead parent was None"));
-                Some(
-                    built_head
-                        .and_then(|head_value| parent_state.map(|parent| (head_value, parent))),
+                combine_result_with_parent(
+                    build_head(std::mem::take(content)),
+                    parent_div.take(),
+                    "internal error: InHead parent was None",
                 )
             },
             |head, parent_state| {
@@ -204,21 +207,18 @@ impl<R: BufRead> TeiPullParser<R> {
                 else {
                     return None;
                 };
-                let built_item = build_item(
-                    RawItemAttrs {
-                        id: item_id.take(),
-                        n: item_n.take(),
-                        corresp: item_corresp.take(),
-                        label: label.take(),
-                    },
-                    std::mem::take(content),
-                );
-                let parent_state = parent_list
-                    .take()
-                    .ok_or_else(|| TeiError::xml("internal error: InItem parent was None"));
-                Some(
-                    built_item
-                        .and_then(|item_value| parent_state.map(|parent| (item_value, parent))),
+                combine_result_with_parent(
+                    build_item(
+                        RawItemAttrs {
+                            id: item_id.take(),
+                            n: item_n.take(),
+                            corresp: item_corresp.take(),
+                            label: label.take(),
+                        },
+                        std::mem::take(content),
+                    ),
+                    parent_list.take(),
+                    "internal error: InItem parent was None",
                 )
             },
             |item, parent_state| {
@@ -241,13 +241,10 @@ impl<R: BufRead> TeiPullParser<R> {
                 else {
                     return None;
                 };
-                let built_list = build_list(list_id.take(), std::mem::take(items));
-                let parent_state = parent_div
-                    .take()
-                    .ok_or_else(|| TeiError::xml("internal error: InList parent was None"));
-                Some(
-                    built_list
-                        .and_then(|list_value| parent_state.map(|parent| (list_value, parent))),
+                combine_result_with_parent(
+                    build_list(list_id.take(), std::mem::take(items)),
+                    parent_div.take(),
+                    "internal error: InList parent was None",
                 )
             },
             |list, parent_state| {

--- a/tei-xml/src/streaming/handlers.rs
+++ b/tei-xml/src/streaming/handlers.rs
@@ -1,26 +1,19 @@
-//! State-specific event handlers for the TEI pull parser.
-//!
-//! This module contains the handler methods for processing XML events in
-//! different parser states. These methods are implemented as part of
-//! [`TeiPullParser`] but are separated into this file for modularity.
+//! Start-element handlers for the TEI pull parser.
 
 use std::io::BufRead;
 
-use quick_xml::events::{BytesEnd, BytesRef, BytesStart, BytesText};
+use quick_xml::events::BytesStart;
 
-use tei_core::{BodyBlock, DivContent, Inline, TeiError};
+use tei_core::{Inline, TeiError};
 
 use super::event::TeiEvent;
-use super::helpers::{
-    RawItemAttrs, append_empty_element, append_end_element, append_start_element, build_div,
-    build_hi, build_item, build_label, build_list, build_paragraph, build_pause, build_utterance,
-    extract_attribute, extract_xml_id, resolve_entity_ref,
-};
+use super::helpers::{append_start_element, extract_attribute, extract_xml_id};
 use super::parser::TeiPullParser;
 use super::state::{ParserState, RawUtteranceAttrs};
 
 /// Classifies a tag name encountered inside a `<div>`.
 enum DivChildKind {
+    Head,
     Paragraph,
     Utterance,
     List,
@@ -31,6 +24,7 @@ enum DivChildKind {
 impl DivChildKind {
     const fn from_tag(name_bytes: &[u8]) -> Self {
         match name_bytes {
+            b"head" => Self::Head,
             b"p" => Self::Paragraph,
             b"u" => Self::Utterance,
             b"list" => Self::List,
@@ -40,7 +34,6 @@ impl DivChildKind {
     }
 }
 
-/// Start element handlers.
 impl<R: BufRead> TeiPullParser<R> {
     /// Handles start elements when awaiting the root TEI element.
     pub(super) fn handle_root_start(&mut self, name_bytes: &[u8]) -> Option<TeiEvent> {
@@ -116,8 +109,9 @@ impl<R: BufRead> TeiPullParser<R> {
         } else if name_bytes == b"div" {
             let div_type = extract_attribute(element, b"type")?
                 .ok_or_else(|| TeiError::xml("div element missing required @type attribute"))?;
+            let subtype = extract_attribute(element, b"subtype")?;
             let id = extract_xml_id(element)?;
-            self.state = ParserState::in_div(div_type, id);
+            self.state = ParserState::in_div(div_type, subtype, id);
         }
         Ok(None)
     }
@@ -135,13 +129,18 @@ impl<R: BufRead> TeiPullParser<R> {
         Ok(None)
     }
 
-    /// Handles start elements within a `<div>` (paragraphs, utterances, lists).
+    /// Handles start elements within a `<div>`.
     pub(super) fn handle_div_content_start(
         &mut self,
         name_bytes: &[u8],
         element: &BytesStart<'_>,
     ) -> Result<Option<TeiEvent>, TeiError> {
         match DivChildKind::from_tag(name_bytes) {
+            DivChildKind::Head => {
+                self.validate_head_placement()?;
+                let current_state = std::mem::take(&mut self.state);
+                self.state = ParserState::in_head(current_state);
+            }
             DivChildKind::Paragraph => {
                 let id = extract_xml_id(element)?;
                 let current_state = std::mem::take(&mut self.state);
@@ -168,11 +167,30 @@ impl<R: BufRead> TeiPullParser<R> {
                 self.state = ParserState::in_list(current_state, list_id);
             }
             DivChildKind::NestedDiv => {
-                return Err(TeiError::xml("nested <div> elements are not supported"));
+                let div_type = extract_attribute(element, b"type")?
+                    .ok_or_else(|| TeiError::xml("div element missing required @type attribute"))?;
+                let subtype = extract_attribute(element, b"subtype")?;
+                let id = extract_xml_id(element)?;
+                let current_state = std::mem::take(&mut self.state);
+                self.state = ParserState::nested_div(current_state, div_type, subtype, id);
             }
             DivChildKind::Other => {}
         }
         Ok(None)
+    }
+
+    /// Validates that a head appears at most once and before any div content.
+    fn validate_head_placement(&self) -> Result<(), TeiError> {
+        let ParserState::InDiv { head, content, .. } = &self.state else {
+            return Ok(());
+        };
+        if head.is_some() {
+            return Err(TeiError::xml("div may only contain one head"));
+        }
+        if !content.is_empty() {
+            return Err(TeiError::xml("head must appear before div content"));
+        }
+        Ok(())
     }
 
     /// Handles start elements within a `<list>` (items).
@@ -223,344 +241,5 @@ impl<R: BufRead> TeiPullParser<R> {
             return Err(TeiError::xml("label must appear before item content"));
         }
         Ok(())
-    }
-}
-
-/// End element handlers.
-impl<R: BufRead> TeiPullParser<R> {
-    /// Handles closing of header elements and emits Header event when complete.
-    pub(super) fn handle_header_end(
-        &mut self,
-        element: &BytesEnd<'_>,
-    ) -> Result<Option<TeiEvent>, TeiError> {
-        if let ParserState::InHeader { depth, buffer } = &mut self.state {
-            append_end_element(buffer, element);
-            *depth -= 1;
-            if *depth == 0 {
-                let header = self.parse_accumulated_header()?;
-                self.header = Some(header.clone());
-                self.state = ParserState::AwaitingText;
-                return Ok(Some(TeiEvent::Header(header)));
-            }
-        }
-        Ok(None)
-    }
-
-    /// Routes a completed body-content value to either the enclosing `<div>`
-    /// (if one is pending) or emits it as a top-level `BodyBlock` event.
-    fn push_to_div_or_emit<V>(
-        &mut self,
-        value: V,
-        wrap_div: fn(V) -> DivContent,
-        wrap_body: fn(V) -> BodyBlock,
-    ) -> Option<TeiEvent> {
-        if let Some(mut parent_div) = self.pending_div_state.take()
-            && let ParserState::InDiv {
-                content: div_children,
-                ..
-            } = parent_div.as_mut()
-        {
-            div_children.push(wrap_div(value));
-            self.state = *parent_div;
-            return None;
-        }
-        self.state = ParserState::InBody;
-        Some(TeiEvent::BodyBlock(wrap_body(value)))
-    }
-
-    /// Finishes parsing a paragraph and emits a `BodyBlock` event or pushes to div.
-    pub(super) fn finish_paragraph(&mut self) -> Result<Option<TeiEvent>, TeiError> {
-        if let ParserState::InParagraph { id, content } = &mut self.state {
-            let paragraph = build_paragraph(id.take(), std::mem::take(content))?;
-            return Ok(self.push_to_div_or_emit(
-                paragraph,
-                DivContent::Paragraph,
-                BodyBlock::Paragraph,
-            ));
-        }
-        Ok(None)
-    }
-
-    /// Finishes parsing an utterance and emits a `BodyBlock` event or pushes to div.
-    pub(super) fn finish_utterance(&mut self) -> Result<Option<TeiEvent>, TeiError> {
-        if let ParserState::InUtterance { attrs, content } = &mut self.state {
-            let utterance = build_utterance(std::mem::take(attrs), std::mem::take(content))?;
-            return Ok(self.push_to_div_or_emit(
-                utterance,
-                DivContent::Utterance,
-                BodyBlock::Utterance,
-            ));
-        }
-        Ok(None)
-    }
-
-    /// Finishes parsing emphasis and pushes it to the parent state.
-    pub(super) fn finish_emphasis(&mut self) -> Result<Option<TeiEvent>, TeiError> {
-        if let ParserState::InEmphasis {
-            parent,
-            rend,
-            content,
-        } = &mut self.state
-        {
-            let hi = build_hi(rend.take(), std::mem::take(content))?;
-            let Some(parent_state) = parent.take() else {
-                return Err(TeiError::xml("internal error: InEmphasis parent was None"));
-            };
-            self.state = *parent_state;
-            self.state.push_inline(Inline::Hi(hi));
-        }
-        Ok(None)
-    }
-
-    /// Finishes parsing a label and stores it in the parent item.
-    pub(super) fn finish_label(&mut self) -> Result<Option<TeiEvent>, TeiError> {
-        if let ParserState::InLabel {
-            parent_item,
-            content,
-        } = &mut self.state
-        {
-            let label = build_label(std::mem::take(content))?;
-            let Some(mut parent_state) = parent_item.take() else {
-                return Err(TeiError::xml("internal error: InLabel parent was None"));
-            };
-            if let ParserState::InItem {
-                label: item_label, ..
-            } = parent_state.as_mut()
-            {
-                *item_label = Some(label);
-            }
-            self.state = *parent_state;
-        }
-        Ok(None)
-    }
-
-    /// Finishes parsing an item and pushes it to the parent list.
-    pub(super) fn finish_item(&mut self) -> Result<Option<TeiEvent>, TeiError> {
-        if let ParserState::InItem {
-            parent_list,
-            item_id,
-            item_n,
-            item_corresp,
-            label,
-            content,
-        } = &mut self.state
-        {
-            let item = build_item(
-                RawItemAttrs {
-                    id: item_id.take(),
-                    n: item_n.take(),
-                    corresp: item_corresp.take(),
-                    label: label.take(),
-                },
-                std::mem::take(content),
-            )?;
-            let Some(mut parent_state) = parent_list.take() else {
-                return Err(TeiError::xml("internal error: InItem parent was None"));
-            };
-            if let ParserState::InList { items, .. } = parent_state.as_mut() {
-                items.push(item);
-            }
-            self.state = *parent_state;
-        }
-        Ok(None)
-    }
-
-    /// Finishes parsing a list and pushes it to the parent div.
-    pub(super) fn finish_list(&mut self) -> Result<Option<TeiEvent>, TeiError> {
-        if let ParserState::InList {
-            parent_div,
-            list_id,
-            items,
-        } = &mut self.state
-        {
-            let list = build_list(list_id.take(), std::mem::take(items))?;
-            let Some(mut parent_state) = parent_div.take() else {
-                return Err(TeiError::xml("internal error: InList parent was None"));
-            };
-            if let ParserState::InDiv { content, .. } = parent_state.as_mut() {
-                content.push(DivContent::List(list));
-            }
-            self.state = *parent_state;
-        }
-        Ok(None)
-    }
-
-    /// Finishes parsing a div and emits a `BodyBlock` event.
-    pub(super) fn finish_div(&mut self) -> Result<Option<TeiEvent>, TeiError> {
-        if let ParserState::InDiv {
-            div_type,
-            id,
-            content,
-        } = &mut self.state
-        {
-            let div = build_div(std::mem::take(div_type), id.take(), std::mem::take(content))?;
-            self.state = ParserState::InBody;
-            return Ok(Some(TeiEvent::BodyBlock(BodyBlock::Div(div))));
-        }
-        Ok(None)
-    }
-
-    /// Handles body end elements.
-    pub(super) fn handle_body_end(&mut self, name_bytes: &[u8]) -> Option<TeiEvent> {
-        match name_bytes {
-            b"body" => {
-                // Body closed, transition to AfterBody state
-                self.state = ParserState::AfterBody;
-                None
-            }
-            _ => None,
-        }
-    }
-
-    /// Handles end elements after the body has closed.
-    pub(super) fn handle_after_body_end(&mut self, name_bytes: &[u8]) -> Option<TeiEvent> {
-        match name_bytes {
-            b"text" | b"TEI" => {
-                self.state = ParserState::DocumentComplete;
-                Some(TeiEvent::DocumentEnd)
-            }
-            _ => None,
-        }
-    }
-}
-
-/// Content handlers (text, empty elements, CDATA, EOF).
-impl<R: BufRead> TeiPullParser<R> {
-    /// Handles a text event.
-    pub(super) fn handle_text(
-        &mut self,
-        text: &BytesText<'_>,
-    ) -> Result<Option<TeiEvent>, TeiError> {
-        match &mut self.state {
-            ParserState::InHeader { buffer, .. } => {
-                // Keep text escaped for later reparsing by quick_xml::de
-                buffer.extend_from_slice(text.as_ref());
-                Ok(None)
-            }
-            ParserState::InParagraph { content, .. }
-            | ParserState::InUtterance { content, .. }
-            | ParserState::InEmphasis { content, .. }
-            | ParserState::InItem { content, .. }
-            | ParserState::InLabel { content, .. } => {
-                let unescaped = text.decode().map_err(|e| TeiError::xml(e.to_string()))?;
-                if !unescaped.is_empty() {
-                    content.push(Inline::Text(unescaped.into_owned()));
-                }
-                Ok(None)
-            }
-            _ => Ok(None),
-        }
-    }
-
-    /// Handles a general entity reference (`&name;` or `&#...;`).
-    ///
-    /// In `quick_xml` 0.39+ entity references are emitted as separate
-    /// `GeneralRef` events rather than being folded into `Text` events.
-    /// This handler resolves them and appends the decoded character(s) to
-    /// the active text-collecting state.
-    pub(super) fn handle_general_ref(
-        &mut self,
-        reference: &BytesRef<'_>,
-    ) -> Result<Option<TeiEvent>, TeiError> {
-        match &mut self.state {
-            ParserState::InHeader { buffer, .. } => {
-                // Reconstruct the entity reference for later reparsing by quick_xml::de
-                buffer.push(b'&');
-                buffer.extend_from_slice(reference.as_ref());
-                buffer.push(b';');
-                Ok(None)
-            }
-            ParserState::InParagraph { content, .. }
-            | ParserState::InUtterance { content, .. }
-            | ParserState::InEmphasis { content, .. }
-            | ParserState::InItem { content, .. }
-            | ParserState::InLabel { content, .. } => {
-                let resolved = resolve_entity_ref(reference)?;
-                content.push(Inline::Text(resolved));
-                Ok(None)
-            }
-            _ => Ok(None),
-        }
-    }
-
-    /// Handles an empty element event (self-closing tag).
-    pub(super) fn handle_empty_element(
-        &mut self,
-        element: &BytesStart<'_>,
-    ) -> Result<Option<TeiEvent>, TeiError> {
-        let name = element.local_name();
-        let name_bytes = name.as_ref();
-
-        match &mut self.state {
-            ParserState::InHeader { buffer, .. } => {
-                append_empty_element(buffer, element)?;
-                Ok(None)
-            }
-            ParserState::InParagraph { content, .. }
-            | ParserState::InUtterance { content, .. }
-            | ParserState::InEmphasis { content, .. }
-            | ParserState::InItem { content, .. }
-            | ParserState::InLabel { content, .. }
-                if name_bytes == b"pause" =>
-            {
-                let dur = extract_attribute(element, b"dur")?;
-                let pause_type = extract_attribute(element, b"type")?;
-                let pause = build_pause(dur, pause_type);
-                content.push(Inline::Pause(pause));
-                Ok(None)
-            }
-            ParserState::AwaitingBody if name_bytes == b"body" => {
-                // Empty body, move to document end
-                self.state = ParserState::DocumentComplete;
-                Ok(Some(TeiEvent::DocumentEnd))
-            }
-            _ => Ok(None),
-        }
-    }
-
-    /// Handles CDATA sections.
-    pub(super) fn handle_cdata(
-        &mut self,
-        cdata: &quick_xml::events::BytesCData<'_>,
-    ) -> Result<Option<TeiEvent>, TeiError> {
-        match &mut self.state {
-            ParserState::InHeader { buffer, .. } => {
-                // Reconstruct CDATA for reparsing
-                buffer.extend_from_slice(b"<![CDATA[");
-                buffer.extend_from_slice(cdata.as_ref());
-                buffer.extend_from_slice(b"]]>");
-                Ok(None)
-            }
-            ParserState::InParagraph { content, .. }
-            | ParserState::InUtterance { content, .. }
-            | ParserState::InEmphasis { content, .. }
-            | ParserState::InItem { content, .. }
-            | ParserState::InLabel { content, .. } => {
-                // CDATA content is already unescaped, convert to string with strict UTF-8
-                let text = std::str::from_utf8(cdata.as_ref())
-                    .map_err(|e| TeiError::xml(format!("invalid UTF-8 in CDATA: {e}")))?;
-                if !text.is_empty() {
-                    content.push(Inline::Text(text.to_owned()));
-                }
-                Ok(None)
-            }
-            _ => Ok(None),
-        }
-    }
-
-    /// Handles end-of-file.
-    pub(super) fn handle_eof(&mut self) -> Result<Option<TeiEvent>, TeiError> {
-        match &self.state {
-            ParserState::DocumentComplete => Ok(None),
-            ParserState::InBody | ParserState::AfterBody => {
-                // Allow EOF after body content if document wasn't properly closed
-                self.state = ParserState::DocumentComplete;
-                Ok(Some(TeiEvent::DocumentEnd))
-            }
-            _ => {
-                self.state = ParserState::Error;
-                Err(TeiError::xml("unexpected end of document"))
-            }
-        }
     }
 }

--- a/tei-xml/src/streaming/helpers.rs
+++ b/tei-xml/src/streaming/helpers.rs
@@ -293,11 +293,7 @@ pub fn build_label(content: Vec<Inline>) -> Result<Label, TeiError> {
 
 /// Builds a Head from inline content.
 pub fn build_head(content: Vec<Inline>) -> Result<Head, TeiError> {
-    if content.is_empty() {
-        Head::from_text("").map_err(|e| TeiError::xml(e.to_string()))
-    } else {
-        Head::new(content).map_err(|e| TeiError::xml(e.to_string()))
-    }
+    Head::new(content).map_err(|e| TeiError::xml(e.to_string()))
 }
 
 /// Resolves a `BytesRef` entity reference to its text representation.

--- a/tei-xml/src/streaming/helpers.rs
+++ b/tei-xml/src/streaming/helpers.rs
@@ -6,7 +6,7 @@
 use quick_xml::events::{BytesEnd, BytesRef, BytesStart};
 
 use tei_core::{
-    BodyContentError, Certainty, Div, DivContent, Hi, Inline, Item, Label, List, P, Pause,
+    BodyContentError, Certainty, Div, DivContent, Head, Hi, Inline, Item, Label, List, P, Pause,
     PointerList, TeiError, Utterance,
 };
 
@@ -202,19 +202,35 @@ pub fn build_pause(dur: Option<String>, pause_type: Option<String>) -> Pause {
     pause
 }
 
-/// Builds a Div from type, optional ID, and content.
-pub fn build_div(
-    div_type: String,
-    id: Option<String>,
-    content: Vec<DivContent>,
-) -> Result<Div, TeiError> {
-    let mut div = Div::new(div_type).map_err(|e| TeiError::xml(e.to_string()))?;
-    apply_id(&mut div, id, Div::set_id)?;
+/// Raw attributes collected for a `<div>` element during parsing.
+pub struct RawDivAttrs {
+    /// Required `@type` attribute.
+    pub div_type: String,
+    /// Optional `@subtype` attribute.
+    pub subtype: Option<String>,
+    /// Optional `xml:id` attribute.
+    pub id: Option<String>,
+    /// Optional `<head>` child element.
+    pub head: Option<Head>,
+}
+
+/// Builds a Div from raw attributes and child content.
+pub fn build_div(attrs: RawDivAttrs, content: Vec<DivContent>) -> Result<Div, TeiError> {
+    let mut div = Div::new(attrs.div_type).map_err(|e| TeiError::xml(e.to_string()))?;
+    if let Some(subtype_value) = attrs.subtype {
+        div.set_subtype(subtype_value)
+            .map_err(|e| TeiError::xml(e.to_string()))?;
+    }
+    apply_id(&mut div, attrs.id, Div::set_id)?;
+    if let Some(heading) = attrs.head {
+        div.set_head(heading);
+    }
     for item in content {
         match item {
             DivContent::Paragraph(p) => div.push_paragraph(p),
             DivContent::Utterance(u) => div.push_utterance(u),
             DivContent::List(l) => div.push_list(l),
+            DivContent::Div(nested_div) => div.push_div(nested_div),
         }
     }
     Ok(div)
@@ -272,6 +288,15 @@ pub fn build_label(content: Vec<Inline>) -> Result<Label, TeiError> {
         Label::from_text("").map_err(|e| TeiError::xml(e.to_string()))
     } else {
         Label::new(content).map_err(|e| TeiError::xml(e.to_string()))
+    }
+}
+
+/// Builds a Head from inline content.
+pub fn build_head(content: Vec<Inline>) -> Result<Head, TeiError> {
+    if content.is_empty() {
+        Head::from_text("").map_err(|e| TeiError::xml(e.to_string()))
+    } else {
+        Head::new(content).map_err(|e| TeiError::xml(e.to_string()))
     }
 }
 

--- a/tei-xml/src/streaming/mod.rs
+++ b/tei-xml/src/streaming/mod.rs
@@ -38,7 +38,9 @@
 //! }
 //! ```
 
+mod content_handlers;
 mod event;
+mod finish_handlers;
 mod handlers;
 mod helpers;
 mod parser;

--- a/tei-xml/src/streaming/parser.rs
+++ b/tei-xml/src/streaming/parser.rs
@@ -158,6 +158,7 @@ impl<R: BufRead> TeiPullParser<R> {
             }
             ParserState::InParagraph { .. }
             | ParserState::InUtterance { .. }
+            | ParserState::InHead { .. }
             | ParserState::InEmphasis { .. } => {
                 self.handle_block_content_start(name_bytes, element)
             }
@@ -181,6 +182,7 @@ impl<R: BufRead> TeiPullParser<R> {
             | ParserState::InUtterance { .. }
             | ParserState::InEmphasis { .. }
             | ParserState::InDiv { .. }
+            | ParserState::InHead { .. }
             | ParserState::InList { .. }
             | ParserState::InItem { .. }
             | ParserState::InLabel { .. } => self.handle_body_content_end(name_bytes),
@@ -189,17 +191,18 @@ impl<R: BufRead> TeiPullParser<R> {
     }
 
     /// Dispatches an end-element event for states that represent body content
-    /// (`<p>`, `<u>`, `<hi>`, `<div>`, `<list>`, `<item>`, `<label>`).
+    /// (`<p>`, `<u>`, `<hi>`, `<div>`, `<head>`, `<list>`, `<item>`, `<label>`).
     ///
     /// Called only when `self.state` is already one of the `InParagraph`,
-    /// `InUtterance`, `InEmphasis`, `InDiv`, `InList`, `InItem`, or `InLabel`
-    /// variants; unrecognised tag names are silently ignored.
+    /// `InUtterance`, `InEmphasis`, `InDiv`, `InHead`, `InList`, `InItem`, or
+    /// `InLabel` variants; unrecognised tag names are silently ignored.
     fn handle_body_content_end(&mut self, name_bytes: &[u8]) -> Result<Option<TeiEvent>, TeiError> {
         match name_bytes {
             b"p" => self.finish_paragraph(),
             b"u" => self.finish_utterance(),
             b"hi" => self.finish_emphasis(),
             b"div" => self.finish_div(),
+            b"head" => self.finish_head(),
             b"list" => self.finish_list(),
             b"item" => self.finish_item(),
             b"label" => self.finish_label(),

--- a/tei-xml/src/streaming/parser.rs
+++ b/tei-xml/src/streaming/parser.rs
@@ -57,6 +57,12 @@ pub struct TeiPullParser<R: BufRead> {
     pub(super) reader: Reader<R>,
     pub(super) state: ParserState,
     pub(super) header: Option<TeiHeader>,
+    /// Pending parent `<div>` used while parsing direct paragraph and
+    /// utterance children so completed blocks can be attached or emitted.
+    ///
+    /// Nested structural containers use `ParserState::InDiv.parent_div`
+    /// instead, so this field is intentionally limited to the flat block
+    /// states that do not carry their own parent pointer.
     pub(super) pending_div_state: Option<Box<ParserState>>,
 }
 

--- a/tei-xml/src/streaming/state.rs
+++ b/tei-xml/src/streaming/state.rs
@@ -4,7 +4,7 @@
 //! pull parser to handle nested elements correctly and yield events at
 //! appropriate boundaries.
 
-use tei_core::{DivContent, Inline, Item, Label};
+use tei_core::{DivContent, Head, Inline, Item, Label};
 
 /// Raw TEI utterance attributes captured during streaming parsing.
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
@@ -97,10 +97,24 @@ pub enum ParserState {
     InDiv {
         /// Required `@type` attribute.
         div_type: String,
+        /// Optional `@subtype` attribute.
+        subtype: Option<String>,
         /// Optional `xml:id` attribute.
         id: Option<String>,
+        /// Optional heading captured before any child content.
+        head: Option<Head>,
+        /// Optional parent div state for nested divisions.
+        parent_div: Option<Box<ParserState>>,
         /// Accumulated content.
         content: Vec<DivContent>,
+    },
+
+    /// Inside a `<head>` element within a `<div>`.
+    InHead {
+        /// The parent div state to return to after closing `</head>`.
+        parent_div: Option<Box<ParserState>>,
+        /// Accumulated inline content.
+        content: Vec<Inline>,
     },
 
     /// Inside a `<list>` element within a `<div>`, accumulating items.
@@ -193,10 +207,31 @@ impl ParserState {
 
     /// Creates a new `InDiv` state with the given type and optional id.
     #[must_use]
-    pub const fn in_div(div_type: String, id: Option<String>) -> Self {
+    pub const fn in_div(div_type: String, subtype: Option<String>, id: Option<String>) -> Self {
         Self::InDiv {
             div_type,
+            subtype,
             id,
+            head: None,
+            parent_div: None,
+            content: Vec::new(),
+        }
+    }
+
+    /// Creates a new nested `InDiv` state with the given parent division.
+    #[must_use]
+    pub fn nested_div(
+        parent_div: Self,
+        div_type: String,
+        subtype: Option<String>,
+        id: Option<String>,
+    ) -> Self {
+        Self::InDiv {
+            div_type,
+            subtype,
+            id,
+            head: None,
+            parent_div: Some(Box::new(parent_div)),
             content: Vec::new(),
         }
     }
@@ -238,6 +273,15 @@ impl ParserState {
         }
     }
 
+    /// Creates a new `InHead` state with the given parent division.
+    #[must_use]
+    pub fn in_head(parent_div: Self) -> Self {
+        Self::InHead {
+            parent_div: Some(Box::new(parent_div)),
+            content: Vec::new(),
+        }
+    }
+
     /// Returns a mutable reference to the inline content of the current block state, if any.
     #[expect(
         clippy::missing_const_for_fn,
@@ -249,6 +293,7 @@ impl ParserState {
             | Self::InUtterance { content, .. }
             | Self::InEmphasis { content, .. }
             | Self::InItem { content, .. }
+            | Self::InHead { content, .. }
             | Self::InLabel { content, .. } => Some(content),
             _ => None,
         }
@@ -299,6 +344,7 @@ mod tests {
                 Self::InParagraph { .. }
                     | Self::InUtterance { .. }
                     | Self::InEmphasis { .. }
+                    | Self::InHead { .. }
                     | Self::InItem { .. }
                     | Self::InLabel { .. }
             )
@@ -337,7 +383,7 @@ mod tests {
         assert!(emphasis.is_in_block());
 
         let item = ParserState::in_item(
-            ParserState::in_list(ParserState::in_div("section".into(), None), None),
+            ParserState::in_list(ParserState::in_div("section".into(), None, None), None),
             Some("item1".into()),
             None,
             None,
@@ -362,7 +408,7 @@ mod tests {
 
     #[test]
     fn push_inline_in_item_state() {
-        let parent = ParserState::in_list(ParserState::in_div("section".into(), None), None);
+        let parent = ParserState::in_list(ParserState::in_div("section".into(), None, None), None);
         let mut item_state =
             ParserState::in_item(parent, Some("i1".into()), Some("1".into()), None);
         item_state.push_inline(Inline::Text("Item content".into()));
@@ -374,7 +420,7 @@ mod tests {
     #[test]
     fn push_inline_in_label_state() {
         let parent_item = ParserState::in_item(
-            ParserState::in_list(ParserState::in_div("section".into(), None), None),
+            ParserState::in_list(ParserState::in_div("section".into(), None, None), None),
             None,
             None,
             None,
@@ -384,6 +430,16 @@ mod tests {
 
         let content = label_state.take_content();
         assert_eq!(content, vec![Inline::Text("Label:".into())]);
+    }
+
+    #[test]
+    fn push_inline_in_head_state() {
+        let parent_div = ParserState::in_div("section".into(), None, None);
+        let mut head_state = ParserState::in_head(parent_div);
+        head_state.push_inline(Inline::Text("Heading".into()));
+
+        let content = head_state.take_content();
+        assert_eq!(content, vec![Inline::Text("Heading".into())]);
     }
 
     #[test]

--- a/tei-xml/src/streaming/state.rs
+++ b/tei-xml/src/streaming/state.rs
@@ -159,6 +159,22 @@ pub enum ParserState {
 }
 
 impl ParserState {
+    fn make_in_div(
+        div_type: String,
+        subtype: Option<String>,
+        id: Option<String>,
+        parent_div: Option<Box<Self>>,
+    ) -> Self {
+        Self::InDiv {
+            div_type,
+            subtype,
+            id,
+            head: None,
+            parent_div,
+            content: Vec::new(),
+        }
+    }
+
     /// Creates a new `InHeader` state with the given initial depth.
     #[must_use]
     pub const fn in_header(depth: usize) -> Self {
@@ -207,15 +223,8 @@ impl ParserState {
 
     /// Creates a new `InDiv` state with the given type and optional id.
     #[must_use]
-    pub const fn in_div(div_type: String, subtype: Option<String>, id: Option<String>) -> Self {
-        Self::InDiv {
-            div_type,
-            subtype,
-            id,
-            head: None,
-            parent_div: None,
-            content: Vec::new(),
-        }
+    pub fn in_div(div_type: String, subtype: Option<String>, id: Option<String>) -> Self {
+        Self::make_in_div(div_type, subtype, id, None)
     }
 
     /// Creates a new nested `InDiv` state with the given parent division.
@@ -226,14 +235,7 @@ impl ParserState {
         subtype: Option<String>,
         id: Option<String>,
     ) -> Self {
-        Self::InDiv {
-            div_type,
-            subtype,
-            id,
-            head: None,
-            parent_div: Some(Box::new(parent_div)),
-            content: Vec::new(),
-        }
+        Self::make_in_div(div_type, subtype, id, Some(Box::new(parent_div)))
     }
 
     /// Creates a new `InList` state with the given parent div and optional list id.

--- a/tei-xml/src/streaming/state.rs
+++ b/tei-xml/src/streaming/state.rs
@@ -159,7 +159,7 @@ pub enum ParserState {
 }
 
 impl ParserState {
-    fn make_in_div(
+    const fn make_in_div(
         div_type: String,
         subtype: Option<String>,
         id: Option<String>,
@@ -223,7 +223,7 @@ impl ParserState {
 
     /// Creates a new `InDiv` state with the given type and optional id.
     #[must_use]
-    pub fn in_div(div_type: String, subtype: Option<String>, id: Option<String>) -> Self {
+    pub const fn in_div(div_type: String, subtype: Option<String>, id: Option<String>) -> Self {
         Self::make_in_div(div_type, subtype, id, None)
     }
 

--- a/tei-xml/src/streaming/state.rs
+++ b/tei-xml/src/streaming/state.rs
@@ -103,7 +103,11 @@ pub enum ParserState {
         id: Option<String>,
         /// Optional heading captured before any child content.
         head: Option<Head>,
-        /// Optional parent div state for nested divisions.
+        /// Optional parent div state for nested structural divisions.
+        ///
+        /// This is distinct from `TeiPullParser::pending_div_state`, which is
+        /// only used while a direct paragraph or utterance child is being
+        /// assembled.
         parent_div: Option<Box<ParserState>>,
         /// Accumulated content.
         content: Vec<DivContent>,

--- a/tei-xml/tests/emit_div.rs
+++ b/tei-xml/tests/emit_div.rs
@@ -118,6 +118,25 @@ const COMPLEX_DIV: &str = concat!(
     "</TEI>",
 );
 
+const NESTED_DIV_WITH_HEAD: &str = concat!(
+    "<TEI>",
+    "<teiHeader>",
+    "<fileDesc><title>Test</title></fileDesc>",
+    "</teiHeader>",
+    "<text>",
+    "<body>",
+    "<div type=\"segment\" subtype=\"chapter-markers\" xml:id=\"seg1\">",
+    "<head>Chapter markers</head>",
+    "<div type=\"segment\" subtype=\"chapter-marker\" xml:id=\"ch1\">",
+    "<head>Cold open</head>",
+    "<u who=\"host\">Welcome back.</u>",
+    "</div>",
+    "</div>",
+    "</body>",
+    "</text>",
+    "</TEI>",
+);
+
 #[test]
 fn round_trips_div_structure() {
     let document = parse_xml(COMPLEX_DIV).expect("test fixture should parse");
@@ -190,4 +209,35 @@ fn round_trips_div_list_content() {
     assert_eq!(second_item.corresp(), None);
     assert!(second_item.label().is_none());
     assert_eq!(second_item.content(), &[Inline::Text("Second".into())]);
+}
+
+#[test]
+fn emits_nested_div_with_head_and_subtype_before_children() {
+    let document = parse_xml(NESTED_DIV_WITH_HEAD).expect("test fixture should parse");
+    let xml = emit_xml(&document).expect("document should emit");
+
+    assert!(xml.contains("<div type=\"segment\" subtype=\"chapter-markers\" xml:id=\"seg1\">"));
+    assert!(xml.contains("<head>Chapter markers</head><div type=\"segment\" subtype=\"chapter-marker\" xml:id=\"ch1\">"));
+    assert!(xml.contains("<head>Cold open</head><u who=\"host\">Welcome back.</u>"));
+}
+
+#[test]
+fn round_trips_nested_div_with_head_and_subtype() {
+    let document = parse_xml(NESTED_DIV_WITH_HEAD).expect("test fixture should parse");
+    let xml = emit_xml(&document).expect("document should emit");
+    let parsed = parse_xml(&xml).expect("emitted XML should parse");
+
+    let parsed_div = parsed
+        .text()
+        .body()
+        .divs()
+        .next()
+        .expect("should have a top-level div");
+    assert_eq!(parsed_div.subtype(), Some("chapter-markers"));
+    assert!(parsed_div.head().is_some());
+    let Some(DivContent::Div(child)) = parsed_div.content().first() else {
+        panic!("expected nested div as first child");
+    };
+    assert_eq!(child.subtype(), Some("chapter-marker"));
+    assert!(child.head().is_some());
 }

--- a/tei-xml/tests/emit_div.rs
+++ b/tei-xml/tests/emit_div.rs
@@ -53,6 +53,19 @@ const ITEM_WITH_LABEL: &str = concat!(
     "</TEI>",
 );
 
+const DIV_WITH_HEAD_ONLY: &str = concat!(
+    "<TEI>",
+    "<teiHeader>",
+    "<fileDesc><title>Test</title></fileDesc>",
+    "</teiHeader>",
+    "<text>",
+    "<body>",
+    "<div type=\"section\"><head>Intro</head></div>",
+    "</body>",
+    "</text>",
+    "</TEI>",
+);
+
 #[test]
 fn emits_div_with_paragraph() {
     let document = parse_xml(DIV_WITH_PARAGRAPH).expect("test fixture should parse");
@@ -216,9 +229,35 @@ fn emits_nested_div_with_head_and_subtype_before_children() {
     let document = parse_xml(NESTED_DIV_WITH_HEAD).expect("test fixture should parse");
     let xml = emit_xml(&document).expect("document should emit");
 
-    assert!(xml.contains("<div type=\"segment\" subtype=\"chapter-markers\" xml:id=\"seg1\">"));
-    assert!(xml.contains("<head>Chapter markers</head><div type=\"segment\" subtype=\"chapter-marker\" xml:id=\"ch1\">"));
-    assert!(xml.contains("<head>Cold open</head><u who=\"host\">Welcome back.</u>"));
+    let outer_div_index = xml
+        .find("<div type=\"segment\" subtype=\"chapter-markers\" xml:id=\"seg1\">")
+        .expect("outer div should be emitted");
+    let outer_head_index = xml
+        .find("<head>Chapter markers</head>")
+        .expect("outer head should be emitted");
+    let inner_div_index = xml
+        .find("<div type=\"segment\" subtype=\"chapter-marker\" xml:id=\"ch1\">")
+        .expect("inner div should be emitted");
+    let inner_head_index = xml
+        .find("<head>Cold open</head>")
+        .expect("inner head should be emitted");
+    let utterance_index = xml
+        .find("<u who=\"host\">Welcome back.</u>")
+        .expect("nested utterance should be emitted");
+
+    assert!(outer_div_index < outer_head_index);
+    assert!(outer_head_index < inner_div_index);
+    assert!(inner_div_index < inner_head_index);
+    assert!(inner_head_index < utterance_index);
+}
+
+#[test]
+fn emits_div_with_head_only_as_non_self_closing() {
+    let document = parse_xml(DIV_WITH_HEAD_ONLY).expect("test fixture should parse");
+    let xml = emit_xml(&document).expect("document should emit");
+
+    assert!(xml.contains("<div type=\"section\"><head>Intro</head></div>"));
+    assert!(!xml.contains("<div type=\"section\"/>"));
 }
 
 #[test]

--- a/tei-xml/tests/features/parse_xml.feature
+++ b/tei-xml/tests/features/parse_xml.feature
@@ -26,3 +26,9 @@ Feature: Parse TEI XML
     When I parse the TEI input
     Then parsing succeeds
     And the parsed document includes stand-off annotations and citation declarations
+
+  Scenario: Parse TEI with nested divisions, headings, and subtypes
+    Given the TEI fixture "nested-div"
+    When I parse the TEI input
+    Then parsing succeeds
+    And the parsed document includes nested divisions with headings and subtypes

--- a/tei-xml/tests/jing_validation.rs
+++ b/tei-xml/tests/jing_validation.rs
@@ -83,6 +83,7 @@ macro_rules! require_jing {
 #[case::utterances("utterances", fixtures::document_with_utterances)]
 #[case::comprehensive("comprehensive", fixtures::comprehensive_document)]
 #[case::div_list("div-list", fixtures::document_with_div_and_list)]
+#[case::nested_div("nested-div", fixtures::document_with_nested_divs)]
 fn validates_fixture(
     #[case] name: &str,
     #[case] builder: fn() -> Result<tei_core::TeiDocument, tei_core::TeiError>,

--- a/tei-xml/tests/parse_xml.rs
+++ b/tei-xml/tests/parse_xml.rs
@@ -5,7 +5,7 @@ use anyhow::{Context, bail, ensure};
 use rstest::fixture;
 use rstest_bdd_macros::{given, scenario, then, when};
 use std::cell::RefCell;
-use tei_core::{TeiDocument, TeiError};
+use tei_core::{BodyBlock, DivContent, TeiDocument, TeiError};
 use tei_test_helpers::expect_validated_state;
 use tei_xml::parse_xml;
 
@@ -76,6 +76,27 @@ const ANNOTATED_FIXTURE: &str = concat!(
     "</TEI>",
 );
 
+const NESTED_DIV_FIXTURE: &str = concat!(
+    "<TEI>",
+    "<teiHeader>",
+    "<fileDesc>",
+    "<title>Nested</title>",
+    "</fileDesc>",
+    "</teiHeader>",
+    "<text>",
+    "<body>",
+    "<div type=\"segment\" subtype=\"chapter-markers\" xml:id=\"seg1\">",
+    "<head>Chapter markers</head>",
+    "<div type=\"segment\" subtype=\"chapter-marker\" xml:id=\"ch1\">",
+    "<head>Cold open</head>",
+    "<u who=\"host\">Welcome back.</u>",
+    "</div>",
+    "</div>",
+    "</body>",
+    "</text>",
+    "</TEI>",
+);
+
 type DocumentResult = std::result::Result<TeiDocument, TeiError>;
 
 #[derive(Default)]
@@ -117,6 +138,7 @@ fn fixture_by_name(name: &str) -> anyhow::Result<&'static str> {
         "unterminated" => Ok(UNTERMINATED_FIXTURE),
         "blank-title" => Ok(BLANK_TITLE_FIXTURE),
         "annotated" => Ok(ANNOTATED_FIXTURE),
+        "nested-div" => Ok(NESTED_DIV_FIXTURE),
         other => bail!("unknown TEI fixture: {other}"),
     }
 }
@@ -234,6 +256,38 @@ fn parsed_document_includes_richer_tei(
     Ok(())
 }
 
+#[then("the parsed document includes nested divisions with headings and subtypes")]
+fn parsed_document_includes_nested_divisions(
+    #[from(validated_state)] state: &ParseState,
+) -> anyhow::Result<()> {
+    let document = state
+        .result()?
+        .context("expected successful parse before asserting nested divisions")?;
+    let Some(BodyBlock::Div(div)) = document.text().body().blocks().first() else {
+        bail!("expected a top-level div body block");
+    };
+    ensure!(
+        div.subtype() == Some("chapter-markers"),
+        "expected top-level div subtype to be chapter-markers"
+    );
+    ensure!(
+        div.head().is_some_and(|head| head.content().len() == 1),
+        "expected top-level div head content"
+    );
+    let Some(DivContent::Div(child)) = div.content().first() else {
+        bail!("expected nested div as first child");
+    };
+    ensure!(
+        child.subtype() == Some("chapter-marker"),
+        "expected nested div subtype to be chapter-marker"
+    );
+    ensure!(
+        child.head().is_some_and(|head| head.content().len() == 1),
+        "expected nested div head content"
+    );
+    Ok(())
+}
+
 #[scenario(path = "tests/features/parse_xml.feature", index = 0)]
 fn parses_valid_documents(
     #[from(validated_state)] _: ParseState,
@@ -252,6 +306,14 @@ fn reports_missing_headers(
 
 #[scenario(path = "tests/features/parse_xml.feature", index = 2)]
 fn reports_malformed_xml(
+    #[from(validated_state)] _: ParseState,
+    #[from(validated_state_result)] result: anyhow::Result<ParseState>,
+) {
+    expect_validated_state(result, "parse");
+}
+
+#[scenario(path = "tests/features/parse_xml.feature", index = 5)]
+fn parses_nested_divisions(
     #[from(validated_state)] _: ParseState,
     #[from(validated_state_result)] result: anyhow::Result<ParseState>,
 ) {

--- a/tei-xml/tests/streaming_behaviour.rs
+++ b/tei-xml/tests/streaming_behaviour.rs
@@ -607,6 +607,27 @@ const DIV_WITH_LIST_FIXTURE: &str = concat!(
     "</TEI>",
 );
 
+const NESTED_DIV_FIXTURE: &str = concat!(
+    "<TEI>",
+    "<teiHeader>",
+    "<fileDesc>",
+    "<title>Test</title>",
+    "</fileDesc>",
+    "</teiHeader>",
+    "<text>",
+    "<body>",
+    "<div type=\"segment\" subtype=\"chapter-markers\" xml:id=\"seg1\">",
+    "<head>Chapter markers</head>",
+    "<div type=\"segment\" subtype=\"chapter-marker\" xml:id=\"ch1\">",
+    "<head>Cold open</head>",
+    "<u who=\"host\">Welcome back.</u>",
+    "</div>",
+    "</div>",
+    "</body>",
+    "</text>",
+    "</TEI>",
+);
+
 #[test]
 fn streams_div_with_paragraphs_and_list_items() -> anyhow::Result<()> {
     use tei_core::{Div, DivContent};
@@ -679,6 +700,62 @@ fn streams_div_with_paragraphs_and_list_items() -> anyhow::Result<()> {
             .iter()
             .any(|i| matches!(i, Inline::Text(t) if t == "Second item")),
         "second item should contain 'Second item'"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn streams_nested_divs_with_headings_and_subtypes() -> anyhow::Result<()> {
+    use tei_core::DivContent;
+
+    let parser = TeiPullParser::from_str(NESTED_DIV_FIXTURE);
+
+    let mut divs = Vec::new();
+    for event in parser {
+        if let TeiEvent::BodyBlock(BodyBlock::Div(div)) = event? {
+            divs.push(div);
+        }
+    }
+
+    ensure!(
+        divs.len() == 1,
+        "expected exactly one top-level Div body block"
+    );
+    let div = divs.first().expect("should have a top-level div");
+    ensure!(div.div_type() == "segment", "expected top-level div type");
+    ensure!(
+        div.subtype() == Some("chapter-markers"),
+        "expected top-level div subtype"
+    );
+    ensure!(
+        div.head().is_some_and(|head| {
+            head.content()
+                .iter()
+                .any(|inline| matches!(inline, Inline::Text(text) if text == "Chapter markers"))
+        }),
+        "expected top-level heading text"
+    );
+
+    let Some(DivContent::Div(child)) = div.content().first() else {
+        bail!("expected nested div as first child");
+    };
+    ensure!(child.div_type() == "segment", "expected nested div type");
+    ensure!(
+        child.subtype() == Some("chapter-marker"),
+        "expected nested div subtype"
+    );
+    ensure!(
+        child.head().is_some_and(|head| {
+            head.content()
+                .iter()
+                .any(|inline| matches!(inline, Inline::Text(text) if text == "Cold open"))
+        }),
+        "expected nested heading text"
+    );
+    ensure!(
+        matches!(child.content().first(), Some(DivContent::Utterance(_))),
+        "expected nested utterance content"
     );
 
     Ok(())

--- a/tei-xml/tests/streaming_empty_elements.rs
+++ b/tei-xml/tests/streaming_empty_elements.rs
@@ -1,0 +1,40 @@
+//! Regression tests for streaming parser handling of unsupported empty
+//! elements.
+
+#![cfg(feature = "streaming")]
+
+use tei_xml::streaming::TeiPullParser;
+
+const EMPTY_ITEM_FIXTURE: &str = concat!(
+    "<TEI>",
+    "<teiHeader>",
+    "<fileDesc>",
+    "<title>Test</title>",
+    "</fileDesc>",
+    "</teiHeader>",
+    "<text>",
+    "<body>",
+    "<div type=\"segment\">",
+    "<list>",
+    "<item/>",
+    "</list>",
+    "</div>",
+    "</body>",
+    "</text>",
+    "</TEI>",
+);
+
+#[test]
+fn empty_item_in_list_is_reported_as_streaming_error() {
+    let parser = TeiPullParser::from_str(EMPTY_ITEM_FIXTURE);
+
+    let error = parser
+        .into_iter()
+        .find_map(Result::err)
+        .expect("empty <item/> should fail the streaming parse");
+
+    assert_eq!(
+        error.to_string(),
+        "XML processing error: unexpected empty element <item/> while parsing state InList"
+    );
+}


### PR DESCRIPTION
## Summary
- Expands from a simple nested-div concept to a full recursive Div model with optional <head> and @subtype, including a dedicated Head wrapper type and a DivSubtype mechanism. All layers (core, XML streaming, JSON schema, Python projections, and tests) are updated to round-trip nested divisions end-to-end.
- Adds a zero-or-one Head per Div and per-div subtype, with recursive DivContent handling to support deeply-nested structures.
- Introduces bounded-depth recursive validation to guard against pathological nesting; propagates depth awareness through core validation, pointer resolution, and streaming tests.
- Extends Python projections, JSON schema, and Serde tests to reflect the new nested-division model and the head/subtype fields. Adds a canonical nested-division fixture across layers.

## Changes
- Core model and exports
  - Added Head type (tei-core/src/text/body/head.rs).
  - Added DivSubtype and DivType handling (tei-core/src/text/div_types.rs).
  - tei-core/src/text/body/div.rs extended to support nested DivContent::Div, optional @subtype, and optional Head; added API to set/clear subtype and head and to push nested divisions.
  - tei-core/src/text/body/mod.rs exports Head and updates Div/DivContent exposure.
  - tei-core/src/text/mod.rs exports DivSubtype and Head alongside existing types.
- Validation
  - Recursive validation support for nested Divs added to tei-core/src/validation/mod.rs and tei-core/src/validation/pointers.rs.
  - Updated DivType/DivSubtype exposure and validation helpers in tei-core/src/text/types.rs.
  - Added max-depth checks to prevent pathological recursion; new ValidationError::TooDeep variant.
- XML streaming and emitter
  - XML streaming pipeline updated to support recursive divisions, including head placement, subtype, and nested div output.
  - tei-xml/src/emitter.rs emits @subtype and optional <head> prior to content; nested Divs emitted recursively.
  - Fixtures and streaming helpers updated to exercise nested divisions with head/subtype.
- Parser and state
  - tei-xml/src/streaming/state.rs extended to carry subtype/head and nested-division support, with new InHead state.
  - tei-xml/src/streaming/handlers.rs and content_handlers.rs updated to parse nested divisions, optional head, and subtype.
  - tei-xml/src/streaming/finish_handlers.rs and parser.rs extended to handle new states (InHead, InDiv) and recursive content.
- Python projections and tests
  - tei-py/python/structs.py extended to include Head and DivContent recursion; DivBlock updated to include subtype and head.
  - tei-py/src/projection/body.rs, events.rs, and mod.rs extended to project head and subtype and to support recursive DivContent.
  - tei-py/src/tests/div_structs.rs and tei-py/src/tests/projection_tests.rs extended to exercise nested divisions with head/subtype.
- JSON schema and Serde tests
  - tei-serde/src/schema.rs updated to include DivSubtype constraints; apply non-empty definitions for DivSubtype and Head usage.
  - tei-serde/tests/arbitrary/text.rs extended for recursive nested Div generation with bounded depth.
  - tei-serde/tests/json_schema_behaviour.rs updated to reflect nested DivContent, DivSubtype, and Head usage.
- Fixtures and tests
  - Extended tei-xml/tests fixtures and tests to cover nested divisions with head and subtype.
  - tei-core/tests/features/validation.feature and validation_behaviour tests extended for nested-division scenarios (duplicate xml:id inside nested divisions, unresolved pointers inside nested divisions).
  - tei-core/tests/validation_behaviour/scenario_order.rs updated to reflect new nested-division scenarios.
- Documentation and design
  - Updated docs/users-guide.md and docs/tei-rapporteur-design-document.md to describe nested divisions, head placement, and the zero-or-one head per division rule.
  - ExecPlan and design notes updated to reflect the canonical nested-division fixture and the end-to-end round-trip guarantees.
- Other repo-wide effects
  - Expanded fixtures and tests to include canonical nested-division example spanning core, XML, JSON schema, Python projections, and tests.

## Rationale
- The Episodic roadmap items require richer TEI structure in body divisions. This change implements true nested <div> blocks with optional head and subtype, along with a recursive content model. The design emphasizes additive changes, preserves the top-level BodyBlock surface, and enables round-tripping across all layers (core, streaming, schema, Python projections, and tests). The legacy single-level handling is retained as the entry point while enabling recursive nesting for future extensions.

## Testing plan (updated)
- Comprehensive tests now cover nested divisions, optional head/subtype, and recursive validation across multiple nesting depths across core, XML streaming, Python projections, and Serde layers.
- Tests include parsing/emitting nested divisions, recursive duplicate xml:id checks, unresolved pointers inside nested divisions, and Python projection round-trips for nested divisions with head/subtype.
- Note: some XML schema validation may require external tooling (jing); CI should validate where available.

## Documentation impact
- User guide and design document updated to describe recursive division model and the single-head-per-division rule.
- JSON schema and Python projection surfaces updated accordingly.

## Risks & mitigations
- Recursion depth and schema recursion: bounded-depth tests and explicit recursion handling reduce risk.
- Compatibility: additive changes only; top-level BodyBlock surface remains the entry point.
- XML streaming/serde coupling: recursive DivContent propagation and head/subtype emission are mirrored across emitter and parser.

## Notes for reviewers
- This PR moves from planning to implementation across core, XML, JSON/Serde, Python projections, and tests. Feedback on API ergonomics (head/subtype handling, recursive DivContent), performance implications, and edge cases in the recursive model is welcome.
- The canonical nested-division fixture demonstrates recursion, head, and subtype in a single tree and is used to guide future changes across layers.
- Task: https://www.devboxer.com/task/3e1b9fa1-9a1a-459d-beab-050dacf40922
