### PR TITLE
Document schema validation caveats for Div/DivContent

### DIFF
--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -11,7 +11,7 @@ available today and how to exercise it.
   paragraphs (`P`), utterances with optional speaker references, and thematic
   divisions (`Div`) that group paragraphs, utterances, and lists as
   `DivContent` children. Each block stores a sequence of `Inline` nodes,
-  allowing clients to mix plain text with emphasised `<hi>` spans and
+  allowing clients to mix plain text with emphasized `<hi>` spans and
   `<pause/>` cues without hand-rolling XML. Plain strings flow through
   `P::from_text_segments`, `Utterance::from_text_segments`,
   `Item::from_text_segments`, and `Label::from_text`; the older `P::new` and

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -19,22 +19,23 @@ available today and how to exercise it.
   callers. The `Div` type models `<div>` elements with a validated `@type`
   attribute (`DivType`), optional `@xml:id`, and a `Vec<DivContent>` of
   children. `DivContent` permits `Paragraph`, `Utterance`, and `List` children
-  inside a division. `List` holds an ordered `Vec<Item>`, and each `Item`
-  carries optional `@n` (numbering or timestamp), `@corresp` (pointer list),
-  `@xml:id`, an optional `Label` prefix, and inline content. `Label` wraps
-  `Vec<Inline>` content. `TeiDocument` now exposes `validate()` to enforce
-  document-wide rules: it rejects duplicate `xml:id` values across annotation
-  systems, paragraphs, utterances, divisions, lists, and items, and ensures
-  utterance speakers appear in the profile cast when it exists. An empty cast
-  still counts as declared—every `who` fails until the speakers are
-  populated—whereas the absence of a cast allows speaker references, so drafts
-  can be validated incrementally. Identifier checks span the header as well,
-  catching clashes between annotation systems and body blocks. Violations
-  surface as `TeiError::Validation`. Utterances now also carry local provenance
-  and citation attributes (`@n`, `@source`, `@resp`, `@cert`, `@corresp`,
-  `@ana`), and XML deserialization remains strict for `<u>` and `<item>`:
-  misspelt or unsupported attributes are rejected instead of being silently
-  discarded.
+  inside a division; see "Text Encoding Initiative (TEI) Episodic Profile
+  schema" below for the formal body content model. `List` holds an ordered
+  `Vec<Item>`, and each `Item` carries optional `@n` (numbering or timestamp),
+  `@corresp` (pointer list), `@xml:id`, an optional `Label` prefix, and inline
+  content. `Label` wraps `Vec<Inline>` content. `TeiDocument` now exposes
+  `validate()` to enforce document-wide rules: it rejects duplicate `xml:id`
+  values across annotation systems, paragraphs, utterances, divisions, lists,
+  and items, and ensures utterance speakers appear in the profile cast when it
+  exists. An empty cast still counts as declared—every `who` fails until the
+  speakers are populated—whereas the absence of a cast allows speaker
+  references, so drafts can be validated incrementally. Identifier checks span
+  the header as well, catching clashes between annotation systems and body
+  blocks. Violations surface as `TeiError::Validation`. Utterances now also
+  carry local provenance and citation attributes (`@n`, `@source`, `@resp`,
+  `@cert`, `@corresp`, `@ana`), and XML deserialization remains strict for
+  `<u>` and `<item>`: misspelt or unsupported attributes are rejected instead
+  of being silently discarded.
 - `tei-xml` depends on the core crate and now covers both directions of XML
   flow. `serialize_document_title(raw_title)` still emits a `<title>` snippet,
   `parse_xml(xml)` wraps `quick-xml` to materialize full `TeiDocument` values,
@@ -320,8 +321,8 @@ The profile supports:
   (`<item>`) that carry optional `@n` (numbering or timestamp metadata),
   `@corresp` (pointer list for cross-references), and `@xml:id`. Each item may
   include an optional label prefix (`<label>`) followed by inline content.
-  Lists are permitted within `<div>` elements only; `<body>` admits top-level
-  `<p>`, `<u>`, and `<div>` children, not bare `<list>` elements.
+  Lists are permitted within `<div>` elements only; `<list>` cannot appear
+  directly as a child of `<body>` and must instead be wrapped in a `<div>`.
 - **Stand-off overlays**: root-level `<standOff>` containers with
   `<spanGrp>`/`<span>` layers for many-to-many citation and analytical markup
 - **Inline elements**: emphasis (`<hi>` with optional `@rend` attribute), pause

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -10,15 +10,14 @@ available today and how to exercise it.
   `TeiHeader` and body-aware `TeiText`. The text model records ordered
   paragraphs (`P`), utterances with optional speaker references, and thematic
   divisions (`Div`) that group paragraphs, utterances, and lists as
-  `DivContent` children. Each block
-  stores a sequence of `Inline` nodes, allowing clients to mix plain text with
-  emphasised `<hi>` spans and `<pause/>` cues without hand-rolling XML. Plain
-  strings flow through `P::from_text_segments`,
-  `Utterance::from_text_segments`, `Item::from_text_segments`, and
-  `Label::from_text`; the older `P::new` and `Utterance::new` constructors
-  remain as deprecated shims for existing callers. The `Div` type models
-  `<div>` elements with a validated
-  `@type` attribute (`DivType`), optional `@xml:id`, and a `Vec<DivContent>` of
+  `DivContent` children. Each block stores a sequence of `Inline` nodes,
+  allowing clients to mix plain text with emphasised `<hi>` spans and
+  `<pause/>` cues without hand-rolling XML. Plain strings flow through
+  `P::from_text_segments`, `Utterance::from_text_segments`,
+  `Item::from_text_segments`, and `Label::from_text`; the older `P::new` and
+  `Utterance::new` constructors remain as deprecated shims for existing
+  callers. The `Div` type models `<div>` elements with a validated `@type`
+  attribute (`DivType`), optional `@xml:id`, and a `Vec<DivContent>` of
   children. `DivContent` permits `Paragraph`, `Utterance`, and `List` children
   inside a division. `List` holds an ordered `Vec<Item>`, and each `Item`
   carries optional `@n` (numbering or timestamp), `@corresp` (pointer list),
@@ -320,7 +319,9 @@ The profile supports:
   paragraphs, utterances, and lists (`<list>`). Lists hold ordered items
   (`<item>`) that carry optional `@n` (numbering or timestamp metadata),
   `@corresp` (pointer list for cross-references), and `@xml:id`. Each item may
-  include an optional label prefix (`<label>`) followed by inline content
+  include an optional label prefix (`<label>`) followed by inline content.
+  Lists are permitted within `<div>` elements only; `<body>` admits top-level
+  `<p>`, `<u>`, and `<div>` children, not bare `<list>` elements.
 - **Stand-off overlays**: root-level `<standOff>` containers with
   `<spanGrp>`/`<span>` layers for many-to-many citation and analytical markup
 - **Inline elements**: emphasis (`<hi>` with optional `@rend` attribute), pause


### PR DESCRIPTION
## Summary
- Updates the user guide to document caveats around schema validation for Div/DivContent and related top-level structure rules.

## Changes
### Documentation updates
- Updated docs/users-guide.md to reflect schema validation caveats:
  - Div models <div> elements with a validated @type attribute (DivType), optional @xml:id, and a Vec<DivContent> of children.
  - DivContent permits Paragraph, Utterance, and List inside a division.
  - List holds an ordered Vec<Item>, and each Item carries optional @n (numbering or timestamp), @corresp (pointer list), and @xml:id.
  - Each Item may include an optional label prefix (<label>) followed by inline content.
  - Lists are permitted within <div> elements only; <body> admits top-level <p>, <u>, and <div> children, not bare <list> elements.
  - The docs note that older constructors (P::new and Utterance::new) remain deprecated shims for existing callers, aligning with the codebase’s evolution.

This aligns the documentation with the code’s schema expectations and helps users avoid common validation pitfalls when composing TEI-rapporteur documents.

## Why this matters
- Clear guidance on what the schema validates for Div and DivContent, and where lists are allowed, reduces confusion and prevents invalid document structures.

## Review guidance
- Verify that the updated descriptions match the intended schema behavior in the code:
  - DivType is the validated @type for Div
  - DivContent supports Paragraph, Utterance, and List inside Div
  - List and Item attributes (@n, @corresp, @xml:id) as described
  - Placement rules: lists only inside div, body allows p/u/div at top level
- Ensure terminology and examples in the docs stay consistent with other sections of the user guide.

◳ Generated by [DevBoxer](https://www.devboxer.com) ◰

---

ℹ️ Tag @devboxerhub to ask questions and address PR feedback

📎 **Task**: https://www.devboxer.com/task/8abf8337-6a4e-42e7-bfa9-f2a825d99dab

## Summary by Sourcery

Documentation:
- Clarify how Div models <div> elements, which child types DivContent permits, and the attributes supported on List and Item elements, including validation behavior and placement rules.