### PR TITLE
Document guest-bio corresp fixtures (2.3.3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2216,6 +2216,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "gherkin 0.16.0",
+ "proptest",
  "rstest",
  "rstest-bdd",
  "rstest-bdd-macros",
@@ -2277,6 +2278,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "criterion",
+ "proptest",
  "quick-xml",
  "rstest",
  "rstest-bdd",

--- a/docs/tei-rapporteur-design-document.md
+++ b/docs/tei-rapporteur-design-document.md
@@ -76,6 +76,17 @@ feel natural to Python users**.
   `@subtype`, and a single optional leading `Head` wrapper for `<head>`.
 - `List` holds ordered `Item` values, and each `Item` may expose a dedicated
   `Label` node plus inline content and an optional `@corresp` pointer list.
+- Guest biographies use the existing structural pattern rather than a bespoke
+  personography branch: `<div type="guest-bios">` contains a `<list>` of
+  labelled `<item>` entries, and each item may use external `@corresp` values
+  such as Episodic reference-document revision URNs.
+- `#...` correspondence pointers remain internal references and must resolve
+  to an `xml:id` in the same TEI document. Repository-owned objects that live
+  outside the TEI payload should therefore use external `urn:`, `tag:`, or
+  `https:` identifiers in `@corresp`.
+- `Item` does not expose `@source` in this structural extension. The current
+  guest-bio integration uses `@corresp`; stronger provenance semantics can be
+  added later as a separate public body-model change if needed.
 - The streaming parser buffers an entire `Div` before yielding a single
   `BodyBlock::Div` event. This preserves the existing event model instead of
   introducing enter/exit events for structural containers.

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -324,6 +324,36 @@ Validation raises `ValueError` with a descriptive message when:
 Documents without a profile cast allow speaker references without validation,
 enabling incremental validation of draft documents.
 
+
+### Correspondence pointers
+
+`@corresp` values follow TEI pointer semantics. A value beginning with `#` is
+an internal pointer and must resolve to an `xml:id` in the same TEI document.
+Use this form only when the referenced node is materialised in the document.
+Validation rejects unresolved internal pointers so callers do not accidentally
+ship dangling local references.
+
+External identifiers such as `urn:...`, `tag:...`, or `https://...` may be used
+when the target lives outside the TEI document. Repository-owned objects,
+including Episodic reference-document revisions, should use an external
+identifier in `@corresp` unless that object is also represented in the same TEI
+document with an `xml:id`.
+
+Guest biographies therefore link to their source reference revision as an
+external correspondence:
+
+```xml
+<item corresp="urn:episodic:reference-document-revision:019e1368">
+  <label>Ada Lovelace</label>
+  Mathematician and computing pioneer.
+</item>
+```
+
+`tei-rapporteur` currently supports `@corresp`, `@n`, and `xml:id` on list
+items. `@source` on `Item` is not part of the public body model yet; it may be
+considered later if callers need stricter provenance semantics beyond the
+current correspondence link.
+
 ## Text Encoding Initiative (TEI) Episodic Profile schema
 
 The TEI Episodic Profile is formally documented in an ODD (One Document Does it
@@ -459,6 +489,9 @@ Episodic Profile:
   speakers via `@who`
 - **div-list**: Body containing `<div type="...">` elements with nested
   `<list>`, `<item>`, and `<label>` children
+- **guest-bios**: Body containing `<div type="guest-bios">` with nested
+  guest-biography items whose `@corresp` values point at external reference
+  revisions
 - **comprehensive**: All profile features combined (synopsis, speakers,
   languages, annotation systems, revision history, mixed body content including
   divisions)

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -324,7 +324,6 @@ Validation raises `ValueError` with a descriptive message when:
 Documents without a profile cast allow speaker references without validation,
 enabling incremental validation of draft documents.
 
-
 ### Correspondence pointers
 
 `@corresp` values follow TEI pointer semantics. A value beginning with `#` is

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -329,7 +329,7 @@ enabling incremental validation of draft documents.
 
 `@corresp` values follow TEI pointer semantics. A value beginning with `#` is
 an internal pointer and must resolve to an `xml:id` in the same TEI document.
-Use this form only when the referenced node is materialised in the document.
+Use this form only when the referenced node is materialized in the document.
 Validation rejects unresolved internal pointers so callers do not accidentally
 ship dangling local references.
 

--- a/tei-core/Cargo.toml
+++ b/tei-core/Cargo.toml
@@ -19,6 +19,7 @@ thiserror = { workspace = true }
 
 [dev-dependencies]
 anyhow = { workspace = true }
+proptest = { workspace = true }
 rstest = { workspace = true }
 rstest-bdd = { workspace = true }
 rstest-bdd-macros = { workspace = true }

--- a/tei-core/tests/corresp_validation_props.rs
+++ b/tei-core/tests/corresp_validation_props.rs
@@ -1,0 +1,69 @@
+//! Property tests for `@corresp` pointer validation.
+
+use anyhow::Context;
+use proptest::prelude::*;
+use tei_core::{Div, Item, List, PointerList, TeiDocument};
+
+fn external_pointer() -> impl Strategy<Value = String> {
+    prop_oneof![
+        prop::string::string_regex("urn:[a-z]{2,8}:[a-z0-9\\-]{1,20}:[a-z0-9]{8,16}")
+            .unwrap_or_else(|error| panic!("URN pointer regex should compile: {error}")),
+        prop::string::string_regex("tag:[a-z0-9.\\-]{3,30},[0-9]{4}:[a-z0-9\\-]{1,20}")
+            .unwrap_or_else(|error| panic!("tag pointer regex should compile: {error}")),
+        prop::string::string_regex("https://[a-z]{3,10}\\.[a-z]{2,6}/[a-z0-9/\\-]{1,30}")
+            .unwrap_or_else(|error| panic!("HTTPS pointer regex should compile: {error}")),
+    ]
+}
+
+fn internal_pointer() -> impl Strategy<Value = String> {
+    prop::string::string_regex("#[a-zA-Z][a-zA-Z0-9_\\-]{1,20}")
+        .unwrap_or_else(|error| panic!("internal pointer regex should compile: {error}"))
+}
+
+fn document_with_corresp(corresp: &str) -> anyhow::Result<TeiDocument> {
+    let document =
+        TeiDocument::from_title_str("Corresp Property").context("document should construct")?;
+    let mut item = Item::from_text_segments(["External reference"]).context("item should build")?;
+    item.set_corresp(PointerList::new([corresp])?);
+    let list = List::new([item]).context("list should be valid")?;
+    let mut div = Div::new("references").context("division should be valid")?;
+    div.push_list(list);
+    let mut text = document.text().clone();
+    text.body_mut().push_div(div);
+    Ok(TeiDocument::new(document.header().clone(), text))
+}
+
+fn prop_result<T>(result: anyhow::Result<T>) -> Result<T, TestCaseError> {
+    result.map_err(|error| TestCaseError::fail(error.to_string()))
+}
+
+mod corresp_validation_props {
+    use super::*;
+
+    proptest! {
+        #[test]
+        fn external_corresp_pointers_pass_validation(pointer in external_pointer()) {
+            let document = prop_result(document_with_corresp(&pointer))?;
+            let validation = document.validate();
+            prop_assert!(validation.is_ok(), "external pointer should validate: {validation:?}");
+        }
+
+        #[test]
+        fn unresolved_internal_corresp_pointers_fail_validation(pointer in internal_pointer()) {
+            let document = prop_result(document_with_corresp(&pointer))?;
+            let error = document
+                .validate()
+                .err()
+                .ok_or_else(|| TestCaseError::fail("unresolved internal pointer should fail"))?;
+            let message = error.to_string();
+            prop_assert!(
+                message.contains("internal pointer"),
+                "validation error should mention internal pointer: {message}"
+            );
+            prop_assert!(
+                message.contains("does not resolve"),
+                "validation error should mention unresolved target: {message}"
+            );
+        }
+    }
+}

--- a/tei-core/tests/features/validation.feature
+++ b/tei-core/tests/features/validation.feature
@@ -82,6 +82,12 @@ Feature: TEI document validation
     And I validate the document
     Then validation fails with "duplicate xml:id 'dup'"
 
+  Scenario: Accepting external item corresp pointers inside divisions
+    Given a TEI document titled "Night Vale"
+    When I add a division "guest-bios" containing an item with corresp "urn:episodic:reference-document-revision:019e1368"
+    And I validate the document
+    Then validation succeeds
+
   Scenario: Rejecting unresolved item corresp pointers inside divisions
     Given a TEI document titled "Night Vale"
     When I add a division "show-notes" containing an item with corresp "#missing"

--- a/tei-core/tests/validation_behaviour.rs
+++ b/tei-core/tests/validation_behaviour.rs
@@ -1,0 +1,4 @@
+//! Integration-test harness for document-level validation behaviour.
+
+#[path = "validation_behaviour/mod.rs"]
+mod validation_behaviour;

--- a/tei-core/tests/validation_behaviour/mod.rs
+++ b/tei-core/tests/validation_behaviour/mod.rs
@@ -7,8 +7,8 @@ use std::cell::RefCell;
 use tei_core::{Div, Item, List, P, ProfileDesc, TeiDocument, TeiError, Utterance};
 use tei_test_helpers::expect_validated_state;
 
-mod stand_off;
 mod scenario_order;
+mod stand_off;
 
 #[derive(Default)]
 struct ValidationState {
@@ -138,7 +138,8 @@ fn i_add_a_division_containing_an_item_with_id(
     identifier: String,
 ) -> Result<()> {
     state.update_document(|document| {
-        let mut item = Item::from_text_segments(["Linked resource"]).context("item should be valid")?;
+        let mut item =
+            Item::from_text_segments(["Linked resource"]).context("item should be valid")?;
         item.set_id(identifier.as_str())
             .context("identifier should validate")?;
         let list = List::new([item]).context("list should be valid")?;
@@ -176,7 +177,8 @@ fn i_add_a_nested_division_containing_an_item_with_id(
     identifier: String,
 ) -> Result<()> {
     state.update_document(|document| {
-        let mut item = Item::from_text_segments(["Nested resource"]).context("item should be valid")?;
+        let mut item =
+            Item::from_text_segments(["Nested resource"]).context("item should be valid")?;
         item.set_id(identifier.as_str())
             .context("identifier should validate")?;
         let list = List::new([item]).context("list should be valid")?;
@@ -366,7 +368,7 @@ fn rejects_duplicate_identifiers_inside_divisions(
 }
 
 #[scenario(path = "tests/features/validation.feature", index = 11)]
-fn rejects_unresolved_item_corresp_pointers_inside_divisions(
+fn accepts_external_item_corresp_pointers_inside_divisions(
     #[from(validated_state)] _: ValidationState,
     #[from(validated_state_result)] validated_state: Result<ValidationState>,
 ) {
@@ -374,7 +376,7 @@ fn rejects_unresolved_item_corresp_pointers_inside_divisions(
 }
 
 #[scenario(path = "tests/features/validation.feature", index = 12)]
-fn rejects_duplicate_identifiers_inside_nested_divisions(
+fn rejects_unresolved_item_corresp_pointers_inside_divisions(
     #[from(validated_state)] _: ValidationState,
     #[from(validated_state_result)] validated_state: Result<ValidationState>,
 ) {
@@ -382,6 +384,14 @@ fn rejects_duplicate_identifiers_inside_nested_divisions(
 }
 
 #[scenario(path = "tests/features/validation.feature", index = 13)]
+fn rejects_duplicate_identifiers_inside_nested_divisions(
+    #[from(validated_state)] _: ValidationState,
+    #[from(validated_state_result)] validated_state: Result<ValidationState>,
+) {
+    expect_validated_state(validated_state, "validation");
+}
+
+#[scenario(path = "tests/features/validation.feature", index = 14)]
 fn rejects_unresolved_item_corresp_pointers_inside_nested_divisions(
     #[from(validated_state)] _: ValidationState,
     #[from(validated_state_result)] validated_state: Result<ValidationState>,

--- a/tei-core/tests/validation_behaviour/scenario_order.rs
+++ b/tei-core/tests/validation_behaviour/scenario_order.rs
@@ -27,6 +27,7 @@ fn validation_feature_scenario_order_matches_expectations() {
         "Rejecting stand-off spans that target missing ids",
         "Rejecting stand-off spans without anchors",
         "Rejecting duplicate xml:id values inside divisions",
+        "Accepting external item corresp pointers inside divisions",
         "Rejecting unresolved item corresp pointers inside divisions",
         "Rejecting duplicate xml:id values inside nested divisions",
         "Rejecting unresolved item corresp pointers inside nested divisions",

--- a/tei-xml/Cargo.toml
+++ b/tei-xml/Cargo.toml
@@ -27,6 +27,7 @@ tracing = { workspace = true }
 
 [dev-dependencies]
 anyhow = { workspace = true }
+proptest = { workspace = true }
 rstest = { workspace = true }
 rstest-bdd = { workspace = true }
 rstest-bdd-macros = { workspace = true }

--- a/tei-xml/src/fixtures/mod.rs
+++ b/tei-xml/src/fixtures/mod.rs
@@ -207,6 +207,36 @@ pub fn document_with_div_and_list() -> Result<TeiDocument, TeiError> {
     Ok(TeiDocument::new(header, text))
 }
 
+/// Returns a document whose body contains generated guest biographies.
+///
+/// # Errors
+///
+/// Returns [`TeiError`] when any component of the document cannot be
+/// constructed.
+pub fn document_with_guest_bios() -> Result<TeiDocument, TeiError> {
+    let file_desc = FileDesc::from_title_str("Guest Biography Fixture")?;
+    let header = TeiHeader::new(file_desc);
+
+    let label = Label::from_text("Ada Lovelace")?;
+    let mut item = Item::from_text_segments(["Mathematician and computing pioneer."])?;
+    item.set_id("guest-bio-ada")?;
+    item.set_corresp(PointerList::new([
+        "urn:episodic:reference-document-revision:019e1368",
+    ])?);
+    item.set_label(label);
+
+    let mut list = List::new([item])?;
+    list.set_id("guest-bio-list")?;
+
+    let mut div = Div::new("guest-bios")?;
+    div.set_id("guest-bios")?;
+    div.push_list(list);
+
+    let body = TeiBody::new([BodyBlock::Div(div)]);
+    let text = TeiText::new(body);
+    Ok(TeiDocument::new(header, text))
+}
+
 /// Returns a document with nested divisions, headings, and subtypes.
 ///
 /// # Errors
@@ -248,6 +278,7 @@ pub fn fixture_builders() -> Vec<NamedFixture> {
         ("utterances", document_with_utterances),
         ("comprehensive", comprehensive_document),
         ("div-list", document_with_div_and_list),
+        ("guest-bios", document_with_guest_bios),
         ("nested-div", document_with_nested_divs),
     ]
 }
@@ -288,6 +319,12 @@ mod tests {
     #[test]
     fn document_with_div_and_list_builds_successfully() {
         let doc = document_with_div_and_list().expect("division fixture should build");
+        assert_eq!(doc.text().body().blocks().len(), 1);
+    }
+
+    #[test]
+    fn document_with_guest_bios_builds_successfully() {
+        let doc = document_with_guest_bios().expect("guest biographies fixture should build");
         assert_eq!(doc.text().body().blocks().len(), 1);
     }
 

--- a/tei-xml/tests/emit_div.rs
+++ b/tei-xml/tests/emit_div.rs
@@ -1,5 +1,6 @@
 //! Tests for div, list, and item XML emission.
 
+use rstest::rstest;
 use tei_core::{DivContent, Inline, PointerList};
 use tei_xml::{emit_xml, parse_xml};
 
@@ -46,6 +47,27 @@ const ITEM_WITH_LABEL: &str = concat!(
     "<div type=\"labeled-list\">",
     "<list>",
     "<item><label>Label:</label>Item content</item>",
+    "</list>",
+    "</div>",
+    "</body>",
+    "</text>",
+    "</TEI>",
+);
+
+const GUEST_BIOS_DIV: &str = concat!(
+    "<TEI>",
+    "<teiHeader>",
+    "<fileDesc><title>Guest Bios</title></fileDesc>",
+    "</teiHeader>",
+    "<text>",
+    "<body>",
+    "<div type=\"guest-bios\" xml:id=\"guest-bios\">",
+    "<list xml:id=\"guest-bio-list\">",
+    "<item xml:id=\"guest-bio-ada\" ",
+    "corresp=\"urn:episodic:reference-document-revision:019e1368\">",
+    "<label>Ada Lovelace</label>",
+    "Mathematician and computing pioneer.",
+    "</item>",
     "</list>",
     "</div>",
     "</body>",
@@ -249,6 +271,63 @@ fn emits_nested_div_with_head_and_subtype_before_children() {
     assert!(outer_head_index < inner_div_index);
     assert!(inner_div_index < inner_head_index);
     assert!(inner_head_index < utterance_index);
+}
+
+#[rstest]
+#[case::episodic_reference_revision(
+    GUEST_BIOS_DIV,
+    "urn:episodic:reference-document-revision:019e1368"
+)]
+fn round_trips_guest_bios_with_external_corresp(#[case] xml: &str, #[case] corresp: &str) {
+    let document = parse_xml(xml).expect("guest-bios fixture should parse");
+    document
+        .validate()
+        .expect("guest-bios fixture should validate");
+
+    let parsed_div = document
+        .text()
+        .body()
+        .divs()
+        .next()
+        .expect("guest-bios fixture should contain a div");
+    assert_eq!(parsed_div.div_type(), "guest-bios");
+    assert_eq!(
+        parsed_div.id().map(tei_core::XmlId::as_str),
+        Some("guest-bios")
+    );
+
+    let Some(DivContent::List(list)) = parsed_div.content().first() else {
+        panic!("guest-bios div should contain a list");
+    };
+    assert_eq!(
+        list.id().map(tei_core::XmlId::as_str),
+        Some("guest-bio-list")
+    );
+
+    let item = list
+        .items()
+        .first()
+        .expect("guest-bios list should have an item");
+    assert_eq!(
+        item.id().map(tei_core::XmlId::as_str),
+        Some("guest-bio-ada")
+    );
+    let label = item.label().expect("guest bio item should have a label");
+    assert_eq!(label.content(), &[Inline::Text("Ada Lovelace".into())]);
+    assert_eq!(
+        item.content(),
+        &[Inline::Text("Mathematician and computing pioneer.".into())]
+    );
+    let expected_corresp =
+        PointerList::parse_attribute(corresp).expect("fixture corresp should be valid");
+    assert_eq!(item.corresp(), Some(&expected_corresp));
+
+    let emitted = emit_xml(&document).expect("guest-bios fixture should emit");
+    assert!(
+        emitted.contains("corresp=\"urn:episodic:reference-document-revision:019e1368\""),
+        "emitted XML should preserve the external @corresp value"
+    );
+    parse_xml(&emitted).expect("emitted guest-bios XML should parse again");
 }
 
 #[test]

--- a/tei-xml/tests/emit_div.rs
+++ b/tei-xml/tests/emit_div.rs
@@ -278,7 +278,10 @@ fn emits_nested_div_with_head_and_subtype_before_children() {
     GUEST_BIOS_DIV,
     "urn:episodic:reference-document-revision:019e1368"
 )]
-fn round_trips_guest_bios_with_external_corresp(#[case] xml: &str, #[case] corresp: &str) {
+fn round_trips_guest_bios_with_external_corresp(
+    #[case] xml: &str,
+    #[case] expected_corresp_value: &str,
+) {
     let document = parse_xml(xml).expect("guest-bios fixture should parse");
     document
         .validate()
@@ -318,16 +321,19 @@ fn round_trips_guest_bios_with_external_corresp(#[case] xml: &str, #[case] corre
         item.content(),
         &[Inline::Text("Mathematician and computing pioneer.".into())]
     );
-    let expected_corresp =
-        PointerList::parse_attribute(corresp).expect("fixture corresp should be valid");
+    let expected_corresp = PointerList::parse_attribute(expected_corresp_value)
+        .expect("fixture corresp should be valid");
     assert_eq!(item.corresp(), Some(&expected_corresp));
 
-    let emitted = emit_xml(&document).expect("guest-bios fixture should emit");
+    let corresp = emit_xml(&document).expect("guest-bios fixture should emit");
     assert!(
-        emitted.contains("corresp=\"urn:episodic:reference-document-revision:019e1368\""),
+        corresp.contains("corresp=\"urn:episodic:reference-document-revision:019e1368\""),
         "emitted XML should preserve the external @corresp value"
     );
-    parse_xml(&emitted).expect("emitted guest-bios XML should parse again");
+    let parsed = parse_xml(&corresp).expect("emitted guest-bios XML should parse again");
+    parsed
+        .validate()
+        .expect("reparsed guest-bios XML should validate");
 }
 
 #[test]

--- a/tei-xml/tests/emit_div.rs
+++ b/tei-xml/tests/emit_div.rs
@@ -326,8 +326,9 @@ fn round_trips_guest_bios_with_external_corresp(
     assert_eq!(item.corresp(), Some(&expected_corresp));
 
     let corresp = emit_xml(&document).expect("guest-bios fixture should emit");
+    let expected_corresp_attr = format!("corresp=\"{expected_corresp_value}\"");
     assert!(
-        corresp.contains("corresp=\"urn:episodic:reference-document-revision:019e1368\""),
+        corresp.contains(&expected_corresp_attr),
         "emitted XML should preserve the external @corresp value"
     );
     let parsed = parse_xml(&corresp).expect("emitted guest-bios XML should parse again");

--- a/tei-xml/tests/features/parse_xml.feature
+++ b/tei-xml/tests/features/parse_xml.feature
@@ -32,3 +32,9 @@ Feature: Parse TEI XML
     When I parse the TEI input
     Then parsing succeeds
     And the parsed document includes nested divisions with headings and subtypes
+
+  Scenario: Parse guest biographies with external reference bindings
+    Given the TEI fixture "guest-bios"
+    When I parse the TEI input
+    Then parsing succeeds
+    And the parsed document includes guest bios linked to an external reference revision

--- a/tei-xml/tests/features/parse_xml.feature
+++ b/tei-xml/tests/features/parse_xml.feature
@@ -38,3 +38,4 @@ Feature: Parse TEI XML
     When I parse the TEI input
     Then parsing succeeds
     And the parsed document includes guest bios linked to an external reference revision
+    And the emitted guest-bios XML round-trips cleanly

--- a/tei-xml/tests/guest_bios_round_trip_props.rs
+++ b/tei-xml/tests/guest_bios_round_trip_props.rs
@@ -1,0 +1,63 @@
+//! Property tests for guest-biography XML round-tripping.
+
+use anyhow::Context;
+use proptest::prelude::*;
+use tei_core::{BodyBlock, Div, FileDesc, Item, Label, List, PointerList, TeiHeader, TeiText};
+use tei_xml::{emit_xml, parse_xml};
+
+fn external_pointer() -> impl Strategy<Value = String> {
+    prop_oneof![
+        prop::string::string_regex("urn:[a-z]{2,8}:[a-z0-9\\-]{1,20}:[a-z0-9]{8,16}")
+            .unwrap_or_else(|error| panic!("URN pointer regex should compile: {error}")),
+        prop::string::string_regex("tag:[a-z0-9.\\-]{3,30},[0-9]{4}:[a-z0-9\\-]{1,20}")
+            .unwrap_or_else(|error| panic!("tag pointer regex should compile: {error}")),
+        prop::string::string_regex("https://[a-z]{3,10}\\.[a-z]{2,6}/[a-z0-9/\\-]{1,30}")
+            .unwrap_or_else(|error| panic!("HTTPS pointer regex should compile: {error}")),
+    ]
+}
+
+fn document_with_guest_bios_corresp(corresp: &str) -> anyhow::Result<tei_core::TeiDocument> {
+    let file_desc = FileDesc::from_title_str("Guest Biography Fixture")?;
+    let header = TeiHeader::new(file_desc);
+
+    let label = Label::from_text("Ada Lovelace")?;
+    let mut item = Item::from_text_segments(["Mathematician and computing pioneer."])?;
+    item.set_id("guest-bio-ada")?;
+    item.set_corresp(PointerList::new([corresp])?);
+    item.set_label(label);
+
+    let mut list = List::new([item])?;
+    list.set_id("guest-bio-list")?;
+
+    let mut div = Div::new("guest-bios")?;
+    div.set_id("guest-bios")?;
+    div.push_list(list);
+
+    let body = tei_core::TeiBody::new([BodyBlock::Div(div)]);
+    let text = TeiText::new(body);
+    Ok(tei_core::TeiDocument::new(header, text))
+}
+
+fn prop_result<T>(result: anyhow::Result<T>) -> Result<T, TestCaseError> {
+    result.map_err(|error| TestCaseError::fail(error.to_string()))
+}
+
+mod guest_bios_round_trip_props {
+    use super::*;
+
+    proptest! {
+        #[test]
+        fn guest_bio_external_corresp_survives_round_trip(pointer in external_pointer()) {
+            let document = prop_result(document_with_guest_bios_corresp(&pointer))?;
+            let emitted = prop_result(emit_xml(&document).context("guest-bios TEI should emit"))?;
+            let expected_corresp = format!("corresp=\"{pointer}\"");
+            prop_assert!(
+                emitted.contains(&expected_corresp),
+                "emitted XML should preserve generated @corresp value"
+            );
+            let reparsed =
+                prop_result(parse_xml(&emitted).context("emitted guest-bios TEI should parse"))?;
+            prop_result(reparsed.validate().context("reparsed guest-bios TEI should validate"))?;
+        }
+    }
+}

--- a/tei-xml/tests/guest_bios_round_trip_props.rs
+++ b/tei-xml/tests/guest_bios_round_trip_props.rs
@@ -58,6 +58,12 @@ mod guest_bios_round_trip_props {
             let reparsed =
                 prop_result(parse_xml(&emitted).context("emitted guest-bios TEI should parse"))?;
             prop_result(reparsed.validate().context("reparsed guest-bios TEI should validate"))?;
+            let re_emitted =
+                prop_result(emit_xml(&reparsed).context("reparsed guest-bios TEI should emit"))?;
+            prop_assert!(
+                re_emitted.contains(&expected_corresp),
+                "re-emitted XML should preserve generated @corresp value"
+            );
         }
     }
 }

--- a/tei-xml/tests/guest_bios_round_trip_props.rs
+++ b/tei-xml/tests/guest_bios_round_trip_props.rs
@@ -43,6 +43,8 @@ fn prop_result<T>(result: anyhow::Result<T>) -> Result<T, TestCaseError> {
 }
 
 mod guest_bios_round_trip_props {
+    //! Validates generated guest-biography correspondence survives XML round-trips.
+
     use super::*;
 
     proptest! {

--- a/tei-xml/tests/jing_validation.rs
+++ b/tei-xml/tests/jing_validation.rs
@@ -83,6 +83,7 @@ macro_rules! require_jing {
 #[case::utterances("utterances", fixtures::document_with_utterances)]
 #[case::comprehensive("comprehensive", fixtures::comprehensive_document)]
 #[case::div_list("div-list", fixtures::document_with_div_and_list)]
+#[case::guest_bios("guest-bios", fixtures::document_with_guest_bios)]
 #[case::nested_div("nested-div", fixtures::document_with_nested_divs)]
 fn validates_fixture(
     #[case] name: &str,

--- a/tei-xml/tests/parse_guest_bios.rs
+++ b/tei-xml/tests/parse_guest_bios.rs
@@ -1,0 +1,181 @@
+//! Behaviour-driven parsing coverage for guest-biography body enrichment.
+
+use anyhow::{Context, bail, ensure};
+use rstest::fixture;
+use rstest_bdd_macros::{given, scenario, then, when};
+use std::cell::RefCell;
+use tei_core::{BodyBlock, DivContent, Inline, PointerList, TeiDocument, TeiError};
+use tei_test_helpers::expect_validated_state;
+use tei_xml::{emit_xml, parse_xml};
+
+// Force Cargo to recompile the test binary when the feature file changes so the
+// embedded scenario stays in sync with expectations.
+const _: &str = include_str!("features/parse_xml.feature");
+
+const GUEST_BIOS_FIXTURE: &str = concat!(
+    "<TEI>",
+    "<teiHeader>",
+    "<fileDesc>",
+    "<title>Guest Bios</title>",
+    "</fileDesc>",
+    "</teiHeader>",
+    "<text>",
+    "<body>",
+    "<div type=\"guest-bios\" xml:id=\"guest-bios\">",
+    "<list xml:id=\"guest-bio-list\">",
+    "<item xml:id=\"guest-bio-ada\" ",
+    "corresp=\"urn:episodic:reference-document-revision:019e1368\">",
+    "<label>Ada Lovelace</label>",
+    "Mathematician and computing pioneer.",
+    "</item>",
+    "</list>",
+    "</div>",
+    "</body>",
+    "</text>",
+    "</TEI>",
+);
+
+type DocumentResult = std::result::Result<TeiDocument, TeiError>;
+
+#[derive(Default)]
+struct ParseState {
+    xml: RefCell<Option<String>>,
+    result: RefCell<Option<DocumentResult>>,
+}
+
+impl ParseState {
+    fn set_xml(&self, xml: &str) {
+        *self.xml.borrow_mut() = Some(xml.to_owned());
+    }
+
+    fn xml(&self) -> anyhow::Result<String> {
+        self.xml
+            .borrow()
+            .as_ref()
+            .cloned()
+            .context("scenario must supply XML input")
+    }
+
+    fn set_result(&self, result: DocumentResult) {
+        *self.result.borrow_mut() = Some(result);
+    }
+
+    fn result(&self) -> anyhow::Result<DocumentResult> {
+        self.result
+            .borrow()
+            .as_ref()
+            .cloned()
+            .context("parse_xml must run before assertions")
+    }
+}
+
+#[fixture]
+fn validated_state_result() -> anyhow::Result<ParseState> {
+    let state = ParseState::default();
+    ensure!(state.xml.borrow().is_none(), "xml slot must start empty");
+    ensure!(
+        state.result.borrow().is_none(),
+        "result slot must start empty"
+    );
+    Ok(state)
+}
+
+#[fixture]
+fn validated_state() -> ParseState {
+    match validated_state_result() {
+        Ok(state) => state,
+        Err(error) => panic!("failed to initialise guest-bios parse state: {error}"),
+    }
+}
+
+// rstest-bdd supplies owned `String` values for placeholders, so keep the
+// signature by value.
+#[given("the TEI fixture \"{fixture}\"")]
+fn the_tei_fixture(
+    #[from(validated_state)] state: &ParseState,
+    fixture: String,
+) -> anyhow::Result<()> {
+    let "guest-bios" = fixture.as_str() else {
+        bail!("unknown guest-bios parsing fixture: {fixture}");
+    };
+    state.set_xml(GUEST_BIOS_FIXTURE);
+    let _ = state.xml()?;
+    Ok(())
+}
+
+#[when("I parse the TEI input")]
+fn i_parse_the_input(#[from(validated_state)] state: &ParseState) -> anyhow::Result<()> {
+    let xml = state.xml()?;
+    let result = parse_xml(&xml);
+    state.set_result(result);
+    Ok(())
+}
+
+#[then("parsing succeeds")]
+fn parsing_succeeds(#[from(validated_state)] state: &ParseState) -> anyhow::Result<()> {
+    let result = state.result()?;
+    result.context("expected guest-bios parsing to succeed")?;
+    Ok(())
+}
+
+#[then("the parsed document includes guest bios linked to an external reference revision")]
+fn parsed_document_includes_guest_bios(
+    #[from(validated_state)] state: &ParseState,
+) -> anyhow::Result<()> {
+    let document = state
+        .result()?
+        .context("expected successful parse before asserting guest bios")?;
+    document
+        .validate()
+        .context("guest-bios TEI should validate")?;
+
+    let Some(BodyBlock::Div(div)) = document.text().body().blocks().first() else {
+        bail!("expected a top-level guest-bios div body block");
+    };
+    ensure!(
+        div.div_type() == "guest-bios",
+        "expected guest-bios div type, found {:?}",
+        div.div_type()
+    );
+
+    let Some(DivContent::List(list)) = div.content().first() else {
+        bail!("expected guest-bios div to contain a list");
+    };
+    let item = list
+        .items()
+        .first()
+        .context("expected guest-bios list to contain an item")?;
+    let label = item.label().context("expected guest-bio item label")?;
+    ensure!(
+        label.content() == [Inline::text("Ada Lovelace")],
+        "guest-bio label should survive parsing"
+    );
+    ensure!(
+        item.content() == [Inline::text("Mathematician and computing pioneer.")],
+        "guest-bio inline body should survive parsing"
+    );
+
+    let expected =
+        PointerList::parse_attribute("urn:episodic:reference-document-revision:019e1368")
+            .context("expected corresp should be valid")?;
+    ensure!(
+        item.corresp() == Some(&expected),
+        "guest-bio @corresp should survive parsing"
+    );
+
+    let emitted = emit_xml(&document).context("guest-bios TEI should emit")?;
+    ensure!(
+        emitted.contains("corresp=\"urn:episodic:reference-document-revision:019e1368\""),
+        "guest-bio @corresp should survive emission"
+    );
+    parse_xml(&emitted).context("emitted guest-bios TEI should parse again")?;
+    Ok(())
+}
+
+#[scenario(path = "tests/features/parse_xml.feature", index = 6)]
+fn parses_guest_bios(
+    #[from(validated_state)] _: ParseState,
+    #[from(validated_state_result)] result: anyhow::Result<ParseState>,
+) {
+    expect_validated_state(result, "guest-bios parse");
+}

--- a/tei-xml/tests/parse_guest_bios.rs
+++ b/tei-xml/tests/parse_guest_bios.rs
@@ -162,7 +162,16 @@ fn parsed_document_includes_guest_bios(
         item.corresp() == Some(&expected),
         "guest-bio @corresp should survive parsing"
     );
+    Ok(())
+}
 
+#[then("the emitted guest-bios XML round-trips cleanly")]
+fn emitted_guest_bios_xml_round_trips(
+    #[from(validated_state)] state: &ParseState,
+) -> anyhow::Result<()> {
+    let document = state
+        .result()?
+        .context("expected successful parse before round-trip")?;
     let emitted = emit_xml(&document).context("guest-bios TEI should emit")?;
     ensure!(
         emitted.contains("corresp=\"urn:episodic:reference-document-revision:019e1368\""),

--- a/tei-xml/tests/parse_guest_bios.rs
+++ b/tei-xml/tests/parse_guest_bios.rs
@@ -177,7 +177,10 @@ fn emitted_guest_bios_xml_round_trips(
         emitted.contains("corresp=\"urn:episodic:reference-document-revision:019e1368\""),
         "guest-bio @corresp should survive emission"
     );
-    parse_xml(&emitted).context("emitted guest-bios TEI should parse again")?;
+    let reparsed_doc = parse_xml(&emitted).context("emitted guest-bios TEI should parse again")?;
+    reparsed_doc
+        .validate()
+        .context("reparsed guest-bios TEI should validate")?;
     Ok(())
 }
 

--- a/tei-xml/tests/parse_xml.rs
+++ b/tei-xml/tests/parse_xml.rs
@@ -5,9 +5,9 @@ use anyhow::{Context, bail, ensure};
 use rstest::fixture;
 use rstest_bdd_macros::{given, scenario, then, when};
 use std::cell::RefCell;
-use tei_core::{BodyBlock, DivContent, Inline, PointerList, TeiDocument, TeiError};
+use tei_core::{BodyBlock, DivContent, TeiDocument, TeiError};
 use tei_test_helpers::expect_validated_state;
-use tei_xml::{emit_xml, parse_xml};
+use tei_xml::parse_xml;
 
 // Force Cargo to recompile the test binary when the feature file changes so the
 // embedded scenarios stay in sync with expectations.
@@ -97,29 +97,6 @@ const NESTED_DIV_FIXTURE: &str = concat!(
     "</TEI>",
 );
 
-const GUEST_BIOS_FIXTURE: &str = concat!(
-    "<TEI>",
-    "<teiHeader>",
-    "<fileDesc>",
-    "<title>Guest Bios</title>",
-    "</fileDesc>",
-    "</teiHeader>",
-    "<text>",
-    "<body>",
-    "<div type=\"guest-bios\" xml:id=\"guest-bios\">",
-    "<list xml:id=\"guest-bio-list\">",
-    "<item xml:id=\"guest-bio-ada\" ",
-    "corresp=\"urn:episodic:reference-document-revision:019e1368\">",
-    "<label>Ada Lovelace</label>",
-    "Mathematician and computing pioneer.",
-    "</item>",
-    "</list>",
-    "</div>",
-    "</body>",
-    "</text>",
-    "</TEI>",
-);
-
 type DocumentResult = std::result::Result<TeiDocument, TeiError>;
 
 #[derive(Default)]
@@ -162,7 +139,6 @@ fn fixture_by_name(name: &str) -> anyhow::Result<&'static str> {
         "blank-title" => Ok(BLANK_TITLE_FIXTURE),
         "annotated" => Ok(ANNOTATED_FIXTURE),
         "nested-div" => Ok(NESTED_DIV_FIXTURE),
-        "guest-bios" => Ok(GUEST_BIOS_FIXTURE),
         other => bail!("unknown TEI fixture: {other}"),
     }
 }
@@ -312,60 +288,6 @@ fn parsed_document_includes_nested_divisions(
     Ok(())
 }
 
-#[then("the parsed document includes guest bios linked to an external reference revision")]
-fn parsed_document_includes_guest_bios(
-    #[from(validated_state)] state: &ParseState,
-) -> anyhow::Result<()> {
-    let document = state
-        .result()?
-        .context("expected successful parse before asserting guest bios")?;
-    document
-        .validate()
-        .context("guest-bios TEI should validate")?;
-
-    let Some(BodyBlock::Div(div)) = document.text().body().blocks().first() else {
-        bail!("expected a top-level guest-bios div body block");
-    };
-    ensure!(
-        div.div_type() == "guest-bios",
-        "expected guest-bios div type, found {:?}",
-        div.div_type()
-    );
-
-    let Some(DivContent::List(list)) = div.content().first() else {
-        bail!("expected guest-bios div to contain a list");
-    };
-    let item = list
-        .items()
-        .first()
-        .context("expected guest-bios list to contain an item")?;
-    let label = item.label().context("expected guest-bio item label")?;
-    ensure!(
-        label.content() == [Inline::text("Ada Lovelace")],
-        "guest-bio label should survive parsing"
-    );
-    ensure!(
-        item.content() == [Inline::text("Mathematician and computing pioneer.")],
-        "guest-bio inline body should survive parsing"
-    );
-
-    let expected =
-        PointerList::parse_attribute("urn:episodic:reference-document-revision:019e1368")
-            .context("expected corresp should be valid")?;
-    ensure!(
-        item.corresp() == Some(&expected),
-        "guest-bio @corresp should survive parsing"
-    );
-
-    let emitted = emit_xml(&document).context("guest-bios TEI should emit")?;
-    ensure!(
-        emitted.contains("corresp=\"urn:episodic:reference-document-revision:019e1368\""),
-        "guest-bio @corresp should survive emission"
-    );
-    parse_xml(&emitted).context("emitted guest-bios TEI should parse again")?;
-    Ok(())
-}
-
 #[scenario(path = "tests/features/parse_xml.feature", index = 0)]
 fn parses_valid_documents(
     #[from(validated_state)] _: ParseState,
@@ -408,14 +330,6 @@ fn rejects_blank_titles(
 
 #[scenario(path = "tests/features/parse_xml.feature", index = 4)]
 fn parses_annotated_documents(
-    #[from(validated_state)] _: ParseState,
-    #[from(validated_state_result)] result: anyhow::Result<ParseState>,
-) {
-    expect_validated_state(result, "parse");
-}
-
-#[scenario(path = "tests/features/parse_xml.feature", index = 6)]
-fn parses_guest_bios(
     #[from(validated_state)] _: ParseState,
     #[from(validated_state_result)] result: anyhow::Result<ParseState>,
 ) {

--- a/tei-xml/tests/parse_xml.rs
+++ b/tei-xml/tests/parse_xml.rs
@@ -5,9 +5,9 @@ use anyhow::{Context, bail, ensure};
 use rstest::fixture;
 use rstest_bdd_macros::{given, scenario, then, when};
 use std::cell::RefCell;
-use tei_core::{BodyBlock, DivContent, TeiDocument, TeiError};
+use tei_core::{BodyBlock, DivContent, Inline, PointerList, TeiDocument, TeiError};
 use tei_test_helpers::expect_validated_state;
-use tei_xml::parse_xml;
+use tei_xml::{emit_xml, parse_xml};
 
 // Force Cargo to recompile the test binary when the feature file changes so the
 // embedded scenarios stay in sync with expectations.
@@ -97,6 +97,29 @@ const NESTED_DIV_FIXTURE: &str = concat!(
     "</TEI>",
 );
 
+const GUEST_BIOS_FIXTURE: &str = concat!(
+    "<TEI>",
+    "<teiHeader>",
+    "<fileDesc>",
+    "<title>Guest Bios</title>",
+    "</fileDesc>",
+    "</teiHeader>",
+    "<text>",
+    "<body>",
+    "<div type=\"guest-bios\" xml:id=\"guest-bios\">",
+    "<list xml:id=\"guest-bio-list\">",
+    "<item xml:id=\"guest-bio-ada\" ",
+    "corresp=\"urn:episodic:reference-document-revision:019e1368\">",
+    "<label>Ada Lovelace</label>",
+    "Mathematician and computing pioneer.",
+    "</item>",
+    "</list>",
+    "</div>",
+    "</body>",
+    "</text>",
+    "</TEI>",
+);
+
 type DocumentResult = std::result::Result<TeiDocument, TeiError>;
 
 #[derive(Default)]
@@ -139,6 +162,7 @@ fn fixture_by_name(name: &str) -> anyhow::Result<&'static str> {
         "blank-title" => Ok(BLANK_TITLE_FIXTURE),
         "annotated" => Ok(ANNOTATED_FIXTURE),
         "nested-div" => Ok(NESTED_DIV_FIXTURE),
+        "guest-bios" => Ok(GUEST_BIOS_FIXTURE),
         other => bail!("unknown TEI fixture: {other}"),
     }
 }
@@ -288,6 +312,60 @@ fn parsed_document_includes_nested_divisions(
     Ok(())
 }
 
+#[then("the parsed document includes guest bios linked to an external reference revision")]
+fn parsed_document_includes_guest_bios(
+    #[from(validated_state)] state: &ParseState,
+) -> anyhow::Result<()> {
+    let document = state
+        .result()?
+        .context("expected successful parse before asserting guest bios")?;
+    document
+        .validate()
+        .context("guest-bios TEI should validate")?;
+
+    let Some(BodyBlock::Div(div)) = document.text().body().blocks().first() else {
+        bail!("expected a top-level guest-bios div body block");
+    };
+    ensure!(
+        div.div_type() == "guest-bios",
+        "expected guest-bios div type, found {:?}",
+        div.div_type()
+    );
+
+    let Some(DivContent::List(list)) = div.content().first() else {
+        bail!("expected guest-bios div to contain a list");
+    };
+    let item = list
+        .items()
+        .first()
+        .context("expected guest-bios list to contain an item")?;
+    let label = item.label().context("expected guest-bio item label")?;
+    ensure!(
+        label.content() == [Inline::text("Ada Lovelace")],
+        "guest-bio label should survive parsing"
+    );
+    ensure!(
+        item.content() == [Inline::text("Mathematician and computing pioneer.")],
+        "guest-bio inline body should survive parsing"
+    );
+
+    let expected =
+        PointerList::parse_attribute("urn:episodic:reference-document-revision:019e1368")
+            .context("expected corresp should be valid")?;
+    ensure!(
+        item.corresp() == Some(&expected),
+        "guest-bio @corresp should survive parsing"
+    );
+
+    let emitted = emit_xml(&document).context("guest-bios TEI should emit")?;
+    ensure!(
+        emitted.contains("corresp=\"urn:episodic:reference-document-revision:019e1368\""),
+        "guest-bio @corresp should survive emission"
+    );
+    parse_xml(&emitted).context("emitted guest-bios TEI should parse again")?;
+    Ok(())
+}
+
 #[scenario(path = "tests/features/parse_xml.feature", index = 0)]
 fn parses_valid_documents(
     #[from(validated_state)] _: ParseState,
@@ -330,6 +408,14 @@ fn rejects_blank_titles(
 
 #[scenario(path = "tests/features/parse_xml.feature", index = 4)]
 fn parses_annotated_documents(
+    #[from(validated_state)] _: ParseState,
+    #[from(validated_state_result)] result: anyhow::Result<ParseState>,
+) {
+    expect_validated_state(result, "parse");
+}
+
+#[scenario(path = "tests/features/parse_xml.feature", index = 6)]
+fn parses_guest_bios(
     #[from(validated_state)] _: ParseState,
     #[from(validated_state_result)] result: anyhow::Result<ParseState>,
 ) {


### PR DESCRIPTION
## Summary

This branch documents and regression-tests the existing TEI body-enrichment shape that downstream Episodic roadmap task (2.3.3), "Generate guest bios from reference document bindings", will consume. It adds a guest-biography fixture using `<div type="guest-bios"><list><item><label>...` with an external `@corresp` reference-document revision URN, then proves that the shape parses, validates, emits, and parses again without adding broader personography or `@source` support.

Roadmap task: (2.3.3)
Execplan: none; this branch follows the implementation prompt directly.

## Review walkthrough

- Start with [tei-xml/src/fixtures/mod.rs](https://github.com/leynos/tei-rapporteur/blob/814e9de7caf16a4cfff0e7e704853abc7249e243/tei-xml/src/fixtures/mod.rs) to see the new upstream `guest-bios` fixture and fixture registry entry.
- Review [tei-xml/tests/emit_div.rs](https://github.com/leynos/tei-rapporteur/blob/814e9de7caf16a4cfff0e7e704853abc7249e243/tei-xml/tests/emit_div.rs) for the parser/emitter round-trip assertions and [tei-xml/tests/parse_guest_bios.rs](https://github.com/leynos/tei-rapporteur/blob/814e9de7caf16a4cfff0e7e704853abc7249e243/tei-xml/tests/parse_guest_bios.rs) for the guest-bio parsing scenario split out from the general parser test module.
- Check [tei-core/tests/validation_behaviour.rs](https://github.com/leynos/tei-rapporteur/blob/814e9de7caf16a4cfff0e7e704853abc7249e243/tei-core/tests/validation_behaviour.rs) and [tei-core/tests/features/validation.feature](https://github.com/leynos/tei-rapporteur/blob/814e9de7caf16a4cfff0e7e704853abc7249e243/tei-core/tests/features/validation.feature) for the activated validation BDD harness and the external-`@corresp` acceptance case.
- Finish with [docs/users-guide.md](https://github.com/leynos/tei-rapporteur/blob/814e9de7caf16a4cfff0e7e704853abc7249e243/docs/users-guide.md) and [docs/tei-rapporteur-design-document.md](https://github.com/leynos/tei-rapporteur/blob/814e9de7caf16a4cfff0e7e704853abc7249e243/docs/tei-rapporteur-design-document.md) for the internal-versus-external `@corresp` guidance and deferred `Item @source` note.

## Validation

- `cargo test -p tei-xml --test emit_div round_trips_guest_bios_with_external_corresp`: passed
- `cargo test -p tei-xml --test parse_xml`: passed
- `cargo test -p tei-xml --test parse_guest_bios`: passed
- `cargo test -p tei-core --test validation_behaviour`: passed
- `cargo test -p tei-xml fixtures::tests::document_with_guest_bios_builds_successfully`: passed
- `make check-fmt`: passed
- `make lint`: passed
- `make test`: passed, 376 tests passed
- `coderabbit review --agent`: passed, 0 findings before and after the parser test split

## Notes

The guest-bio parsing scenario now lives in its own integration test file so [tei-xml/tests/parse_xml.rs](https://github.com/leynos/tei-rapporteur/blob/814e9de7caf16a4cfff0e7e704853abc7249e243/tei-xml/tests/parse_xml.rs) is 337 lines and remains below the repository 400-line file-size limit.

`make fmt` was attempted after the documentation edits. It completed Rust formatting but stopped during Markdown lint-fix because existing unrelated Markdown line-length violations remain elsewhere in the repository. The branch retains only task-relevant documentation changes; `make check-fmt`, `make lint`, and `make test` all pass.
