### PR TITLE
Update PyO3 dependency versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1498,7 +1498,7 @@ dependencies = [
  "memoffset",
  "once_cell",
  "portable-atomic",
- "pyo3-build-config 0.24.2",
+ "pyo3-build-config",
  "pyo3-ffi",
  "pyo3-macros",
  "unindent",
@@ -1515,22 +1515,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "pyo3-build-config"
-version = "0.28.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e368e7ddfdeb98c9bca7f8383be1648fd84ab466bf2bc015e94008db6d35611e"
-dependencies = [
- "target-lexicon",
-]
-
-[[package]]
 name = "pyo3-ffi"
 version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78f9cf92ba9c409279bc3305b5409d90db2d2c22392d443a87df3a1adad59e33"
 dependencies = [
  "libc",
- "pyo3-build-config 0.24.2",
+ "pyo3-build-config",
 ]
 
 [[package]]
@@ -1553,7 +1544,7 @@ checksum = "822ece1c7e1012745607d5cf0bcb2874769f0f7cb34c4cde03b9358eb9ef911a"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
- "pyo3-build-config 0.24.2",
+ "pyo3-build-config",
  "quote",
  "syn 2.0.106",
 ]
@@ -2224,7 +2215,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "pyo3",
- "pyo3-build-config 0.28.3",
+ "pyo3-build-config",
  "rstest",
  "rstest-bdd",
  "rstest-bdd-macros",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1488,9 +1488,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.23.5"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7778bffd85cf38175ac1f545509665d0b9b92a198ca7941f131f85f7a4f9a872"
+checksum = "e5203598f366b11a02b13aa20cab591229ff0a89fd121a308a5df751d5fc9219"
 dependencies = [
  "cfg-if",
  "indoc",
@@ -1498,7 +1498,7 @@ dependencies = [
  "memoffset",
  "once_cell",
  "portable-atomic",
- "pyo3-build-config",
+ "pyo3-build-config 0.24.2",
  "pyo3-ffi",
  "pyo3-macros",
  "unindent",
@@ -1506,29 +1506,38 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.23.5"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94f6cbe86ef3bf18998d9df6e0f3fc1050a8c5efa409bf712e661a4366e010fb"
+checksum = "99636d423fa2ca130fa5acde3059308006d46f98caac629418e53f7ebb1e9999"
 dependencies = [
  "once_cell",
  "target-lexicon",
 ]
 
 [[package]]
-name = "pyo3-ffi"
-version = "0.23.5"
+name = "pyo3-build-config"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9f1b4c431c0bb1c8fb0a338709859eed0d030ff6daa34368d3b152a63dfdd8d"
+checksum = "e368e7ddfdeb98c9bca7f8383be1648fd84ab466bf2bc015e94008db6d35611e"
+dependencies = [
+ "target-lexicon",
+]
+
+[[package]]
+name = "pyo3-ffi"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78f9cf92ba9c409279bc3305b5409d90db2d2c22392d443a87df3a1adad59e33"
 dependencies = [
  "libc",
- "pyo3-build-config",
+ "pyo3-build-config 0.24.2",
 ]
 
 [[package]]
 name = "pyo3-macros"
-version = "0.23.5"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbc2201328f63c4710f68abdf653c89d8dbc2858b88c5d88b0ff38a75288a9da"
+checksum = "0b999cb1a6ce21f9a6b147dcf1be9ffedf02e0043aec74dc390f3007047cecd9"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -1538,13 +1547,13 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.23.5"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fca6726ad0f3da9c9de093d6f116a93c1a38e417ed73bf138472cf4064f72028"
+checksum = "822ece1c7e1012745607d5cf0bcb2874769f0f7cb34c4cde03b9358eb9ef911a"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
- "pyo3-build-config",
+ "pyo3-build-config 0.24.2",
  "quote",
  "syn 2.0.106",
 ]
@@ -2189,9 +2198,9 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.16"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
+checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "tei-core"
@@ -2215,7 +2224,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "pyo3",
- "pyo3-build-config",
+ "pyo3-build-config 0.28.3",
  "rstest",
  "rstest-bdd",
  "rstest-bdd-macros",

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -51,3 +51,48 @@ enough for benchmark and diagnostic consumers:
 Treat `input_bytes`, `segment_count`, `text_bytes`, and `elapsed_microseconds`
 as the metrics surface for spoken extraction. Throughput dashboards should
 derive rates from those fields rather than adding counters in the library.
+
+## tei-py build requirements
+
+`tei-py` uses PyO3 for the Python binding layer. The current supported PyO3
+minor series is `0.24.x`, with `pyo3` pinned to `0.24.2` and the direct
+`pyo3-build-config` build dependency pinned to `0.24.2`.
+
+Keep `pyo3` and `pyo3-build-config` on the same minor series. PyO3 uses the
+build configuration crate to resolve interpreter configuration and emit cfg
+flags consumed by the runtime crate. Mixing minor series risks subtle build
+configuration mismatches, including cfg flags or generated binding assumptions
+that no longer match the runtime dependency.
+
+The `pyo3` dependency enables `auto-initialize` so tests and Rust-side helpers
+can attach to an embedded Python interpreter without requiring every caller to
+perform explicit interpreter initialization first. The `pyo3-build-config`
+dependency enables `resolve-config` so `tei-py/build.rs` can resolve the active
+Python configuration and apply the PyO3 cfg values needed by the crate.
+
+## tei-py test-support API
+
+`tei-py/src/test_support.rs` contains the private `run_with_kwargs` helper used
+by the `msgspec` bootstrap path:
+
+```rust
+fn run_with_kwargs<'py, A>(
+    run: &Bound<'py, PyAny>,
+    args: A,
+    kwargs: &Bound<'py, PyDict>,
+)
+where
+    A: pyo3::call::PyCallArgs<'py>,
+```
+
+Any future caller must pass an argument value that implements
+`pyo3::call::PyCallArgs<'py>`. PyO3 0.24 tightened `PyAnyMethods::call` to use
+`PyCallArgs` directly rather than accepting any value convertible through
+`IntoPyObject<'py, Target = PyTuple>`. When the intended Python call receives
+one positional argument, wrap that argument in a Rust one-tuple, such as
+`(args_tuple,)`.
+
+Only `ensure_msgspec_installed` and `msgspec_available` are public exports from
+this module. They are thread-safe: `ensure_msgspec_installed` guards the
+bootstrap with `Once`, and `msgspec_available` delegates to it while attached
+to the Python interpreter.

--- a/tei-py/Cargo.toml
+++ b/tei-py/Cargo.toml
@@ -32,4 +32,4 @@ anyhow = { workspace = true }
 tei-test-helpers = { path = "../tei-test-helpers" }
 
 [build-dependencies]
-pyo3-build-config = { version = "0.28.3", features = ["resolve-config"] }
+pyo3-build-config = { version = "0.24.2", features = ["resolve-config"] }

--- a/tei-py/Cargo.toml
+++ b/tei-py/Cargo.toml
@@ -19,7 +19,7 @@ extension-module = ["pyo3/extension-module"]
 tei-core = { path = "../tei-core" }
 tei-serde = { workspace = true }
 tei-xml = { path = "../tei-xml", features = ["streaming"] }
-pyo3 = { version = "0.23.3", features = ["auto-initialize"] }
+pyo3 = { version = "0.24.2", features = ["auto-initialize"] }
 pyo3-serde = { package = "serde-pyobject", version = "0.6.2" }
 serde = { workspace = true }
 thiserror = { workspace = true }
@@ -32,4 +32,4 @@ anyhow = { workspace = true }
 tei-test-helpers = { path = "../tei-test-helpers" }
 
 [build-dependencies]
-pyo3-build-config = { version = "0.23.3", features = ["resolve-config"] }
+pyo3-build-config = { version = "0.28.3", features = ["resolve-config"] }

--- a/tei-py/src/test_support.rs
+++ b/tei-py/src/test_support.rs
@@ -346,9 +346,10 @@ mod tests {
 
     #[test]
     fn msgspec_available_reports_true_only_when_msgspec_is_importable() {
+        let available = msgspec_available();
         let directly_importable = Python::with_gil(|py| py.import("msgspec").is_ok());
 
-        assert_eq!(msgspec_available(), directly_importable);
+        assert_eq!(available, directly_importable);
     }
 
     #[test]

--- a/tei-py/src/test_support.rs
+++ b/tei-py/src/test_support.rs
@@ -381,13 +381,7 @@ mod tests {
         });
 
         let handles: Vec<_> = (0..8)
-            .map(|_| {
-                let thread_run_count = Arc::clone(&run_count);
-                thread::spawn(move || {
-                    drop(thread_run_count);
-                    Python::with_gil(ensure_msgspec_installed)
-                })
-            })
+            .map(|_| thread::spawn(move || Python::with_gil(ensure_msgspec_installed)))
             .collect();
 
         for handle in handles {

--- a/tei-py/src/test_support.rs
+++ b/tei-py/src/test_support.rs
@@ -196,8 +196,18 @@ mod tests {
         let restore =
             CString::new("import subprocess\nsubprocess.run = _original_run\n_calls = []\n")
                 .expect("CString build");
-        py.run(restore.as_c_str(), Some(globals), None)
-            .expect("restore subprocess.run");
+        py.run(restore.as_c_str(), Some(globals), None).ok();
+    }
+
+    struct SubprocessRestoreGuard<'py> {
+        py: Python<'py>,
+        globals: Bound<'py, PyDict>,
+    }
+
+    impl Drop for SubprocessRestoreGuard<'_> {
+        fn drop(&mut self) {
+            restore_subprocess_run(self.py, &self.globals);
+        }
     }
 
     fn recorded_call_count(globals: &Bound<'_, PyDict>) -> usize {
@@ -219,6 +229,10 @@ mod tests {
                 kwargs,
                 globals,
             } = setup_run_and_kwargs(py);
+            let _restore_guard = SubprocessRestoreGuard {
+                py,
+                globals: globals.clone(),
+            };
 
             match arg_shape {
                 RunWithKwargsArgShape::Unit => run_with_kwargs(&run, (), &kwargs),
@@ -235,7 +249,6 @@ mod tests {
             }
 
             let call_count = recorded_call_count(&globals);
-            restore_subprocess_run(py, &globals);
 
             assert_eq!(call_count, 1);
         });
@@ -272,21 +285,37 @@ mod tests {
     #[case::path_means_present("'/usr/bin/uv'", true)]
     fn has_uv_reflects_which_return_value(#[case] which_return_expr: &str, #[case] expected: bool) {
         Python::with_gil(|py| {
+            let globals = PyDict::new(py);
             let patch = CString::new(format!(
                 "import shutil\n\
                  orig = shutil.which\n\
                  shutil.which = lambda name: {which_return_expr}\n"
             ))
             .expect("CString build");
-            py.run(patch.as_c_str(), None, None)
+            py.run(patch.as_c_str(), Some(&globals), None)
                 .expect("monkeypatch shutil.which");
+            let _restore_guard = ShutilRestoreGuard {
+                py,
+                globals: globals.clone(),
+            };
 
             assert_eq!(has_uv(py), expected);
-
-            let restore =
-                CString::new("import shutil\nshutil.which = orig\n").expect("CString build");
-            py.run(restore.as_c_str(), None, None)
-                .expect("restore shutil.which");
         });
+    }
+
+    fn restore_shutil_which(py: Python<'_>, globals: &Bound<'_, PyDict>) {
+        let restore = CString::new("import shutil\nshutil.which = orig\n").expect("CString build");
+        py.run(restore.as_c_str(), Some(globals), None).ok();
+    }
+
+    struct ShutilRestoreGuard<'py> {
+        py: Python<'py>,
+        globals: Bound<'py, PyDict>,
+    }
+
+    impl Drop for ShutilRestoreGuard<'_> {
+        fn drop(&mut self) {
+            restore_shutil_which(self.py, &self.globals);
+        }
     }
 }

--- a/tei-py/src/test_support.rs
+++ b/tei-py/src/test_support.rs
@@ -29,7 +29,7 @@ fn has_uv(py: Python<'_>) -> bool {
 
 fn run_with_kwargs<'py, A>(run: &Bound<'py, PyAny>, args: A, kwargs: &Bound<'py, PyDict>)
 where
-    A: pyo3::IntoPyObject<'py, Target = pyo3::types::PyTuple>,
+    A: pyo3::call::PyCallArgs<'py>,
 {
     // Best-effort: subprocess.run may fail (e.g., missing network); the final
     // `py.import("msgspec")?` is the authoritative error path for callers.

--- a/tei-py/src/test_support.rs
+++ b/tei-py/src/test_support.rs
@@ -366,7 +366,7 @@ mod tests {
             .map(|_| {
                 let thread_run_count = Arc::clone(&run_count);
                 thread::spawn(move || {
-                    let _run_count = Arc::clone(&thread_run_count);
+                    drop(thread_run_count);
                     Python::with_gil(ensure_msgspec_installed)
                 })
             })

--- a/tei-py/src/test_support.rs
+++ b/tei-py/src/test_support.rs
@@ -149,6 +149,41 @@ mod tests {
     use std::ffi::CString;
 
     #[test]
+    fn run_with_kwargs_accepts_unit_tuple() {
+        Python::with_gil(|py| {
+            let subprocess = py.import("subprocess").expect("import subprocess");
+            let run = subprocess.getattr("run").expect("get subprocess.run");
+            let kwargs = PyDict::new(py);
+
+            run_with_kwargs(&run, (), &kwargs);
+        });
+    }
+
+    #[test]
+    fn run_with_kwargs_accepts_one_tuple_of_pybytes() {
+        Python::with_gil(|py| {
+            let subprocess = py.import("subprocess").expect("import subprocess");
+            let run = subprocess.getattr("run").expect("get subprocess.run");
+            let kwargs = PyDict::new(py);
+            let args_tuple = PyTuple::new(py, ["true"]).expect("build argument tuple");
+
+            run_with_kwargs(&run, (args_tuple,), &kwargs);
+        });
+    }
+
+    #[test]
+    fn run_with_kwargs_accepts_bound_pytuple() {
+        Python::with_gil(|py| {
+            let subprocess = py.import("subprocess").expect("import subprocess");
+            let run = subprocess.getattr("run").expect("get subprocess.run");
+            let kwargs = PyDict::new(py);
+            let args_tuple = PyTuple::new(py, [["true"]]).expect("build subprocess args");
+
+            run_with_kwargs(&run, args_tuple, &kwargs);
+        });
+    }
+
+    #[test]
     fn has_uv_reports_absence_when_which_returns_none() {
         Python::with_gil(|py| {
             let code = CString::new(

--- a/tei-py/src/test_support.rs
+++ b/tei-py/src/test_support.rs
@@ -1,4 +1,14 @@
-//! Test-only helpers shared across Rust and Python BDD suites.
+//! Test-only helpers shared across Rust unit tests and Python BDD suites.
+//!
+//! The helpers use `PyO3`'s embedding API, including `pyo3::sync::OnceExt`,
+//! `pyo3::call::PyCallArgs`, and `Bound<PyAny>`, against the supported `PyO3`
+//! `0.24.x` minor series. The primary job is bootstrapping
+//! `msgspec>=0.19,<0.20` into the embedded interpreter with `uv` or `pip` via
+//! `subprocess.run`, so both Rust and Python BDD tests can import it. Only
+//! [`ensure_msgspec_installed`] and [`msgspec_available`] are exported;
+//! `run_with_kwargs`, `install_msgspec`, and `has_uv` are private details.
+//! The bootstrap is serialised with `Once` via `OnceExt::call_once_py_attached`
+//! to prevent races when tests run in parallel.
 const MSGSPEC_REQUIREMENT: &str = "msgspec>=0.19,<0.20";
 const PIP_COMMON_FLAGS: [&str; 6] = [
     "--no-input",

--- a/tei-py/src/test_support.rs
+++ b/tei-py/src/test_support.rs
@@ -1,13 +1,12 @@
 //! Test-only helpers shared across Rust unit tests and Python BDD suites.
-//!
-//! The helpers use `PyO3`'s embedding API, including `pyo3::sync::OnceExt`,
-//! `pyo3::call::PyCallArgs`, and `Bound<PyAny>`, against the supported `PyO3`
-//! `0.24.x` minor series. The primary job is bootstrapping
-//! `msgspec>=0.19,<0.20` into the embedded interpreter with `uv` or `pip` via
-//! `subprocess.run`, so both Rust and Python BDD tests can import it. Only
-//! [`ensure_msgspec_installed`] and [`msgspec_available`] are exported;
+//! They use `PyO3`'s embedding API (`pyo3::sync::OnceExt`,
+//! `pyo3::call::PyCallArgs`, and `Bound<PyAny>`) with the supported `PyO3`
+//! `0.24.x` minor series to interact with an embedded Python interpreter.
+//! Their primary job is bootstrapping `msgspec>=0.19,<0.20` with `uv` or `pip`
+//! via `subprocess.run` so Rust and Python BDD tests can import it.
+//! Only [`ensure_msgspec_installed`] and [`msgspec_available`] are exported;
 //! `run_with_kwargs`, `install_msgspec`, and `has_uv` are private details.
-//! The bootstrap is serialised with `Once` via `OnceExt::call_once_py_attached`
+//! The bootstrap is serialized with `Once` via `OnceExt::call_once_py_attached`
 //! to prevent races when tests run in parallel.
 const MSGSPEC_REQUIREMENT: &str = "msgspec>=0.19,<0.20";
 const PIP_COMMON_FLAGS: [&str; 6] = [

--- a/tei-py/src/test_support.rs
+++ b/tei-py/src/test_support.rs
@@ -155,40 +155,49 @@ mod tests {
     //! Unit tests for Python-side test support helpers.
 
     use super::*;
+    use rstest::rstest;
     use std::ffi::CString;
 
-    #[test]
-    fn run_with_kwargs_accepts_unit_tuple() {
-        Python::with_gil(|py| {
-            let subprocess = py.import("subprocess").expect("import subprocess");
-            let run = subprocess.getattr("run").expect("get subprocess.run");
-            let kwargs = PyDict::new(py);
-
-            run_with_kwargs(&run, (), &kwargs);
-        });
+    struct RunAndKwargs<'py> {
+        run: Bound<'py, PyAny>,
+        kwargs: Bound<'py, PyDict>,
     }
 
-    #[test]
-    fn run_with_kwargs_accepts_one_tuple_of_pybytes() {
-        Python::with_gil(|py| {
-            let subprocess = py.import("subprocess").expect("import subprocess");
-            let run = subprocess.getattr("run").expect("get subprocess.run");
-            let kwargs = PyDict::new(py);
-            let args_tuple = PyTuple::new(py, ["true"]).expect("build argument tuple");
-
-            run_with_kwargs(&run, (args_tuple,), &kwargs);
-        });
+    enum RunWithKwargsArgShape {
+        Unit,
+        NestedPyTuple,
+        DirectPyTuple,
     }
 
-    #[test]
-    fn run_with_kwargs_accepts_bound_pytuple() {
-        Python::with_gil(|py| {
-            let subprocess = py.import("subprocess").expect("import subprocess");
-            let run = subprocess.getattr("run").expect("get subprocess.run");
-            let kwargs = PyDict::new(py);
-            let args_tuple = PyTuple::new(py, [["true"]]).expect("build subprocess args");
+    fn setup_run_and_kwargs(py: Python<'_>) -> RunAndKwargs<'_> {
+        let subprocess = py.import("subprocess").expect("import subprocess");
+        let run = subprocess.getattr("run").expect("get subprocess.run");
+        let kwargs = PyDict::new(py);
 
-            run_with_kwargs(&run, args_tuple, &kwargs);
+        RunAndKwargs { run, kwargs }
+    }
+
+    #[rstest]
+    #[case::unit_tuple(RunWithKwargsArgShape::Unit)]
+    #[case::one_tuple_of_pytuple(RunWithKwargsArgShape::NestedPyTuple)]
+    #[case::bound_pytuple(RunWithKwargsArgShape::DirectPyTuple)]
+    fn run_with_kwargs_accepts_supported_arg_shapes(#[case] arg_shape: RunWithKwargsArgShape) {
+        Python::with_gil(|py| {
+            let RunAndKwargs { run, kwargs } = setup_run_and_kwargs(py);
+
+            match arg_shape {
+                RunWithKwargsArgShape::Unit => run_with_kwargs(&run, (), &kwargs),
+                RunWithKwargsArgShape::NestedPyTuple => {
+                    let args_tuple = PyTuple::new(py, ["true"]).expect("build argument tuple");
+
+                    run_with_kwargs(&run, (args_tuple,), &kwargs);
+                }
+                RunWithKwargsArgShape::DirectPyTuple => {
+                    let args_tuple = PyTuple::new(py, [["true"]]).expect("build subprocess args");
+
+                    run_with_kwargs(&run, args_tuple, &kwargs);
+                }
+            }
         });
     }
 

--- a/tei-py/src/test_support.rs
+++ b/tei-py/src/test_support.rs
@@ -268,15 +268,17 @@ mod tests {
     }
 
     #[rstest]
-    #[case::which_returns_none("None", false)]
-    #[case::which_returns_path("'/usr/bin/uv'", true)]
-    fn has_uv_reflects_which_result(#[case] which_result: &str, #[case] expected: bool) {
+    #[case::none_means_absent("None", false)]
+    #[case::path_means_present("'/usr/bin/uv'", true)]
+    fn has_uv_reflects_which_return_value(#[case] which_return_expr: &str, #[case] expected: bool) {
         Python::with_gil(|py| {
-            let code = CString::new(format!(
-                "import shutil\norig = shutil.which\nshutil.which = lambda name: {which_result}\n",
+            let patch = CString::new(format!(
+                "import shutil\n\
+                 orig = shutil.which\n\
+                 shutil.which = lambda name: {which_return_expr}\n"
             ))
             .expect("CString build");
-            py.run(code.as_c_str(), None, None)
+            py.run(patch.as_c_str(), None, None)
                 .expect("monkeypatch shutil.which");
 
             assert_eq!(has_uv(py), expected);

--- a/tei-py/src/test_support.rs
+++ b/tei-py/src/test_support.rs
@@ -399,7 +399,9 @@ mod tests {
             ensure_msgspec_installed(py).ok();
         });
 
-        assert!(run_count.load(Ordering::SeqCst) <= 1);
+        // The Once guard fires at most once across all threads; each firing makes at
+        // most two subprocess.run calls (ensurepip + msgspec install).
+        assert!(run_count.load(Ordering::SeqCst) <= 2);
     }
 
     #[rstest]

--- a/tei-py/src/test_support.rs
+++ b/tei-py/src/test_support.rs
@@ -172,6 +172,7 @@ mod tests {
         globals: Bound<'py, PyDict>,
     }
 
+    #[derive(Clone, Copy)]
     enum RunWithKwargsArgShape {
         Unit,
         NestedPyTuple,
@@ -265,6 +266,14 @@ mod tests {
             .expect("count recorded subprocess.run calls")
     }
 
+    fn recorded_args<'py>(globals: &Bound<'py, PyDict>) -> Bound<'py, PyAny> {
+        let expr = CString::new("_calls[0][0]").expect("CString build");
+        globals
+            .py()
+            .eval(expr.as_c_str(), Some(globals), None)
+            .expect("read recorded subprocess.run positional arguments")
+    }
+
     #[rstest]
     #[case::unit_tuple(RunWithKwargsArgShape::Unit)]
     #[case::one_tuple_of_pytuple(RunWithKwargsArgShape::NestedPyTuple)]
@@ -298,6 +307,32 @@ mod tests {
             let call_count = recorded_call_count(&globals);
 
             assert_eq!(call_count, 1);
+
+            let args = recorded_args(&globals);
+            match arg_shape {
+                RunWithKwargsArgShape::Unit => {
+                    assert_eq!(args.len().expect("count positional arguments"), 0);
+                }
+                RunWithKwargsArgShape::NestedPyTuple => {
+                    let first_arg = args.get_item(0).expect("read first positional argument");
+                    assert_eq!(
+                        first_arg
+                            .extract::<(String,)>()
+                            .expect("extract nested tuple argument"),
+                        ("true".to_owned(),)
+                    );
+                }
+                RunWithKwargsArgShape::DirectPyTuple => {
+                    assert_eq!(args.len().expect("count positional arguments"), 1);
+                    let first_arg = args.get_item(0).expect("read first positional argument");
+                    assert_eq!(
+                        first_arg
+                            .extract::<Vec<String>>()
+                            .expect("extract direct list argument"),
+                        vec!["true".to_owned()]
+                    );
+                }
+            }
         });
     }
 
@@ -310,10 +345,10 @@ mod tests {
     }
 
     #[test]
-    fn msgspec_available_matches_ensure_installed() {
-        let ensure_result = Python::with_gil(|py| ensure_msgspec_installed(py).is_ok());
+    fn msgspec_available_reports_true_only_when_msgspec_is_importable() {
+        let directly_importable = Python::with_gil(|py| py.import("msgspec").is_ok());
 
-        assert_eq!(msgspec_available(), ensure_result);
+        assert_eq!(msgspec_available(), directly_importable);
     }
 
     #[test]

--- a/tei-py/src/test_support.rs
+++ b/tei-py/src/test_support.rs
@@ -337,19 +337,37 @@ mod tests {
     }
 
     #[test]
-    fn ensure_msgspec_installed_is_idempotent() {
-        let first_result = Python::with_gil(ensure_msgspec_installed).is_ok();
-        let second_result = Python::with_gil(ensure_msgspec_installed).is_ok();
+    fn ensure_msgspec_installed_invokes_subprocess_at_most_once_across_repeated_calls() {
+        let run_count = Arc::new(AtomicUsize::new(0));
 
-        assert_eq!(first_result, second_result);
+        let globals = Python::with_gil(|py| {
+            let g = setup_bootstrap_run_counter(py, Arc::clone(&run_count));
+            remove_msgspec_from_modules(py);
+            g
+        });
+
+        Python::with_gil(ensure_msgspec_installed).ok();
+        Python::with_gil(ensure_msgspec_installed).ok();
+
+        Python::with_gil(|py| {
+            restore_subprocess_run(py, globals.bind(py));
+            ensure_msgspec_installed(py).ok();
+        });
+
+        // The Once guard must prevent a second bootstrap: subprocess.run is invoked
+        // for ensurepip and for the msgspec install, so at most two calls occur in
+        // total across both ensure_msgspec_installed invocations.
+        assert!(run_count.load(Ordering::SeqCst) <= 2);
     }
 
     #[test]
     fn msgspec_available_reports_true_only_when_msgspec_is_importable() {
-        let available = msgspec_available();
-        let directly_importable = Python::with_gil(|py| py.import("msgspec").is_ok());
+        // Call the function under test first; it may bootstrap msgspec as a
+        // side-effect, so the importability check must come *after* the call.
+        let reported_available = msgspec_available();
+        let importable_after_check = Python::with_gil(|py| py.import("msgspec").is_ok());
 
-        assert_eq!(available, directly_importable);
+        assert_eq!(reported_available, importable_after_check);
     }
 
     #[test]

--- a/tei-py/src/test_support.rs
+++ b/tei-py/src/test_support.rs
@@ -237,13 +237,8 @@ mod tests {
             let call_count = recorded_call_count(&globals);
             restore_subprocess_run(py, &globals);
 
-            assert!(call_count > 0);
+            assert_eq!(call_count, 1);
         });
-    }
-
-    #[test]
-    fn msgspec_available_returns_bool() {
-        assert_eq!(msgspec_available(), msgspec_available());
     }
 
     #[test]
@@ -272,39 +267,19 @@ mod tests {
         }
     }
 
-    #[test]
-    fn has_uv_reports_absence_when_which_returns_none() {
+    #[rstest]
+    #[case::which_returns_none("None", false)]
+    #[case::which_returns_path("'/usr/bin/uv'", true)]
+    fn has_uv_reflects_which_result(#[case] which_result: &str, #[case] expected: bool) {
         Python::with_gil(|py| {
-            let code = CString::new(
-                "import shutil\norig = shutil.which\nshutil.which = lambda name: None\n",
-            )
+            let code = CString::new(format!(
+                "import shutil\norig = shutil.which\nshutil.which = lambda name: {which_result}\n",
+            ))
             .expect("CString build");
             py.run(code.as_c_str(), None, None)
                 .expect("monkeypatch shutil.which");
 
-            assert!(!has_uv(py), "uv should be absent when which returns None");
-
-            let restore =
-                CString::new("import shutil\nshutil.which = orig\n").expect("CString build");
-            py.run(restore.as_c_str(), None, None)
-                .expect("restore shutil.which");
-        });
-    }
-
-    #[test]
-    fn has_uv_reports_presence_when_which_returns_path() {
-        Python::with_gil(|py| {
-            let code = CString::new(
-                "import shutil\norig = shutil.which\nshutil.which = lambda name: '/usr/bin/uv'\n",
-            )
-            .expect("CString build");
-            py.run(code.as_c_str(), None, None)
-                .expect("monkeypatch shutil.which");
-
-            assert!(
-                has_uv(py),
-                "uv should be detected when which returns a path"
-            );
+            assert_eq!(has_uv(py), expected);
 
             let restore =
                 CString::new("import shutil\nshutil.which = orig\n").expect("CString build");

--- a/tei-py/src/test_support.rs
+++ b/tei-py/src/test_support.rs
@@ -156,7 +156,7 @@ mod tests {
 
     use super::*;
     use rstest::rstest;
-    use std::ffi::CString;
+    use std::{ffi::CString, thread};
 
     struct RunAndKwargs<'py> {
         run: Bound<'py, PyAny>,
@@ -199,6 +199,37 @@ mod tests {
                 }
             }
         });
+    }
+
+    #[test]
+    fn msgspec_available_returns_bool() {
+        assert_eq!(msgspec_available(), msgspec_available());
+    }
+
+    #[test]
+    fn ensure_msgspec_installed_is_idempotent() {
+        let first_result = Python::with_gil(ensure_msgspec_installed).is_ok();
+        let second_result = Python::with_gil(ensure_msgspec_installed).is_ok();
+
+        assert_eq!(first_result, second_result);
+    }
+
+    #[test]
+    fn msgspec_available_matches_ensure_installed() {
+        let ensure_result = Python::with_gil(|py| ensure_msgspec_installed(py).is_ok());
+
+        assert_eq!(msgspec_available(), ensure_result);
+    }
+
+    #[test]
+    fn ensure_msgspec_installed_is_safe_under_concurrent_access() {
+        let handles: Vec<_> = (0..8)
+            .map(|_| thread::spawn(|| Python::with_gil(ensure_msgspec_installed)))
+            .collect();
+
+        for handle in handles {
+            assert!(handle.join().is_ok());
+        }
     }
 
     #[test]

--- a/tei-py/src/test_support.rs
+++ b/tei-py/src/test_support.rs
@@ -161,6 +161,7 @@ mod tests {
     struct RunAndKwargs<'py> {
         run: Bound<'py, PyAny>,
         kwargs: Bound<'py, PyDict>,
+        globals: Bound<'py, PyDict>,
     }
 
     enum RunWithKwargsArgShape {
@@ -170,11 +171,41 @@ mod tests {
     }
 
     fn setup_run_and_kwargs(py: Python<'_>) -> RunAndKwargs<'_> {
+        let globals = PyDict::new(py);
+        let patch = CString::new(
+            "import subprocess\n\
+             _original_run = subprocess.run\n\
+             _calls = []\n\
+             subprocess.run = lambda *a, **kw: _calls.append((a, kw))\n",
+        )
+        .expect("CString build");
+        py.run(patch.as_c_str(), Some(&globals), None)
+            .expect("monkeypatch subprocess.run");
         let subprocess = py.import("subprocess").expect("import subprocess");
         let run = subprocess.getattr("run").expect("get subprocess.run");
         let kwargs = PyDict::new(py);
 
-        RunAndKwargs { run, kwargs }
+        RunAndKwargs {
+            run,
+            kwargs,
+            globals,
+        }
+    }
+
+    fn restore_subprocess_run(py: Python<'_>, globals: &Bound<'_, PyDict>) {
+        let restore =
+            CString::new("import subprocess\nsubprocess.run = _original_run\n_calls = []\n")
+                .expect("CString build");
+        py.run(restore.as_c_str(), Some(globals), None)
+            .expect("restore subprocess.run");
+    }
+
+    fn recorded_call_count(globals: &Bound<'_, PyDict>) -> usize {
+        globals
+            .get_item("_calls")
+            .expect("read recorded subprocess.run calls")
+            .len()
+            .expect("count recorded subprocess.run calls")
     }
 
     #[rstest]
@@ -183,7 +214,11 @@ mod tests {
     #[case::bound_pytuple(RunWithKwargsArgShape::DirectPyTuple)]
     fn run_with_kwargs_accepts_supported_arg_shapes(#[case] arg_shape: RunWithKwargsArgShape) {
         Python::with_gil(|py| {
-            let RunAndKwargs { run, kwargs } = setup_run_and_kwargs(py);
+            let RunAndKwargs {
+                run,
+                kwargs,
+                globals,
+            } = setup_run_and_kwargs(py);
 
             match arg_shape {
                 RunWithKwargsArgShape::Unit => run_with_kwargs(&run, (), &kwargs),
@@ -198,6 +233,11 @@ mod tests {
                     run_with_kwargs(&run, args_tuple, &kwargs);
                 }
             }
+
+            let call_count = recorded_call_count(&globals);
+            restore_subprocess_run(py, &globals);
+
+            assert!(call_count > 0);
         });
     }
 

--- a/tei-py/src/test_support.rs
+++ b/tei-py/src/test_support.rs
@@ -155,8 +155,16 @@ mod tests {
     //! Unit tests for Python-side test support helpers.
 
     use super::*;
+    use pyo3::{pyclass, pymethods};
     use rstest::rstest;
-    use std::{ffi::CString, thread};
+    use std::{
+        ffi::CString,
+        sync::{
+            Arc,
+            atomic::{AtomicUsize, Ordering},
+        },
+        thread,
+    };
 
     struct RunAndKwargs<'py> {
         run: Bound<'py, PyAny>,
@@ -208,6 +216,45 @@ mod tests {
         fn drop(&mut self) {
             restore_subprocess_run(self.py, &self.globals);
         }
+    }
+
+    #[pyclass]
+    struct BootstrapRunCounter {
+        count: Arc<AtomicUsize>,
+    }
+
+    #[pymethods]
+    impl BootstrapRunCounter {
+        fn __call__(&self, _args: &Bound<'_, PyTuple>, _kwargs: Option<&Bound<'_, PyDict>>) {
+            self.count.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    fn setup_bootstrap_run_counter(py: Python<'_>, count: Arc<AtomicUsize>) -> pyo3::Py<PyDict> {
+        let globals = PyDict::new(py);
+        globals
+            .set_item(
+                "_counter",
+                pyo3::Py::new(py, BootstrapRunCounter { count }).expect("build run counter"),
+            )
+            .expect("install run counter");
+        let patch = CString::new(
+            "import subprocess\n\
+             _original_run = subprocess.run\n\
+             subprocess.run = _counter\n",
+        )
+        .expect("CString build");
+        py.run(patch.as_c_str(), Some(&globals), None)
+            .expect("monkeypatch subprocess.run");
+
+        globals.unbind()
+    }
+
+    fn remove_msgspec_from_modules(py: Python<'_>) {
+        let remove =
+            CString::new("import sys\nsys.modules.pop('msgspec', None)\n").expect("CString build");
+        py.run(remove.as_c_str(), None, None)
+            .expect("remove msgspec from sys.modules");
     }
 
     fn recorded_call_count(globals: &Bound<'_, PyDict>) -> usize {
@@ -271,13 +318,34 @@ mod tests {
 
     #[test]
     fn ensure_msgspec_installed_is_safe_under_concurrent_access() {
+        let run_count = Arc::new(AtomicUsize::new(0));
+        let globals = Python::with_gil(|py| {
+            let globals = setup_bootstrap_run_counter(py, Arc::clone(&run_count));
+            remove_msgspec_from_modules(py);
+
+            globals
+        });
+
         let handles: Vec<_> = (0..8)
-            .map(|_| thread::spawn(|| Python::with_gil(ensure_msgspec_installed)))
+            .map(|_| {
+                let thread_run_count = Arc::clone(&run_count);
+                thread::spawn(move || {
+                    let _run_count = Arc::clone(&thread_run_count);
+                    Python::with_gil(ensure_msgspec_installed)
+                })
+            })
             .collect();
 
         for handle in handles {
             assert!(handle.join().is_ok());
         }
+
+        Python::with_gil(|py| {
+            restore_subprocess_run(py, globals.bind(py));
+            ensure_msgspec_installed(py).ok();
+        });
+
+        assert!(run_count.load(Ordering::SeqCst) <= 1);
     }
 
     #[rstest]


### PR DESCRIPTION
## Summary

This branch updates the Python binding crate to use `pyo3` 0.24.2 and keeps the direct `pyo3-build-config` build dependency aligned at 0.24.2. It also adjusts the test-support subprocess helper to use PyO3 0.24's `PyCallArgs` call contract, which removes the CI lint failure where generic tuple-convertible arguments no longer satisfied `PyAnyMethods::call`.

No roadmap task or issue is associated with this branch. No execplan was created because this is a small dependency and compatibility update.

## Review walkthrough

- Start with [tei-py/Cargo.toml](https://github.com/leynos/tei-rapporteur/blob/a1818e0682810556a5f20f23c432afbfefc81ff9/tei-py/Cargo.toml) to see the aligned `pyo3` and `pyo3-build-config` version requirements.
- Then review [tei-py/src/test_support.rs](https://github.com/leynos/tei-rapporteur/blob/a1818e0682810556a5f20f23c432afbfefc81ff9/tei-py/src/test_support.rs) for the PyO3 0.24 call argument bound used by the Python test bootstrap helper.
- Finish with [Cargo.lock](https://github.com/leynos/tei-rapporteur/blob/a1818e0682810556a5f20f23c432afbfefc81ff9/Cargo.lock) to confirm the resolved PyO3 crate graph no longer carries a duplicate `pyo3-build-config` version.

## Validation

- `make check-fmt`: passed.
- `make lint`: passed.
- `make test`: passed, 394 tests passed and 0 skipped.

## Notes

- Review feedback asked for `pyo3-build-config` to stay aligned with the `pyo3` minor series. This branch now uses 0.24.2 for both direct PyO3 dependencies.
