### PR TITLE
Add PyCallArgs compile-fail coverage (#78)

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -6,3 +6,7 @@ slow-timeout = { period = "60s", terminate-after = 1, grace-period = "5s" }
 # Put a hard ceiling on the whole run.
 global-timeout = "10m"
 
+[[profile.default.overrides]]
+# trybuild spawns a cold cargo build; allow enough time for it to finish.
+filter = 'package(tei-py) and test(=ui)'
+slow-timeout = { period = "300s", terminate-after = 1, grace-period = "10s" }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -203,6 +203,22 @@ project:
   `newt-hype` for the common case, tuple structs for outliers, and
   `the-newtype` to unify behaviour when you own the trait definitions.
 
+### Rust/Python Testing Boundary Concerns
+
+- Consult `docs/developers-guide.md` before changing `tei-py` test-support or
+  Python embedding tests; it records the current `trybuild`,
+  `OnceExt::call_once_py_attached`, and Python monkeypatching conventions.
+- For the `msgspec` bootstrap, prefer the existing `Once` plus
+  `OnceExt::call_once_py_attached` pattern over `#[serial]` attributes or an
+  external `Mutex`. The `Once` owns the single critical section and releases the
+  GIL while blocked threads wait.
+- Reserve `#[serial]` for tests that must coordinate multiple distinct statics
+  or process-global side effects across separate test functions.
+- When patching Python standard-library functions in tests, use typed RAII
+  restore guards such as `SubprocessRestoreGuard` and `ShutilRestoreGuard`.
+  Guards must carry the `Python<'py>` token and globals dictionary, restore in
+  `Drop`, and be named after what they undo.
+
 ### Dependency Management
 
 - **Mandate caret requirements for all dependencies.** All crate versions

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -477,7 +477,7 @@ version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59a98bbaacea1c0eb6a0876280051b892eb73594fd90cf3b20e9c817029c57d2"
 dependencies = [
- "toml",
+ "toml 0.5.11",
 ]
 
 [[package]]
@@ -2088,6 +2088,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2207,6 +2216,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
+name = "target-triple"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "591ef38edfb78ca4771ee32cf494cb8771944bee237a9b91fc9c1424ac4b777b"
+
+[[package]]
 name = "tei-core"
 version = "0.1.0"
 dependencies = [
@@ -2240,6 +2255,7 @@ dependencies = [
  "tei-test-helpers",
  "tei-xml",
  "thiserror 2.0.17",
+ "trybuild",
 ]
 
 [[package]]
@@ -2297,6 +2313,15 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -2394,6 +2419,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0dc8b1fb61449e27716ec0e1bdf0f6b8f3e8f6b05391e8497b8b6d7804ea6d8"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2422,6 +2462,12 @@ checksum = "c0cbe268d35bdb4bb5a56a2de88d0ad0eb70af5384a99d648cd4b3d04039800e"
 dependencies = [
  "winnow",
 ]
+
+[[package]]
+name = "toml_writer"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tower"
@@ -2492,6 +2538,21 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "trybuild"
+version = "1.0.115"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f614c21bd3a61bad9501d75cbb7686f00386c806d7f456778432c25cf86948a"
+dependencies = [
+ "glob",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "target-triple",
+ "termcolor",
+ "toml 0.9.8",
+]
 
 [[package]]
 name = "type-map"

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -134,6 +134,12 @@ tests because `trybuild` starts a nested Cargo build. That build may be cold in
 CI or after dependency updates, so `.config/nextest.toml` allows the UI harness
 five minutes before nextest terminates it.
 
+The UI harness does not mutate process environment variables. `trybuild`
+derives its nested Cargo target directory from Cargo metadata and passes that
+directory to its child Cargo process. If a CI job needs the nested build to
+share an existing target directory, set `CARGO_TARGET_DIR` before launching
+`cargo test`; `CARGO_LLVM_COV_TARGET_DIR` is not forwarded by the harness.
+
 The first fixture, `tei-py/tests/ui/non_pycallargs_rejected.rs`, verifies that
 `run_with_kwargs` rejects a plain `String` because `String` does not implement
 `pyo3::call::PyCallArgs<'py>`.

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -112,7 +112,7 @@ extension-safe linker flags without linking `libpython`. The
 can resolve the active Python configuration and apply the PyO3 cfg values
 needed by the crate.
 
-## tei-py UI compile tests
+## Tei-py UI compile tests
 
 `tei-py` uses `trybuild` as a dev-dependency for UI tests that assert
 compile-time API behaviour. The harness lives in `tei-py/tests/ui.rs` and calls
@@ -144,13 +144,14 @@ The first fixture, `tei-py/tests/ui/non_pycallargs_rejected.rs`, verifies that
 helper used by the `msgspec` bootstrap path and UI compile tests:
 
 ```rust
+#[doc(hidden)]
 pub fn run_with_kwargs<'py, A>(
     run: &Bound<'py, PyAny>,
     args: A,
     kwargs: &Bound<'py, PyDict>,
 )
 where
-    A: pyo3::call::PyCallArgs<'py>,
+    A: RunWithKwargsArgs<'py>,
 ```
 
 Any future caller must pass an argument value that implements
@@ -160,7 +161,7 @@ Any future caller must pass an argument value that implements
 one positional argument, wrap that argument in a Rust one-tuple, such as
 `(args_tuple,)`.
 
-Only `ensure_msgspec_installed` and `msgspec_available` are public exports from
-this module. They are thread-safe: `ensure_msgspec_installed` guards the
-bootstrap with `Once`, and `msgspec_available` delegates to it while attached
-to the Python interpreter.
+Only `ensure_msgspec_installed` and `msgspec_available` are documented public
+exports from this module. They are thread-safe: `ensure_msgspec_installed`
+guards the bootstrap with `Once`, and `msgspec_available` delegates to it while
+attached to the Python interpreter.

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -130,14 +130,11 @@ generated snapshot under `tei-py/wip/`, then move the `.stderr` file into
 contract.
 
 The default nextest profile gives `tei-py::ui` a longer timeout than ordinary
-tests because `trybuild` starts a nested Cargo build. That build may be cold in
-CI or after dependency updates. The most common trigger in CI is
-`cargo-llvm-cov`, which redirects compiled artefacts to a separate target
-directory (e.g. `target/llvm-cov-target/`) via `--target-dir` without exporting
-that path as `CARGO_TARGET_DIR`. Trybuild's child `cargo build` therefore
-cannot reuse the instrumented artefacts and must rebuild the full dependency
-graph from scratch. `.config/nextest.toml` allows the UI harness five minutes
-before nextest terminates it.
+tests because `trybuild` starts a nested Cargo build. In the
+`cargo llvm-cov --target-dir ...` CI path, that child build does not inherit the
+redirected target directory, so it rebuilds cold and can overrun the normal
+nextest limit. `.config/nextest.toml` therefore allows the UI harness five
+minutes before nextest terminates it.
 
 The UI harness does not mutate process environment variables. `trybuild`
 derives its nested Cargo target directory from Cargo metadata and passes that
@@ -147,7 +144,7 @@ share an existing target directory, set `CARGO_TARGET_DIR` before launching
 
 The first fixture, `tei-py/tests/ui/non_pycallargs_rejected.rs`, verifies that
 `run_with_kwargs` rejects a plain `String` because `String` does not implement
-`pyo3::call::PyCallArgs<'py>`.
+`RunWithKwargsArgs<'py>`.
 
 ## tei-py test-support API
 
@@ -166,11 +163,10 @@ where
 ```
 
 Any future caller must pass an argument value that implements
-`RunWithKwargsArgs<'py>` — the crate-owned wrapper trait that delegates to
-PyO3's `pyo3::call::PyCallArgs<'py>`. Under PyO3 0.28.3, `PyAnyMethods::call`
-takes `PyCallArgs` directly rather than accepting any value convertible through
-`IntoPyObject<'py, Target = PyTuple>`. When the intended Python call receives
-one positional argument, wrap that argument in a Rust one-tuple, such as
+`RunWithKwargsArgs<'py>`. That wrapper delegates to PyO3's `PyCallArgs` bound
+used by `PyAnyMethods::call`, so the helper stays hidden-public while the docs
+keep the crate-owned trait name. When the intended Python call receives one
+positional argument, wrap that argument in a Rust one-tuple, such as
 `(args_tuple,)`.
 
 Only `ensure_msgspec_installed` and `msgspec_available` are documented public

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -162,6 +162,13 @@ where
     A: RunWithKwargsArgs<'py>,
 ```
 
+`run_with_kwargs` is `#[doc(hidden)] pub` rather than `pub(crate)` because
+trybuild compiles each `tests/ui/*.rs` fixture as an **independent external
+crate**; `pub(crate)` items are invisible to external crates, so the fixture's
+`use tei_py::test_support::run_with_kwargs` would fail to resolve without full
+`pub` visibility. `#[doc(hidden)]` suppresses the item from rustdoc so it does
+not appear as a documented stable API.
+
 Any future caller must pass an argument value that implements
 `RunWithKwargsArgs<'py>`. That wrapper delegates to PyO3's `PyCallArgs` bound
 used by `PyAnyMethods::call`, so the helper stays hidden-public while the docs

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -112,10 +112,31 @@ extension-safe linker flags without linking `libpython`. The
 can resolve the active Python configuration and apply the PyO3 cfg values
 needed by the crate.
 
+## tei-py UI compile tests
+
+`tei-py` uses `trybuild` as a dev-dependency for UI tests that assert
+compile-time API behaviour. The harness lives in `tei-py/tests/ui.rs` and calls
+`trybuild::TestCases::new().compile_fail("tests/ui/*.rs")`, so each Rust
+file under `tei-py/tests/ui/` must fail to compile and must have a committed
+matching `.stderr` snapshot.
+
+Use UI tests when a runtime test cannot prove a public or hidden-public Rust
+API rejects an invalid type. Name fixtures after the behaviour being guarded,
+for example `non_pycallargs_rejected.rs`, and commit the generated
+`non_pycallargs_rejected.stderr` beside it. To add a fixture, create the
+compile-fail `.rs` file, run `cargo test -p tei-py --test ui`, inspect the
+generated snapshot under `tei-py/wip/`, then move the `.stderr` file into
+`tei-py/tests/ui/` only when the compiler error demonstrates the intended
+contract.
+
+The first fixture, `tei-py/tests/ui/non_pycallargs_rejected.rs`, verifies that
+`run_with_kwargs` rejects a plain `String` because `String` does not implement
+`pyo3::call::PyCallArgs<'py>`.
+
 ## tei-py test-support API
 
-`tei-py/src/test_support.rs` contains the private `run_with_kwargs` helper used
-by the `msgspec` bootstrap path:
+`tei-py/src/test_support.rs` contains the hidden-public `run_with_kwargs`
+helper used by the `msgspec` bootstrap path and UI compile tests:
 
 ```rust
 fn run_with_kwargs<'py, A>(

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -116,9 +116,9 @@ needed by the crate.
 
 `tei-py` uses `trybuild` as a dev-dependency for UI tests that assert
 compile-time API behaviour. The harness lives in `tei-py/tests/ui.rs` and calls
-`trybuild::TestCases::new().compile_fail("tests/ui/*.rs")`, so each Rust
-file under `tei-py/tests/ui/` must fail to compile and must have a committed
-matching `.stderr` snapshot.
+`trybuild::TestCases::new().compile_fail("tests/ui/*.rs")`, so each Rust file
+under `tei-py/tests/ui/` must fail to compile and must have a committed matching
+`.stderr` snapshot.
 
 Use UI tests when a runtime test cannot prove a public or hidden-public Rust
 API rejects an invalid type. Name fixtures after the behaviour being guarded,
@@ -128,6 +128,11 @@ compile-fail `.rs` file, run `cargo test -p tei-py --test ui`, inspect the
 generated snapshot under `tei-py/wip/`, then move the `.stderr` file into
 `tei-py/tests/ui/` only when the compiler error demonstrates the intended
 contract.
+
+The default nextest profile gives `tei-py::ui` a longer timeout than ordinary
+tests because `trybuild` starts a nested Cargo build. That build may be cold in
+CI or after dependency updates, so `.config/nextest.toml` allows the UI harness
+five minutes before nextest terminates it.
 
 The first fixture, `tei-py/tests/ui/non_pycallargs_rejected.rs`, verifies that
 `run_with_kwargs` rejects a plain `String` because `String` does not implement
@@ -139,7 +144,7 @@ The first fixture, `tei-py/tests/ui/non_pycallargs_rejected.rs`, verifies that
 helper used by the `msgspec` bootstrap path and UI compile tests:
 
 ```rust
-fn run_with_kwargs<'py, A>(
+pub fn run_with_kwargs<'py, A>(
     run: &Bound<'py, PyAny>,
     args: A,
     kwargs: &Bound<'py, PyDict>,

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -131,8 +131,13 @@ contract.
 
 The default nextest profile gives `tei-py::ui` a longer timeout than ordinary
 tests because `trybuild` starts a nested Cargo build. That build may be cold in
-CI or after dependency updates, so `.config/nextest.toml` allows the UI harness
-five minutes before nextest terminates it.
+CI or after dependency updates. The most common trigger in CI is
+`cargo-llvm-cov`, which redirects compiled artefacts to a separate target
+directory (e.g. `target/llvm-cov-target/`) via `--target-dir` without exporting
+that path as `CARGO_TARGET_DIR`. Trybuild's child `cargo build` therefore
+cannot reuse the instrumented artefacts and must rebuild the full dependency
+graph from scratch. `.config/nextest.toml` allows the UI harness five minutes
+before nextest terminates it.
 
 The UI harness does not mutate process environment variables. `trybuild`
 derives its nested Cargo target directory from Cargo metadata and passes that
@@ -161,8 +166,9 @@ where
 ```
 
 Any future caller must pass an argument value that implements
-`pyo3::call::PyCallArgs<'py>`. Under PyO3 0.28.3, `PyAnyMethods::call` takes
-`PyCallArgs` directly rather than accepting any value convertible through
+`RunWithKwargsArgs<'py>` — the crate-owned wrapper trait that delegates to
+PyO3's `pyo3::call::PyCallArgs<'py>`. Under PyO3 0.28.3, `PyAnyMethods::call`
+takes `PyCallArgs` directly rather than accepting any value convertible through
 `IntoPyObject<'py, Target = PyTuple>`. When the intended Python call receives
 one positional argument, wrap that argument in a Rust one-tuple, such as
 `(args_tuple,)`.

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -131,16 +131,13 @@ contract.
 
 The default nextest profile gives `tei-py::ui` a longer timeout than ordinary
 tests because `trybuild` starts a nested Cargo build. In the
-`cargo llvm-cov --target-dir ...` CI path, that child build does not inherit the
-redirected target directory, so it rebuilds cold and can overrun the normal
-nextest limit. `.config/nextest.toml` therefore allows the UI harness five
-minutes before nextest terminates it.
-
-The UI harness does not mutate process environment variables. `trybuild`
-derives its nested Cargo target directory from Cargo metadata and passes that
-directory to its child Cargo process. If a CI job needs the nested build to
-share an existing target directory, set `CARGO_TARGET_DIR` before launching
-`cargo test`; `CARGO_LLVM_COV_TARGET_DIR` is not forwarded by the harness.
+`cargo llvm-cov --target-dir ...` CI path, `cargo-llvm-cov` redirects compiled
+artefacts without exporting that directory as `CARGO_TARGET_DIR` for child
+Cargo processes. The nested build therefore starts cold and can overrun the
+normal nextest limit; `trybuild` is not dropping the path. Export
+`CARGO_TARGET_DIR` before launching `cargo test` when CI needs the nested build
+to share an existing target directory. `.config/nextest.toml` therefore allows
+the UI harness five minutes before nextest terminates it.
 
 The first fixture, `tei-py/tests/ui/non_pycallargs_rejected.rs`, verifies that
 `run_with_kwargs` rejects a plain `String` because `String` does not implement

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -176,6 +176,17 @@ keep the crate-owned trait name. When the intended Python call receives one
 positional argument, wrap that argument in a Rust one-tuple, such as
 `(args_tuple,)`.
 
+`RunWithKwargsArgs<'py>` is deliberately single-use. It exists so this crate,
+not PyO3, owns the `#[diagnostic::on_unimplemented]` message that drives the
+compile-fail snapshot. Binding `run_with_kwargs` directly to
+`pyo3::call::PyCallArgs<'py>` would make the expected stderr depend on PyO3's
+diagnostic wording, so a PyO3 minor release could silently break the committed
+snapshot without any `tei-py` API change. The diagnostic notes on
+`RunWithKwargsArgs<'py>` are therefore the source of
+`non_pycallargs_rejected.stderr`, not a copy of upstream output. Do not remove
+the wrapper unless the UI test is intentionally moved to a different
+crate-owned compile-fail boundary.
+
 Only `ensure_msgspec_installed` and `msgspec_available` are documented public
 exports from this module. They are thread-safe: `ensure_msgspec_installed`
 guards the bootstrap with `Once`, and `msgspec_available` delegates to it while

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -173,3 +173,29 @@ Only `ensure_msgspec_installed` and `msgspec_available` are documented public
 exports from this module. They are thread-safe: `ensure_msgspec_installed`
 guards the bootstrap with `Once`, and `msgspec_available` delegates to it while
 attached to the Python interpreter.
+
+### Rust/Python test boundary patterns
+
+The `msgspec` bootstrap path anchors shared state to
+`static MSGSPEC_INIT: Once`. Use `OnceExt::call_once_py_attached` for this
+implicit serialisation rather than adding `#[serial]` to every test that
+touches Python or wrapping the bootstrap in an external `Mutex`. The `Once`
+guard ensures exactly one thread runs the installer, and `OnceExt` releases the
+Python GIL while blocked threads wait. The
+`ensure_msgspec_installed_is_safe_under_concurrent_access` test validates the
+contract directly: it starts eight threads, expects `subprocess.run` to be
+called exactly twice, once for `ensurepip` and once for the `msgspec` install,
+and relies on `Once`'s internal atomics instead of test-framework
+serialisation. Reserve `#[serial]` for cases where separate test functions must
+exclude multiple distinct statics or process-global side effects; the single
+`Once` owns the whole `msgspec` bootstrap critical section.
+
+Tests that monkeypatch Python standard-library functions must bind restoration
+to RAII guards. `SubprocessRestoreGuard` restores `subprocess.run`, and
+`ShutilRestoreGuard` restores `shutil.which`; both carry the `Python<'py>` GIL
+token and globals dictionary, then delegate their `Drop` implementation to the
+existing restore function. This guarantees cleanup during panic unwinding, which
+a final manual `restore_*` call at the end of a test body cannot provide. Name
+future guards after what they undo, compose multiple guards in one scope when a
+test patches multiple globals, and rely on reverse declaration order to mirror a
+conventional `try`/`finally` stack.

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -196,7 +196,7 @@ attached to the Python interpreter.
 
 The `msgspec` bootstrap path anchors shared state to
 `static MSGSPEC_INIT: Once`. Use `OnceExt::call_once_py_attached` for this
-implicit serialisation rather than adding `#[serial]` to every test that
+implicit serialization rather than adding `#[serial]` to every test that
 touches Python or wrapping the bootstrap in an external `Mutex`. The `Once`
 guard ensures exactly one thread runs the installer, and `OnceExt` releases the
 Python GIL while blocked threads wait. The
@@ -204,7 +204,7 @@ Python GIL while blocked threads wait. The
 contract directly: it starts eight threads, expects `subprocess.run` to be
 called exactly twice, once for `ensurepip` and once for the `msgspec` install,
 and relies on `Once`'s internal atomics instead of test-framework
-serialisation. Reserve `#[serial]` for cases where separate test functions must
+serialization. Reserve `#[serial]` for cases where separate test functions must
 exclude multiple distinct statics or process-global side effects; the single
 `Once` owns the whole `msgspec` bootstrap critical section.
 

--- a/tei-py/Cargo.toml
+++ b/tei-py/Cargo.toml
@@ -31,6 +31,7 @@ rstest-bdd = { workspace = true }
 rstest-bdd-macros = { workspace = true }
 anyhow = { workspace = true }
 tei-test-helpers = { path = "../tei-test-helpers" }
+trybuild = "1"
 
 [build-dependencies]
 pyo3-build-config = { version = "0.28.3", features = ["resolve-config"] }

--- a/tei-py/src/bindings.rs
+++ b/tei-py/src/bindings.rs
@@ -198,12 +198,10 @@ pub(crate) mod py_exports {
         /// # Examples
         ///
         /// ```
-        /// use tei_serde::msgpack::to_vec_named;
-        /// use tei_core::TeiDocument;
-        /// use tei_py::from_msgpack;
+        /// use tei_py::{Document, from_msgpack, to_msgpack};
         ///
-        /// let source = TeiDocument::from_title_str("Wolf 359")?;
-        /// let payload = to_vec_named(&source)?;
+        /// let source = Document::try_from_title("Wolf 359")?;
+        /// let payload = to_msgpack(&source)?;
         /// let document = from_msgpack(&payload)?;
         /// assert_eq!(document.title(), "Wolf 359");
         /// # Ok::<(), Box<dyn std::error::Error>>(())
@@ -297,9 +295,9 @@ pub(crate) mod py_exports {
     ///     let payload = to_dict(py, &document)?;
     ///     let round_tripped = from_dict(payload)?;
     ///     assert_eq!(round_tripped.title(), "Wolf 359");
-    ///     Ok::<(), pyo3::PyErr>(())
+    ///     Ok::<(), Box<dyn std::error::Error>>(())
     /// })?;
-    /// # Ok::<(), pyo3::PyErr>(())
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
     #[pyfunction(name = "from_dict")]
     pub fn from_dict(payload: Bound<'_, PyAny>) -> PyResult<Document> {
@@ -325,14 +323,14 @@ pub(crate) mod py_exports {
     ///     let document = Document::try_from_title("Bridgewater")?;
     ///     let payload = to_dict(py, &document)?;
     ///     let title: String = payload
-    ///         .get_item("teiHeader")?
-    ///         .get_item("fileDesc")?
+    ///         .get_item("header")?
+    ///         .get_item("file_desc")?
     ///         .get_item("title")?
     ///         .extract()?;
     ///     assert_eq!(title, "Bridgewater");
-    ///     Ok::<(), pyo3::PyErr>(())
+    ///     Ok::<(), Box<dyn std::error::Error>>(())
     /// })?;
-    /// # Ok::<(), pyo3::PyErr>(())
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
     #[pyfunction(name = "to_dict")]
     pub fn to_dict<'py>(py: Python<'py>, document: &'py Document) -> PyResult<Bound<'py, PyAny>> {

--- a/tei-py/src/streaming.rs
+++ b/tei-py/src/streaming.rs
@@ -64,7 +64,7 @@ impl BufRead for SliceReader {
 /// immediately return `None`.
 ///
 /// # Usage
-/// ```
+/// ```python
 /// for event in tei_rapporteur.iter_parse(xml_string):
 ///     ...
 /// ```

--- a/tei-py/src/test_support.rs
+++ b/tei-py/src/test_support.rs
@@ -27,6 +27,17 @@ use pyo3::{
 };
 use std::sync::Once;
 
+#[doc(hidden)]
+#[diagnostic::on_unimplemented(
+    message = "`{Self}` cannot be used as a Python `call` argument",
+    note = "`PyCallArgs` is implemented for Rust tuples, `Bound<'py, PyTuple>` and `Py<PyTuple>`",
+    note = "if your type is convertible to `PyTuple` via `IntoPyObject`, call `<arg>.into_pyobject(py)` manually",
+    note = "if you meant to pass the type as a single argument, wrap it in a 1-tuple, `(<arg>,)`"
+)]
+pub trait RunWithKwargsArgs<'py>: pyo3::call::PyCallArgs<'py> {}
+
+impl<'py, A> RunWithKwargsArgs<'py> for A where A: pyo3::call::PyCallArgs<'py> {}
+
 fn has_uv(py: Python<'_>) -> bool {
     py.import("shutil")
         .ok()
@@ -40,7 +51,7 @@ fn has_uv(py: Python<'_>) -> bool {
 #[doc(hidden)]
 pub fn run_with_kwargs<'py, A>(run: &Bound<'py, PyAny>, args: A, kwargs: &Bound<'py, PyDict>)
 where
-    A: pyo3::call::PyCallArgs<'py>,
+    A: RunWithKwargsArgs<'py>,
 {
     // Best-effort: subprocess.run may fail (e.g., missing network); the final
     // `py.import("msgspec")?` is the authoritative error path for callers.

--- a/tei-py/src/test_support.rs
+++ b/tei-py/src/test_support.rs
@@ -48,13 +48,16 @@ fn has_uv(py: Python<'_>) -> bool {
         .is_some()
 }
 
+/// Calls a Python callable with positional arguments and keyword arguments.
+///
+/// This helper intentionally discards any error returned by the Python call.
+/// It is used only for best-effort setup paths where a later import check is
+/// the authoritative failure signal.
 #[doc(hidden)]
 pub fn run_with_kwargs<'py, A>(run: &Bound<'py, PyAny>, args: A, kwargs: &Bound<'py, PyDict>)
 where
     A: RunWithKwargsArgs<'py>,
 {
-    // Best-effort: subprocess.run may fail (e.g., missing network); the final
-    // `py.import("msgspec")?` is the authoritative error path for callers.
     run.call(args, Some(kwargs)).ok();
 }
 

--- a/tei-py/src/test_support.rs
+++ b/tei-py/src/test_support.rs
@@ -4,8 +4,9 @@
 //! `0.28.x` minor series to interact with an embedded Python interpreter.
 //! Their primary job is bootstrapping `msgspec>=0.19,<0.20` with `uv` or `pip`
 //! via `subprocess.run` so Rust and Python BDD tests can import it.
-//! Only [`ensure_msgspec_installed`] and [`msgspec_available`] are exported;
-//! `run_with_kwargs`, `install_msgspec`, and `has_uv` are private details.
+//! [`ensure_msgspec_installed`] and [`msgspec_available`] are public exports.
+//! `run_with_kwargs` is a hidden-public helper for compile-fail UI tests, while
+//! `install_msgspec` and `has_uv` are private details.
 //! The bootstrap is serialized with `Once` via `OnceExt::call_once_py_attached`
 //! to prevent races when tests run in parallel.
 const MSGSPEC_REQUIREMENT: &str = "msgspec>=0.19,<0.20";

--- a/tei-py/src/test_support.rs
+++ b/tei-py/src/test_support.rs
@@ -36,7 +36,8 @@ fn has_uv(py: Python<'_>) -> bool {
         .is_some()
 }
 
-fn run_with_kwargs<'py, A>(run: &Bound<'py, PyAny>, args: A, kwargs: &Bound<'py, PyDict>)
+#[doc(hidden)]
+pub fn run_with_kwargs<'py, A>(run: &Bound<'py, PyAny>, args: A, kwargs: &Bound<'py, PyDict>)
 where
     A: pyo3::call::PyCallArgs<'py>,
 {

--- a/tei-py/src/test_support.rs
+++ b/tei-py/src/test_support.rs
@@ -27,6 +27,16 @@ use pyo3::{
 };
 use std::sync::Once;
 
+/// Crate-owned wrapper for Python call argument diagnostics.
+///
+/// This trait intentionally has no reuse strategy beyond `run_with_kwargs`.
+/// Its purpose is to anchor the compile-fail contract at a `tei-py` symbol so
+/// the committed trybuild snapshot is driven by this crate's
+/// `#[diagnostic::on_unimplemented]` text, not by PyO3's `PyCallArgs`
+/// diagnostic, which may change across PyO3 minor releases.
+///
+/// The notes below are the source of the expected UI-test output. Keep them in
+/// sync with `tei-py/tests/ui/non_pycallargs_rejected.stderr`.
 #[doc(hidden)]
 #[diagnostic::on_unimplemented(
     message = "`{Self}` cannot be used as a Python `call` argument",

--- a/tei-py/tests/ui.rs
+++ b/tei-py/tests/ui.rs
@@ -1,59 +1,7 @@
 //! Compile-fail tests for the `tei-py` Rust API surface.
 
-use std::{
-    ffi::OsString,
-    sync::{Mutex, OnceLock},
-};
-
-fn env_guard() -> &'static Mutex<()> {
-    static ENV_GUARD: OnceLock<Mutex<()>> = OnceLock::new();
-    ENV_GUARD.get_or_init(|| Mutex::new(()))
-}
-
-struct CargoTargetDirRestore(Option<OsString>);
-
-impl CargoTargetDirRestore {
-    fn capture() -> Self {
-        Self(std::env::var_os("CARGO_TARGET_DIR"))
-    }
-}
-
-impl Drop for CargoTargetDirRestore {
-    fn drop(&mut self) {
-        // SAFETY: access to the process-global environment is serialised by
-        // `env_guard`, and this restores the value observed at test entry.
-        unsafe {
-            match self.0.take() {
-                Some(dir) => std::env::set_var("CARGO_TARGET_DIR", dir),
-                None => std::env::remove_var("CARGO_TARGET_DIR"),
-            }
-        }
-    }
-}
-
 #[test]
 fn ui() {
-    let _guard = env_guard()
-        .lock()
-        .expect("CARGO_TARGET_DIR environment guard should not be poisoned");
-    let _target_dir_restore = CargoTargetDirRestore::capture();
-
-    // When the workspace was compiled with cargo-llvm-cov (or any tool that
-    // redirects the target directory), forward that directory to trybuild so
-    // its sub-cargo invocation can reuse the already-compiled artefacts
-    // instead of starting a cold build.
-    //
-    // cargo-llvm-cov exports CARGO_LLVM_COV_TARGET_DIR; a plain nextest run
-    // or a CI step may instead set CARGO_TARGET_DIR directly.  We honour
-    // whichever is present, preferring CARGO_TARGET_DIR.
-    if std::env::var_os("CARGO_TARGET_DIR").is_none()
-        && let Ok(dir) = std::env::var("CARGO_LLVM_COV_TARGET_DIR")
-    {
-        // SAFETY: access to the process-global environment is serialised by
-        // `env_guard`, and the original value is restored before returning.
-        unsafe { std::env::set_var("CARGO_TARGET_DIR", dir) };
-    }
-
     let tests = trybuild::TestCases::new();
     tests.compile_fail("tests/ui/*.rs");
 }

--- a/tei-py/tests/ui.rs
+++ b/tei-py/tests/ui.rs
@@ -1,4 +1,16 @@
-//! Compile-fail tests for the `tei-py` Rust API surface.
+//! Compile-fail UI tests for the `tei-py` Rust API surface.
+//!
+//! This module is a [`trybuild`] test harness. The single `ui` test calls
+//! [`trybuild::TestCases::compile_fail`] with the glob `tests/ui/*.rs`, which
+//! discovers every `*.rs` fixture under `tei-py/tests/ui/` and compiles each
+//! one as an independent external crate. Each fixture **must** have a committed
+//! `.stderr` snapshot alongside it (same stem, `.stderr` extension); trybuild
+//! diffs the compiler output against that snapshot and fails the test on any
+//! divergence.
+//!
+//! To add a new fixture: create the `.rs` file, run
+//! `cargo test -p tei-py --test ui`, copy the generated snapshot from
+//! `tei-py/wip/` to `tei-py/tests/ui/`, then commit both files together.
 
 #[test]
 fn ui() {

--- a/tei-py/tests/ui.rs
+++ b/tei-py/tests/ui.rs
@@ -1,0 +1,22 @@
+//! Compile-fail tests for the `tei-py` Rust API surface.
+
+#[test]
+fn ui() {
+    // When the workspace was compiled with cargo-llvm-cov (or any tool that
+    // redirects the target directory), forward that directory to trybuild so
+    // its sub-cargo invocation can reuse the already-compiled artefacts
+    // instead of starting a cold build.
+    //
+    // cargo-llvm-cov exports CARGO_LLVM_COV_TARGET_DIR; a plain nextest run
+    // or a CI step may instead set CARGO_TARGET_DIR directly.  We honour
+    // whichever is present, preferring CARGO_TARGET_DIR.
+    if std::env::var_os("CARGO_TARGET_DIR").is_none()
+        && let Ok(dir) = std::env::var("CARGO_LLVM_COV_TARGET_DIR")
+    {
+        // SAFETY: single-threaded at this point in the test harness.
+        unsafe { std::env::set_var("CARGO_TARGET_DIR", dir) };
+    }
+
+    let tests = trybuild::TestCases::new();
+    tests.compile_fail("tests/ui/*.rs");
+}

--- a/tei-py/tests/ui.rs
+++ b/tei-py/tests/ui.rs
@@ -1,7 +1,43 @@
 //! Compile-fail tests for the `tei-py` Rust API surface.
 
+use std::{
+    ffi::OsString,
+    sync::{Mutex, OnceLock},
+};
+
+fn env_guard() -> &'static Mutex<()> {
+    static ENV_GUARD: OnceLock<Mutex<()>> = OnceLock::new();
+    ENV_GUARD.get_or_init(|| Mutex::new(()))
+}
+
+struct CargoTargetDirRestore(Option<OsString>);
+
+impl CargoTargetDirRestore {
+    fn capture() -> Self {
+        Self(std::env::var_os("CARGO_TARGET_DIR"))
+    }
+}
+
+impl Drop for CargoTargetDirRestore {
+    fn drop(&mut self) {
+        // SAFETY: access to the process-global environment is serialised by
+        // `env_guard`, and this restores the value observed at test entry.
+        unsafe {
+            match self.0.take() {
+                Some(dir) => std::env::set_var("CARGO_TARGET_DIR", dir),
+                None => std::env::remove_var("CARGO_TARGET_DIR"),
+            }
+        }
+    }
+}
+
 #[test]
 fn ui() {
+    let _guard = env_guard()
+        .lock()
+        .expect("CARGO_TARGET_DIR environment guard should not be poisoned");
+    let _target_dir_restore = CargoTargetDirRestore::capture();
+
     // When the workspace was compiled with cargo-llvm-cov (or any tool that
     // redirects the target directory), forward that directory to trybuild so
     // its sub-cargo invocation can reuse the already-compiled artefacts
@@ -13,7 +49,8 @@ fn ui() {
     if std::env::var_os("CARGO_TARGET_DIR").is_none()
         && let Ok(dir) = std::env::var("CARGO_LLVM_COV_TARGET_DIR")
     {
-        // SAFETY: single-threaded at this point in the test harness.
+        // SAFETY: access to the process-global environment is serialised by
+        // `env_guard`, and the original value is restored before returning.
         unsafe { std::env::set_var("CARGO_TARGET_DIR", dir) };
     }
 

--- a/tei-py/tests/ui/non_pycallargs_rejected.rs
+++ b/tei-py/tests/ui/non_pycallargs_rejected.rs
@@ -1,0 +1,11 @@
+//! Ensures `run_with_kwargs` rejects argument shapes outside `PyCallArgs`.
+
+use pyo3::prelude::*;
+use pyo3::types::PyDict;
+use tei_py::test_support::run_with_kwargs;
+
+fn rejects_plain_string<'py>(run: &Bound<'py, PyAny>, kwargs: &Bound<'py, PyDict>) {
+    run_with_kwargs(run, String::from("not call args"), kwargs);
+}
+
+fn main() {}

--- a/tei-py/tests/ui/non_pycallargs_rejected.rs
+++ b/tei-py/tests/ui/non_pycallargs_rejected.rs
@@ -1,4 +1,10 @@
-//! Ensures `run_with_kwargs` rejects argument shapes outside `PyCallArgs`.
+//! Compile-fail fixture: verifies that `run_with_kwargs` rejects a plain `String`.
+//!
+//! This file is a [`trybuild`] compile-fail fixture. It is compiled by
+//! `tei-py/tests/ui.rs` as an independent external crate; it must **not**
+//! compile successfully. The companion `non_pycallargs_rejected.stderr` snapshot
+//! records the expected `E0277` diagnostic produced when `String` — which does
+//! not implement `RunWithKwargsArgs<'py>` — is passed to `run_with_kwargs`.
 
 use pyo3::prelude::*;
 use pyo3::types::PyDict;

--- a/tei-py/tests/ui/non_pycallargs_rejected.stderr
+++ b/tei-py/tests/ui/non_pycallargs_rejected.stderr
@@ -1,0 +1,33 @@
+error[E0277]: `String` cannot used as a Python `call` argument
+ --> tests/ui/non_pycallargs_rejected.rs:8:26
+  |
+8 |     run_with_kwargs(run, String::from("not call args"), kwargs);
+  |     ---------------      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `PyCallArgs<'_>` is not implemented for `String`
+  |     |
+  |     required by a bound introduced by this call
+  |
+  = note: `PyCallArgs` is implemented for Rust tuples, `Bound<'py, PyTuple>` and `Py<PyTuple>`
+  = note: if your type is convertible to `PyTuple` via `IntoPyObject`, call `<arg>.into_pyobject(py)` manually
+  = note: if you meant to pass the type as a single argument, wrap it in a 1-tuple, `(<arg>,)`
+  = help: the following other types implement trait `PyCallArgs<'py>`:
+            &'a (T0, T1)
+            &'a (T0, T1, T2)
+            &'a (T0, T1, T2, T3)
+            &'a (T0, T1, T2, T3, T4)
+            &'a (T0, T1, T2, T3, T4, T5)
+            &'a (T0, T1, T2, T3, T4, T5, T6)
+            &'a (T0, T1, T2, T3, T4, T5, T6, T7)
+            &'a (T0, T1, T2, T3, T4, T5, T6, T7, T8)
+          and $N others
+note: required by a bound in `run_with_kwargs`
+ --> src/test_support.rs
+  |
+  | pub fn run_with_kwargs<'py, A>(run: &Bound<'py, PyAny>, args: A, kwargs: &Bound<'py, PyDict>)
+  |        --------------- required by a bound in this function
+  | where
+  |     A: pyo3::call::PyCallArgs<'py>,
+  |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `run_with_kwargs`
+help: use a unary tuple instead
+  |
+8 |     run_with_kwargs(run, (String::from("not call args"),), kwargs);
+  |                          +                             ++

--- a/tei-py/tests/ui/non_pycallargs_rejected.stderr
+++ b/tei-py/tests/ui/non_pycallargs_rejected.stderr
@@ -1,4 +1,4 @@
-error[E0277]: `String` cannot used as a Python `call` argument
+error[E0277]: `String` cannot be used as a Python `call` argument
  --> tests/ui/non_pycallargs_rejected.rs:8:26
   |
 8 |     run_with_kwargs(run, String::from("not call args"), kwargs);
@@ -19,14 +19,15 @@ error[E0277]: `String` cannot used as a Python `call` argument
             &'a (T0, T1, T2, T3, T4, T5, T6, T7)
             &'a (T0, T1, T2, T3, T4, T5, T6, T7, T8)
           and $N others
+  = note: required for `String` to implement `RunWithKwargsArgs<'_>`
 note: required by a bound in `run_with_kwargs`
  --> src/test_support.rs
   |
   | pub fn run_with_kwargs<'py, A>(run: &Bound<'py, PyAny>, args: A, kwargs: &Bound<'py, PyDict>)
   |        --------------- required by a bound in this function
   | where
-  |     A: pyo3::call::PyCallArgs<'py>,
-  |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `run_with_kwargs`
+  |     A: RunWithKwargsArgs<'py>,
+  |        ^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `run_with_kwargs`
 help: use a unary tuple instead
   |
 8 |     run_with_kwargs(run, (String::from("not call args"),), kwargs);

--- a/tei-py/tests/ui/non_pycallargs_rejected.stderr
+++ b/tei-py/tests/ui/non_pycallargs_rejected.stderr
@@ -1,34 +1,34 @@
 error[E0277]: `String` cannot be used as a Python `call` argument
- --> tests/ui/non_pycallargs_rejected.rs:8:26
-  |
-8 |     run_with_kwargs(run, String::from("not call args"), kwargs);
-  |     ---------------      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `PyCallArgs<'_>` is not implemented for `String`
-  |     |
-  |     required by a bound introduced by this call
-  |
-  = note: `PyCallArgs` is implemented for Rust tuples, `Bound<'py, PyTuple>` and `Py<PyTuple>`
-  = note: if your type is convertible to `PyTuple` via `IntoPyObject`, call `<arg>.into_pyobject(py)` manually
-  = note: if you meant to pass the type as a single argument, wrap it in a 1-tuple, `(<arg>,)`
-  = help: the following other types implement trait `PyCallArgs<'py>`:
-            &'a (T0, T1)
-            &'a (T0, T1, T2)
-            &'a (T0, T1, T2, T3)
-            &'a (T0, T1, T2, T3, T4)
-            &'a (T0, T1, T2, T3, T4, T5)
-            &'a (T0, T1, T2, T3, T4, T5, T6)
-            &'a (T0, T1, T2, T3, T4, T5, T6, T7)
-            &'a (T0, T1, T2, T3, T4, T5, T6, T7, T8)
-          and $N others
-  = note: required for `String` to implement `RunWithKwargsArgs<'_>`
+  --> tests/ui/non_pycallargs_rejected.rs:14:26
+   |
+14 |     run_with_kwargs(run, String::from("not call args"), kwargs);
+   |     ---------------      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `PyCallArgs<'_>` is not implemented for `String`
+   |     |
+   |     required by a bound introduced by this call
+   |
+   = note: `PyCallArgs` is implemented for Rust tuples, `Bound<'py, PyTuple>` and `Py<PyTuple>`
+   = note: if your type is convertible to `PyTuple` via `IntoPyObject`, call `<arg>.into_pyobject(py)` manually
+   = note: if you meant to pass the type as a single argument, wrap it in a 1-tuple, `(<arg>,)`
+   = help: the following other types implement trait `PyCallArgs<'py>`:
+             &'a (T0, T1)
+             &'a (T0, T1, T2)
+             &'a (T0, T1, T2, T3)
+             &'a (T0, T1, T2, T3, T4)
+             &'a (T0, T1, T2, T3, T4, T5)
+             &'a (T0, T1, T2, T3, T4, T5, T6)
+             &'a (T0, T1, T2, T3, T4, T5, T6, T7)
+             &'a (T0, T1, T2, T3, T4, T5, T6, T7, T8)
+           and $N others
+   = note: required for `String` to implement `RunWithKwargsArgs<'_>`
 note: required by a bound in `run_with_kwargs`
- --> src/test_support.rs
-  |
-  | pub fn run_with_kwargs<'py, A>(run: &Bound<'py, PyAny>, args: A, kwargs: &Bound<'py, PyDict>)
-  |        --------------- required by a bound in this function
-  | where
-  |     A: RunWithKwargsArgs<'py>,
-  |        ^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `run_with_kwargs`
+  --> src/test_support.rs
+   |
+   | pub fn run_with_kwargs<'py, A>(run: &Bound<'py, PyAny>, args: A, kwargs: &Bound<'py, PyDict>)
+   |        --------------- required by a bound in this function
+   | where
+   |     A: RunWithKwargsArgs<'py>,
+   |        ^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `run_with_kwargs`
 help: use a unary tuple instead
-  |
-8 |     run_with_kwargs(run, (String::from("not call args"),), kwargs);
-  |                          +                             ++
+   |
+14 |     run_with_kwargs(run, (String::from("not call args"),), kwargs);
+   |                          +                             ++


### PR DESCRIPTION
## Summary

Closes #78

- Add a trybuild UI test for `run_with_kwargs` rejecting non-`PyCallArgs` values.
- Commit the compiler stderr snapshot for the `String`\-rejection case.
- Expose `run_with_kwargs` as `#[doc(hidden)] pub` so trybuild fixtures (compiled as independent external crates) can resolve it; `pub(crate)` and `#[cfg(test)]` are both infeasible for external test harnesses.
- Introduce a crate-owned `RunWithKwargsArgs<'py>` wrapper trait with `#[diagnostic::on_unimplemented]` so the crate controls compile-fail diagnostic wording independently of PyO3 minor-version changes.
- Widen the nextest slow-timeout for `tei-py::ui` to 300 s; trybuild spawns a nested `cargo build` that can go cold under `cargo-llvm-cov` (which redirects artefacts via `--target-dir` without exporting `CARGO_TARGET_DIR`). Set `CARGO_TARGET_DIR` externally before running tests to let trybuild reuse an existing build cache.
- Document the UI compile-test workflow and snapshot-update steps in the developer guide.

## Validation

- `cargo test -p tei-py`
- `coderabbit review --agent`
- `make check-fmt`
- `make lint`
- `make test`
- `make markdownlint`

---

The key corrections over the previous description:

- Removes the stale claim that the UI harness forwards `CARGO_LLVM_COV_TARGET_DIR` to `CARGO_TARGET_DIR` at runtime (it does not; the guide now says `CARGO_TARGET_DIR` must be set externally if warm-starting is desired).
- Names `RunWithKwargsArgs<'py>` and `#[doc(hidden)] pub` explicitly, with the rationale for both.
- States the nextest timeout rationale concretely (cold build under `cargo-llvm-cov` target-dir redirection).