### PR TITLE
Wire the CodeScene coverage upload into CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,10 @@ jobs:
       WHITAKER_INSTALLER_VERSION: '0.2.5'
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+        with:
+          fetch-depth: 0
       - name: Setup Rust
-        uses: leynos/shared-actions/.github/actions/setup-rust@2b09d10192627fd6e1034e7c12625dd266b45503
+        uses: leynos/shared-actions/.github/actions/setup-rust@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
       - name: Format
         run: make check-fmt
       - name: Markdown lint
@@ -48,10 +50,11 @@ jobs:
       - name: Lint
         run: make lint
       - name: Test and Measure Coverage
-        uses: leynos/shared-actions/.github/actions/generate-coverage@455d9ed03477c0026da96c2541ca26569a74acac
+        uses: leynos/shared-actions/.github/actions/generate-coverage@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
         with:
-          output-path: coverage.xml
-          format: cobertura
+          output-path: lcov.info
+          format: lcov
+          with-ratchet: 'true'
       - name: Install jing for XML validation
         run: sudo apt-get update && sudo apt-get install -y jing
       - name: Validate XML fixtures against Relax NG schema
@@ -105,12 +108,17 @@ jobs:
         run: |
           python -c "import tei_rapporteur as tr; print(f'Version: {tr.__version__}'); assert hasattr(tr, 'Document'), 'Document class not exported'; assert hasattr(tr, 'emit_title_markup'), 'emit_title_markup missing'"
           echo "SMOKE_TEST_PASSED"
-      - name: Upload coverage data to CodeScene
-        env:
-          CS_ACCESS_TOKEN: ${{ secrets.CS_ACCESS_TOKEN }}
-        if: ${{ env.CS_ACCESS_TOKEN }}
-        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@feeb29c2be7b343cb62b0ffcb1cca176eb5b4db9
-        with:
-          format: cobertura
-          access-token: ${{ env.CS_ACCESS_TOKEN }}
-          installer-checksum: ${{ vars.CODESCENE_CLI_SHA256 }}
+      # `cs-coverage upload` (the shared action's default mode) is only
+      # accepted by CodeScene for analysed branches, typically main, so
+      # it cannot run from a pull-request head; coverage-main.yml
+      # uploads on push to main instead. The `mode: check` changed-line
+      # gate is deliberately not wired in yet: CodeScene project 72456
+      # has no coverage-gates configuration, so `cs-coverage check`
+      # fails every run with "HTTP call succeeded, but the received
+      # project-config isn't valid. Lacks the gates configuration." — a
+      # CodeScene-side per-project setting, not a CI defect (see
+      # ddlint#287 and chutoro#156 for the same failure on other
+      # projects). Add the check step in a fast-follow PR once
+      # coverage-main.yml has uploaded to main at least once and the
+      # gate is confirmed to resolve, or once CodeScene confirms the
+      # project's coverage gate is enabled.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,8 +52,12 @@ jobs:
       - name: Test and Measure Coverage
         uses: leynos/shared-actions/.github/actions/generate-coverage@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
         with:
-          output-path: lcov.info
-          format: lcov
+          # The shared action detects this repository as a mixed
+          # Rust-and-Python project (root Cargo.toml plus root
+          # pyproject.toml), and mixed projects only support the merged
+          # cobertura format.
+          output-path: coverage.xml
+          format: cobertura
           with-ratchet: 'true'
       - name: Install jing for XML validation
         run: sudo apt-get update && sudo apt-get install -y jing

--- a/.github/workflows/coverage-main.yml
+++ b/.github/workflows/coverage-main.yml
@@ -30,13 +30,17 @@ jobs:
       - name: Generate coverage
         uses: leynos/shared-actions/.github/actions/generate-coverage@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
         with:
-          output-path: lcov.info
-          format: lcov
+          # The shared action detects this repository as a mixed
+          # Rust-and-Python project (root Cargo.toml plus root
+          # pyproject.toml), and mixed projects only support the merged
+          # cobertura format.
+          output-path: coverage.xml
+          format: cobertura
           with-ratchet: 'true'
       - name: Upload coverage data to CodeScene
         if: env.CS_ACCESS_TOKEN
         uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
         with:
-          format: lcov
+          format: cobertura
           access-token: ${{ env.CS_ACCESS_TOKEN }}
           installer-checksum: ${{ env.CODESCENE_CLI_SHA256 }}

--- a/.github/workflows/coverage-main.yml
+++ b/.github/workflows/coverage-main.yml
@@ -1,0 +1,42 @@
+name: Coverage (main)
+
+# CodeScene accepts `cs-coverage upload` only for analysed branches, so
+# main-branch coverage is uploaded here on push; pull requests only
+# generate coverage in ci.yml (the changed-line `mode: check` gate is
+# deferred until CodeScene's project-side gates configuration is
+# confirmed — see the comment in ci.yml). This workflow also advances
+# the coverage ratchet baseline: caches saved on main are readable by
+# every pull-request run, so the baseline written here is the one PR
+# ratchet checks compare against.
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  coverage-upload:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      CARGO_TERM_COLOR: always
+      BUILD_PROFILE: debug
+      CS_ACCESS_TOKEN: ${{ secrets.CS_ACCESS_TOKEN || '' }}
+      CODESCENE_CLI_SHA256: ${{ vars.CODESCENE_CLI_SHA256 || '' }}
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+      - name: Setup Rust
+        uses: leynos/shared-actions/.github/actions/setup-rust@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
+      - name: Generate coverage
+        uses: leynos/shared-actions/.github/actions/generate-coverage@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
+        with:
+          output-path: lcov.info
+          format: lcov
+          with-ratchet: 'true'
+      - name: Upload coverage data to CodeScene
+        if: env.CS_ACCESS_TOKEN
+        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
+        with:
+          format: lcov
+          access-token: ${{ env.CS_ACCESS_TOKEN }}
+          installer-checksum: ${{ env.CODESCENE_CLI_SHA256 }}

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -28,6 +28,6 @@ jobs:
       # The token is not used for any external cloud auth.
       id-token: write
     if: ${{ github.event_name == 'workflow_dispatch' || github.actor == 'dependabot[bot]' }}
-    uses: leynos/shared-actions/.github/workflows/dependabot-automerge.yml@1990e9a6aaa73f0929e04dbc7da12326005606bf
+    uses: leynos/shared-actions/.github/workflows/dependabot-automerge.yml@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
     with:
       pull-request-number: ${{ inputs.pull-request-number || github.event.pull_request.number }}

--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -26,7 +26,7 @@ jobs:
     permissions:
       contents: read
       id-token: write # OIDC workflow-source resolution
-    uses: leynos/shared-actions/.github/workflows/mutation-cargo.yml@47aea18960d24f33aedc4782ec6b73e365418313
+    uses: leynos/shared-actions/.github/workflows/mutation-cargo.yml@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
     with:
       # Workspace crates live in root-level directories, not crates/;
       # tei-test-helpers is excluded from mutation so it is omitted

--- a/tests/workflow_contracts/mutation_testing_test.py
+++ b/tests/workflow_contracts/mutation_testing_test.py
@@ -22,9 +22,11 @@ WORKFLOW_PATH = (
 )
 
 #: The commit SHA of the shared-actions revision adopted across the
-#: estate (the merge commit of leynos/shared-actions PR #319). Bump the
-#: workflow and this test together.
-PINNED_SHA = "47aea18960d24f33aedc4782ec6b73e365418313"
+#: estate (leynos/shared-actions PR #334, which adds the `mode: check`
+#: coverage gate used by the CI workflow's coverage steps; the estate
+#: keeps a single repo-wide pin). Bump the workflow and this test
+#: together.
+PINNED_SHA = "927edd45ae77be4251a8a18ca9eb5613a2e32cbd"
 
 EXPECTED_USES = (
     "leynos/shared-actions/.github/workflows/mutation-cargo.yml@" + PINNED_SHA


### PR DESCRIPTION
## Summary

- Enable the coverage ratchet (`with-ratchet: 'true'`) on the existing
  merged-cobertura coverage generation. (The shared action detects
  this repository as a mixed Rust-and-Python project — root
  `Cargo.toml` plus root `pyproject.toml` — and mixed projects only
  support the merged cobertura format, so the estate's usual LCOV
  switch does not apply here.)
- Add `coverage-main.yml` (`on: push: branches: [main]`) that
  generates coverage and uploads it to CodeScene project
  [72456](https://codescene.io/projects/72456) with `cs-coverage
  upload`, the only mode CodeScene accepts outside a pull request.
  It also writes the ratchet baseline that PR runs will compare
  against.
- Bump every `leynos/shared-actions/...` pin in the repo to
  `927edd45ae77be4251a8a18ca9eb5613a2e32cbd` (fixes the
  `install-cs-coverage-tool.sh` version-extraction regression and adds
  the `mode: check` gate), including `mutation-testing.yml`,
  `dependabot-automerge.yml`, and the pinned SHA asserted by
  `tests/workflow_contracts/mutation_testing_test.py`.
- Remove the old PR-side `upload-codescene-coverage` step from
  `ci.yml`. It ran in `mode: upload` (the shared action's default),
  which CodeScene only accepts for analysed branches (main) — with a
  real `CS_ACCESS_TOKEN` in place it would fail on every pull request.
  A comment in `ci.yml` explains why the changed-line `mode: check`
  gate is not wired in yet: CodeScene's project-config for 72456 has
  no gates configuration, so `cs-coverage check` fails with `Lacks the
  gates configuration.` — the same error hit by
  [ddlint#287](https://github.com/leynos/ddlint/pull/287) and
  chutoro#156 on their own projects. That is a CodeScene-side toggle,
  not a CI defect; the check step is deferred to a fast-follow once it
  resolves.
- Set `CS_ACCESS_TOKEN` in both the repository Actions secret store
  and the Dependabot secret store, so Dependabot-triggered runs of
  `coverage-main.yml` (and any future gate) are not silently skipped.

## Review walkthrough

- [`.github/workflows/ci.yml`](https://github.com/leynos/tei-rapporteur/blob/codescene-coverage-gate/.github/workflows/ci.yml) —
  `fetch-depth: 0` checkout (future-proofs the deferred `mode: check`
  step, which diffs against the merge base), ratchet-enabled coverage
  generation, pin bump, and the old upload step replaced with an
  explanatory comment.
- [`.github/workflows/coverage-main.yml`](https://github.com/leynos/tei-rapporteur/blob/codescene-coverage-gate/.github/workflows/coverage-main.yml) —
  new push-to-main workflow, modelled on mxd#362 and ddlint#287.
- [`.github/workflows/mutation-testing.yml`](https://github.com/leynos/tei-rapporteur/blob/codescene-coverage-gate/.github/workflows/mutation-testing.yml) and
  [`.github/workflows/dependabot-automerge.yml`](https://github.com/leynos/tei-rapporteur/blob/codescene-coverage-gate/.github/workflows/dependabot-automerge.yml) —
  pin bump only, no behaviour change.
- [`tests/workflow_contracts/mutation_testing_test.py`](https://github.com/leynos/tei-rapporteur/blob/codescene-coverage-gate/tests/workflow_contracts/mutation_testing_test.py) —
  updated pinned-SHA contract to match.

Note for reviewers: the CodeScene app posts a `CodeScene Code Health
Review` check on this repo's PRs today, but no `CodeScene Code
Coverage` check — that check only appears once CodeScene's coverage
gate is enabled for a project, which is not the case here yet. Nothing
in the branch ruleset requires it, so this PR does not change what is
required to merge.

## Validation

- `python3 -c "import yaml; yaml.safe_load(open(f))"` for every
  workflow file under `.github/workflows/`.
- `make test-workflow-contracts` (6 passed).
- `CS_ACCESS_TOKEN` confirmed present in both the Actions and
  Dependabot secret stores for this repository.
- CI on this PR's own head, to confirm `build-test` still passes with
  the ratchet-enabled coverage step.
