### PR TITLE
Stop pinning the exact shared-actions SHA in workflow contract tests

### DIFF
--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -357,3 +357,39 @@ which a final manual `restore_*` call at the end of a test body cannot provide.
 Name future guards after what they undo, compose multiple guards in one scope
 when a test patches multiple globals, and rely on reverse declaration order to
 mirror a conventional `try`/`finally` stack.
+
+## Workflow pins and Dependabot
+
+Dependabot owns the upgrade of GitHub Actions and reusable workflows,
+including calls into `leynos/shared-actions`. Contract tests that assert a
+caller's exact commit SHA create a lockstep dependency: every time Dependabot
+opens a bump PR, the test fails until a human edits the pinned constant to
+match. That defeats the purpose of automated dependency updates and turns a
+routine bump into a manual chore.
+
+Contract tests may still verify the *shape* of a reusable-workflow caller.
+They must not verify the specific SHA value.
+
+- Do assert the workflow references the correct reusable workflow path.
+- Do assert the ref is pinned to a full 40-character commit SHA, not a
+  mutable branch such as `main` or `rolling`.
+- Do assert the expected `on:` triggers, least-privilege `permissions:`, and
+  the inputs the caller relies on.
+- Do not hard-code the current SHA value as an expected string. Match it with
+  a pattern instead.
+- Do not fail a test purely because Dependabot bumped the pinned SHA.
+
+```python
+import re
+
+SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+
+
+def test_uses_pinned_full_sha(caller_step):
+    ref = caller_step["uses"].split("@")[-1]
+    assert SHA_RE.match(ref), f"expected a 40-hex commit SHA, got {ref!r}"
+```
+
+If a workflow's behaviour genuinely depends on a feature only present from a
+particular commit onwards, express that as a comment or a changelog note, not
+as a test assertion on the SHA string.

--- a/tests/workflow_contracts/mutation_testing_test.py
+++ b/tests/workflow_contracts/mutation_testing_test.py
@@ -3,16 +3,22 @@
 The executable logic lives in the ``leynos/shared-actions`` reusable
 workflow, which carries its own unit and integration tests;
 tei-rapporteur's caller is declarative configuration. These tests parse
-the caller with PyYAML and pin the contract it must uphold, so drift
-(repointing the pin at a branch, widening permissions, or losing the
+the caller with PyYAML and assert the shape of the contract it must
+uphold — the correct reusable workflow path, pinned to a full commit
+SHA rather than a mutable branch or tag, with least-privilege
+permissions and the expected caller configuration — so drift (repointing
+the reference at a branch, widening permissions, or losing the
 workspace paths, scaffolding excludes, or feature arguments) fails CI
 on the pull request rather than surfacing in a scheduled or manual run.
+Dependabot owns the pinned SHA value itself; these tests do not assert
+which SHA is pinned.
 
 Run via ``make test-workflow-contracts``.
 """
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 import yaml
@@ -21,15 +27,11 @@ WORKFLOW_PATH = (
     Path(__file__).resolve().parents[2] / ".github" / "workflows" / "mutation-testing.yml"
 )
 
-#: The commit SHA of the shared-actions revision adopted across the
-#: estate (leynos/shared-actions PR #334, which adds the `mode: check`
-#: coverage gate used by the CI workflow's coverage steps; the estate
-#: keeps a single repo-wide pin). Bump the workflow and this test
-#: together.
-PINNED_SHA = "927edd45ae77be4251a8a18ca9eb5613a2e32cbd"
-
-EXPECTED_USES = (
-    "leynos/shared-actions/.github/workflows/mutation-cargo.yml@" + PINNED_SHA
+#: Matches the reusable workflow path pinned to a full 40-hex commit
+#: SHA. Dependabot owns the SHA value; this contract only pins the
+#: shape of the reference.
+USES_RE = re.compile(
+    r"^leynos/shared-actions/\.github/workflows/mutation-cargo\.yml@[0-9a-f]{40}$"
 )
 
 #: The exact caller configuration: change detection over the four
@@ -75,25 +77,14 @@ def _mutation_job(workflow: dict[str, object]) -> dict[str, object]:
     return jobs["mutation"]
 
 
-def test_uses_reference_is_pinned_to_the_documented_sha() -> None:
-    """The job must call the shared workflow at the exact documented SHA."""
+def test_uses_reference_is_pinned_to_a_commit_sha() -> None:
+    """The job must call the shared workflow pinned to a full commit SHA."""
     uses = _mutation_job(_load()).get("uses")
     assert uses is not None, "jobs.mutation.uses is missing"
-    path, _, ref = uses.partition("@")
-    assert path == "leynos/shared-actions/.github/workflows/mutation-cargo.yml", (
-        f"jobs.mutation.uses must reference mutation-cargo.yml, got {path!r}"
-    )
-    assert len(ref) == 40, (
-        f"jobs.mutation.uses must pin a full 40-character commit SHA, "
-        f"not a branch or tag: {ref!r}"
-    )
-    assert all(c in "0123456789abcdef" for c in ref), (
-        f"jobs.mutation.uses must pin a lowercase hex commit SHA, "
-        f"not a branch or tag: {ref!r}"
-    )
-    assert uses == EXPECTED_USES, (
-        f"jobs.mutation.uses pins {ref!r}; the estate documents {PINNED_SHA!r} — "
-        "bump this test together with the workflow"
+    assert USES_RE.match(uses), (
+        f"jobs.mutation.uses must reference mutation-cargo.yml pinned to a "
+        f"full 40-character lowercase hex commit SHA (not a branch or tag), "
+        f"got {uses!r}"
     )
 
 


### PR DESCRIPTION
## Summary

- The mutation-testing workflow contract test asserted an exact
  `leynos/shared-actions` commit SHA, so every Dependabot bump of that
  pin failed CI until a human hand-edited the constant to match.
- Replace the exact-SHA equality assertion with a regular expression
  that still confirms the caller references the correct reusable
  workflow path, pinned to a full 40-character commit SHA rather than
  a mutable branch or tag — but does not constrain which SHA. Dependabot
  now owns the pinned value; all other structural assertions
  (permissions, triggers, concurrency, `with:` inputs) are unchanged.
- Document the policy in `docs/developers-guide.md` so future contract
  tests follow the same shape-only pattern.

## Review walkthrough

- `tests/workflow_contracts/mutation_testing_test.py`: drop
  `PINNED_SHA`/`EXPECTED_USES`, add a `USES_RE` pattern, and rename
  `test_uses_reference_is_pinned_to_the_documented_sha` to
  `test_uses_reference_is_pinned_to_a_commit_sha`, which now matches
  the shape only. Module docstring updated to describe the shape
  contract and note that Dependabot owns the SHA value.
- `docs/developers-guide.md`: new "Workflow pins and Dependabot"
  section with the estate-wide policy and example pattern.
- `.github/dependabot.yml` already has a `github-actions` ecosystem
  entry with `directory: "/"`, so Dependabot already owns this pin —
  no change needed there.

## Validation

- `make test-workflow-contracts` passes locally (6/6), confirming the
  new regex matches the currently pinned SHA
  (`927edd45ae77be4251a8a18ca9eb5613a2e32cbd`).
- The regex `^leynos/shared-actions/\.github/workflows/mutation-cargo\.yml@[0-9a-f]{40}$`
  contains no reference to any specific SHA value, so it would equally
  match a hypothetical different 40-hex SHA — the next Dependabot bump
  will not break this test.
- `markdownlint-cli2` passes on the updated developers' guide.
- No workflow files were touched; only the test and documentation
  changed, so this PR does not require the `workflow` OAuth scope.
