### PR TITLE
Bump whitaker-installer to 0.2.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     env:
       CARGO_TERM_COLOR: always
       BUILD_PROFILE: debug
-      WHITAKER_INSTALLER_VERSION: '0.2.5'
+      WHITAKER_INSTALLER_VERSION: '0.2.6'
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
         with:

--- a/tei-py/tests/python_module/steps_construction.rs
+++ b/tei-py/tests/python_module/steps_construction.rs
@@ -118,38 +118,22 @@ pub(super) fn i_emit_markup_from_the_document(
     path = "tests/features/python_module.feature",
     name = "Construct a Document from a valid title"
 )]
-#[expect(
-    unused_variables,
-    reason = "rstest-bdd matches scenario fixtures by parameter name"
-)]
-pub fn constructs_a_document(python_state: PythonModuleState) {}
+pub fn constructs_a_document(#[from(python_state)] _python_state: PythonModuleState) {}
 
 #[scenario(
     path = "tests/features/python_module.feature",
     name = "Reject blank titles in the Python constructor"
 )]
-#[expect(
-    unused_variables,
-    reason = "rstest-bdd matches scenario fixtures by parameter name"
-)]
-pub fn rejects_blank_titles(python_state: PythonModuleState) {}
+pub fn rejects_blank_titles(#[from(python_state)] _python_state: PythonModuleState) {}
 
 #[scenario(
     path = "tests/features/python_module.feature",
     name = "Emit title markup via the Python helper"
 )]
-#[expect(
-    unused_variables,
-    reason = "rstest-bdd matches scenario fixtures by parameter name"
-)]
-pub fn emits_title_markup(python_state: PythonModuleState) {}
+pub fn emits_title_markup(#[from(python_state)] _python_state: PythonModuleState) {}
 
 #[scenario(
     path = "tests/features/python_module.feature",
     name = "Document method escapes XML special characters"
 )]
-#[expect(
-    unused_variables,
-    reason = "rstest-bdd matches scenario fixtures by parameter name"
-)]
-pub fn document_markup_escapes_special_characters(python_state: PythonModuleState) {}
+pub fn document_markup_escapes_special_characters(#[from(python_state)] _python_state: PythonModuleState) {}

--- a/tei-py/tests/python_module/steps_construction.rs
+++ b/tei-py/tests/python_module/steps_construction.rs
@@ -136,4 +136,7 @@ pub fn emits_title_markup(#[from(python_state)] _python_state: PythonModuleState
     path = "tests/features/python_module.feature",
     name = "Document method escapes XML special characters"
 )]
-pub fn document_markup_escapes_special_characters(#[from(python_state)] _python_state: PythonModuleState) {}
+pub fn document_markup_escapes_special_characters(
+    #[from(python_state)] _python_state: PythonModuleState,
+) {
+}

--- a/tei-py/tests/python_module/steps_dict.rs
+++ b/tei-py/tests/python_module/steps_dict.rs
@@ -273,63 +273,39 @@ pub(super) fn the_div_structure_is_preserved(
     path = "tests/features/python_module.feature",
     name = "Decode a Document from a dictionary payload"
 )]
-#[expect(
-    unused_variables,
-    reason = "rstest-bdd matches scenario fixtures by parameter name"
-)]
-pub fn decodes_dictionary_payloads(python_state: PythonModuleState) {}
+pub fn decodes_dictionary_payloads(#[from(python_state)] _python_state: PythonModuleState) {}
 
 /// Scenario: Reject dictionary payloads missing required fields.
 #[scenario(
     path = "tests/features/python_module.feature",
     name = "Reject dictionary payloads missing required fields"
 )]
-#[expect(
-    unused_variables,
-    reason = "rstest-bdd matches scenario fixtures by parameter name"
-)]
-pub fn rejects_incomplete_dictionary_payloads(python_state: PythonModuleState) {}
+pub fn rejects_incomplete_dictionary_payloads(#[from(python_state)] _python_state: PythonModuleState) {}
 
 /// Scenario: Reject dictionary payloads with blank titles.
 #[scenario(
     path = "tests/features/python_module.feature",
     name = "Reject dictionary payloads with blank titles"
 )]
-#[expect(
-    unused_variables,
-    reason = "rstest-bdd matches scenario fixtures by parameter name"
-)]
-pub fn rejects_blank_titles_in_dictionary_payloads(python_state: PythonModuleState) {}
+pub fn rejects_blank_titles_in_dictionary_payloads(#[from(python_state)] _python_state: PythonModuleState) {}
 
 /// Scenario: Encode a `Document` to a dictionary payload.
 #[scenario(
     path = "tests/features/python_module.feature",
     name = "Encode a Document to a dictionary payload"
 )]
-#[expect(
-    unused_variables,
-    reason = "rstest-bdd matches scenario fixtures by parameter name"
-)]
-pub fn encodes_documents_to_dictionaries(python_state: PythonModuleState) {}
+pub fn encodes_documents_to_dictionaries(#[from(python_state)] _python_state: PythonModuleState) {}
 
 /// Scenario: Reject `to_dict` when a `Document` is not provided.
 #[scenario(
     path = "tests/features/python_module.feature",
     name = "Reject to_dict when a Document is not provided"
 )]
-#[expect(
-    unused_variables,
-    reason = "rstest-bdd matches scenario fixtures by parameter name"
-)]
-pub fn rejects_to_dict_without_document(python_state: PythonModuleState) {}
+pub fn rejects_to_dict_without_document(#[from(python_state)] _python_state: PythonModuleState) {}
 
 /// Scenario: Round-trip a div-containing `Document` through a dictionary payload.
 #[scenario(
     path = "tests/features/python_module.feature",
     name = "Round-trip dictionary payload with div blocks"
 )]
-#[expect(
-    unused_variables,
-    reason = "rstest-bdd injects state through scenario signatures"
-)]
-pub fn round_trips_div_blocks_via_dictionary(python_state: PythonModuleState) {}
+pub fn round_trips_div_blocks_via_dictionary(#[from(python_state)] _python_state: PythonModuleState) {}

--- a/tei-py/tests/python_module/steps_dict.rs
+++ b/tei-py/tests/python_module/steps_dict.rs
@@ -280,14 +280,20 @@ pub fn decodes_dictionary_payloads(#[from(python_state)] _python_state: PythonMo
     path = "tests/features/python_module.feature",
     name = "Reject dictionary payloads missing required fields"
 )]
-pub fn rejects_incomplete_dictionary_payloads(#[from(python_state)] _python_state: PythonModuleState) {}
+pub fn rejects_incomplete_dictionary_payloads(
+    #[from(python_state)] _python_state: PythonModuleState,
+) {
+}
 
 /// Scenario: Reject dictionary payloads with blank titles.
 #[scenario(
     path = "tests/features/python_module.feature",
     name = "Reject dictionary payloads with blank titles"
 )]
-pub fn rejects_blank_titles_in_dictionary_payloads(#[from(python_state)] _python_state: PythonModuleState) {}
+pub fn rejects_blank_titles_in_dictionary_payloads(
+    #[from(python_state)] _python_state: PythonModuleState,
+) {
+}
 
 /// Scenario: Encode a `Document` to a dictionary payload.
 #[scenario(
@@ -308,4 +314,7 @@ pub fn rejects_to_dict_without_document(#[from(python_state)] _python_state: Pyt
     path = "tests/features/python_module.feature",
     name = "Round-trip dictionary payload with div blocks"
 )]
-pub fn round_trips_div_blocks_via_dictionary(#[from(python_state)] _python_state: PythonModuleState) {}
+pub fn round_trips_div_blocks_via_dictionary(
+    #[from(python_state)] _python_state: PythonModuleState,
+) {
+}

--- a/tei-py/tests/python_module/steps_div_structs.rs
+++ b/tei-py/tests/python_module/steps_div_structs.rs
@@ -189,4 +189,7 @@ pub(super) fn the_div_blocks_are_preserved(
     path = "tests/features/python_module.feature",
     name = "Round-trip MessagePack via Episode struct with div blocks"
 )]
-pub fn round_trips_div_blocks_via_episode_struct(#[from(python_state)] _python_state: PythonModuleState) {}
+pub fn round_trips_div_blocks_via_episode_struct(
+    #[from(python_state)] _python_state: PythonModuleState,
+) {
+}

--- a/tei-py/tests/python_module/steps_div_structs.rs
+++ b/tei-py/tests/python_module/steps_div_structs.rs
@@ -189,8 +189,4 @@ pub(super) fn the_div_blocks_are_preserved(
     path = "tests/features/python_module.feature",
     name = "Round-trip MessagePack via Episode struct with div blocks"
 )]
-#[expect(
-    unused_variables,
-    reason = "rstest-bdd injects the state fixture into generated step calls"
-)]
-pub fn round_trips_div_blocks_via_episode_struct(python_state: PythonModuleState) {}
+pub fn round_trips_div_blocks_via_episode_struct(#[from(python_state)] _python_state: PythonModuleState) {}

--- a/tei-py/tests/python_module/steps_msgpack.rs
+++ b/tei-py/tests/python_module/steps_msgpack.rs
@@ -110,40 +110,20 @@ pub(super) fn i_encode_messagepack_without_a_document(
 
 /// Scenario: Deserialize a `Document` from `MessagePack` bytes.
 #[scenario(path = "tests/features/python_module.feature", index = 4)]
-#[expect(
-    unused_variables,
-    reason = "rstest-bdd matches scenario fixtures by parameter name"
-)]
-pub fn decodes_messagepack_documents(python_state: PythonModuleState) {}
+pub fn decodes_messagepack_documents(#[from(python_state)] _python_state: PythonModuleState) {}
 
 /// Scenario: Reject invalid `MessagePack` payloads during decoding.
 #[scenario(path = "tests/features/python_module.feature", index = 5)]
-#[expect(
-    unused_variables,
-    reason = "rstest-bdd matches scenario fixtures by parameter name"
-)]
-pub fn rejects_invalid_messagepack_payloads(python_state: PythonModuleState) {}
+pub fn rejects_invalid_messagepack_payloads(#[from(python_state)] _python_state: PythonModuleState) {}
 
 /// Scenario: Reject `MessagePack` payloads missing required fields.
 #[scenario(path = "tests/features/python_module.feature", index = 6)]
-#[expect(
-    unused_variables,
-    reason = "rstest-bdd matches scenario fixtures by parameter name"
-)]
-pub fn rejects_missing_field_messagepack_payloads(python_state: PythonModuleState) {}
+pub fn rejects_missing_field_messagepack_payloads(#[from(python_state)] _python_state: PythonModuleState) {}
 
 /// Scenario: Encode a constructed `Document` into `MessagePack` bytes.
 #[scenario(path = "tests/features/python_module.feature", index = 7)]
-#[expect(
-    unused_variables,
-    reason = "rstest-bdd matches scenario fixtures by parameter name"
-)]
-pub fn encodes_documents_to_messagepack(python_state: PythonModuleState) {}
+pub fn encodes_documents_to_messagepack(#[from(python_state)] _python_state: PythonModuleState) {}
 
 /// Scenario: Surface errors when `to_msgpack` is called without a `Document`.
 #[scenario(path = "tests/features/python_module.feature", index = 8)]
-#[expect(
-    unused_variables,
-    reason = "rstest-bdd matches scenario fixtures by parameter name"
-)]
-pub fn rejects_to_msgpack_without_document(python_state: PythonModuleState) {}
+pub fn rejects_to_msgpack_without_document(#[from(python_state)] _python_state: PythonModuleState) {}

--- a/tei-py/tests/python_module/steps_msgpack.rs
+++ b/tei-py/tests/python_module/steps_msgpack.rs
@@ -114,11 +114,17 @@ pub fn decodes_messagepack_documents(#[from(python_state)] _python_state: Python
 
 /// Scenario: Reject invalid `MessagePack` payloads during decoding.
 #[scenario(path = "tests/features/python_module.feature", index = 5)]
-pub fn rejects_invalid_messagepack_payloads(#[from(python_state)] _python_state: PythonModuleState) {}
+pub fn rejects_invalid_messagepack_payloads(
+    #[from(python_state)] _python_state: PythonModuleState,
+) {
+}
 
 /// Scenario: Reject `MessagePack` payloads missing required fields.
 #[scenario(path = "tests/features/python_module.feature", index = 6)]
-pub fn rejects_missing_field_messagepack_payloads(#[from(python_state)] _python_state: PythonModuleState) {}
+pub fn rejects_missing_field_messagepack_payloads(
+    #[from(python_state)] _python_state: PythonModuleState,
+) {
+}
 
 /// Scenario: Encode a constructed `Document` into `MessagePack` bytes.
 #[scenario(path = "tests/features/python_module.feature", index = 7)]
@@ -126,4 +132,5 @@ pub fn encodes_documents_to_messagepack(#[from(python_state)] _python_state: Pyt
 
 /// Scenario: Surface errors when `to_msgpack` is called without a `Document`.
 #[scenario(path = "tests/features/python_module.feature", index = 8)]
-pub fn rejects_to_msgpack_without_document(#[from(python_state)] _python_state: PythonModuleState) {}
+pub fn rejects_to_msgpack_without_document(#[from(python_state)] _python_state: PythonModuleState) {
+}

--- a/tei-py/tests/python_module/steps_structs.rs
+++ b/tei-py/tests/python_module/steps_structs.rs
@@ -95,19 +95,11 @@ pub(super) fn i_decode_the_payload_to_an_episode(
     path = "tests/features/python_module.feature",
     name = "Round-trip MessagePack via the Episode struct"
 )]
-#[expect(
-    unused_variables,
-    reason = "rstest-bdd injects the state fixture into generated step calls"
-)]
-pub fn round_trips_via_episode_struct(python_state: PythonModuleState) {}
+pub fn round_trips_via_episode_struct(#[from(python_state)] _python_state: PythonModuleState) {}
 
 /// Scenario: Report msgspec errors for malformed payloads.
 #[scenario(
     path = "tests/features/python_module.feature",
     name = "Report msgspec errors for malformed payloads"
 )]
-#[expect(
-    unused_variables,
-    reason = "rstest-bdd injects the state fixture into generated step calls"
-)]
-pub fn episode_decoding_reports_errors(python_state: PythonModuleState) {}
+pub fn episode_decoding_reports_errors(#[from(python_state)] _python_state: PythonModuleState) {}

--- a/tei-py/tests/python_module/steps_validation.rs
+++ b/tei-py/tests/python_module/steps_validation.rs
@@ -37,30 +37,18 @@ pub(super) fn validation_succeeds(#[from(python_state)] state: &PythonModuleStat
     path = "tests/features/python_module.feature",
     name = "Validate a well-formed Document"
 )]
-#[expect(
-    unused_variables,
-    reason = "rstest-bdd matches scenario fixtures by parameter name"
-)]
-pub fn validates_well_formed_document(python_state: PythonModuleState) {}
+pub fn validates_well_formed_document(#[from(python_state)] _python_state: PythonModuleState) {}
 
 /// Scenario: Reject Documents with duplicate xml:id values.
 #[scenario(
     path = "tests/features/python_module.feature",
     name = "Reject Documents with duplicate xml:id values"
 )]
-#[expect(
-    unused_variables,
-    reason = "rstest-bdd matches scenario fixtures by parameter name"
-)]
-pub fn rejects_duplicate_identifiers(python_state: PythonModuleState) {}
+pub fn rejects_duplicate_identifiers(#[from(python_state)] _python_state: PythonModuleState) {}
 
 /// Scenario: Reject Documents with unknown speaker references.
 #[scenario(
     path = "tests/features/python_module.feature",
     name = "Reject Documents with unknown speaker references"
 )]
-#[expect(
-    unused_variables,
-    reason = "rstest-bdd matches scenario fixtures by parameter name"
-)]
-pub fn rejects_unknown_speakers(python_state: PythonModuleState) {}
+pub fn rejects_unknown_speakers(#[from(python_state)] _python_state: PythonModuleState) {}

--- a/tei-py/tests/python_module/steps_xml.rs
+++ b/tei-py/tests/python_module/steps_xml.rs
@@ -105,4 +105,7 @@ pub fn emits_documents_to_tei_xml(#[from(python_state)] _python_state: PythonMod
     path = "tests/features/python_module.feature",
     name = "Reject TEI emission when XML would contain forbidden characters"
 )]
-pub fn rejects_emit_xml_with_control_characters(#[from(python_state)] _python_state: PythonModuleState) {}
+pub fn rejects_emit_xml_with_control_characters(
+    #[from(python_state)] _python_state: PythonModuleState,
+) {
+}

--- a/tei-py/tests/python_module/steps_xml.rs
+++ b/tei-py/tests/python_module/steps_xml.rs
@@ -87,38 +87,22 @@ pub(super) fn i_emit_the_document_to_tei_xml(
     path = "tests/features/python_module.feature",
     name = "Parse TEI XML into a Document"
 )]
-#[expect(
-    unused_variables,
-    reason = "rstest-bdd matches scenario fixtures by parameter name"
-)]
-pub fn parses_tei_xml_payloads(python_state: PythonModuleState) {}
+pub fn parses_tei_xml_payloads(#[from(python_state)] _python_state: PythonModuleState) {}
 
 #[scenario(
     path = "tests/features/python_module.feature",
     name = "Reject malformed TEI XML payloads"
 )]
-#[expect(
-    unused_variables,
-    reason = "rstest-bdd matches scenario fixtures by parameter name"
-)]
-pub fn rejects_invalid_tei_xml_payloads(python_state: PythonModuleState) {}
+pub fn rejects_invalid_tei_xml_payloads(#[from(python_state)] _python_state: PythonModuleState) {}
 
 #[scenario(
     path = "tests/features/python_module.feature",
     name = "Emit TEI XML for a Document"
 )]
-#[expect(
-    unused_variables,
-    reason = "rstest-bdd matches scenario fixtures by parameter name"
-)]
-pub fn emits_documents_to_tei_xml(python_state: PythonModuleState) {}
+pub fn emits_documents_to_tei_xml(#[from(python_state)] _python_state: PythonModuleState) {}
 
 #[scenario(
     path = "tests/features/python_module.feature",
     name = "Reject TEI emission when XML would contain forbidden characters"
 )]
-#[expect(
-    unused_variables,
-    reason = "rstest-bdd matches scenario fixtures by parameter name"
-)]
-pub fn rejects_emit_xml_with_control_characters(python_state: PythonModuleState) {}
+pub fn rejects_emit_xml_with_control_characters(#[from(python_state)] _python_state: PythonModuleState) {}


### PR DESCRIPTION
## What changed and why

Whitaker's rolling release now pins toolchain `nightly-2026-05-28`, which
requires `cargo-dylint` 6.0.1. The CI-pinned `whitaker-installer` version
provisions `cargo-dylint` 4.1.0, whose driver cannot compile on that
nightly, so the CI lint step has been failing. `whitaker-installer` 0.2.6
fixes this by provisioning `cargo-dylint` 6.0.1, and its prebuilt
dependency binaries are now published.

This bumps `WHITAKER_INSTALLER_VERSION` from `0.2.5` to `0.2.6` in the CI
workflow so the cached installer, and the `cargo binstall` fallback, pull
in the fixed version.

## Changed files

- [`.github/workflows/ci.yml`](https://github.com/leynos/tei-rapporteur/blob/bump-whitaker-installer-0.2.6/.github/workflows/ci.yml)
